### PR TITLE
fix(wallet): clear React Query cache on Stellar wallet disconnect

### DIFF
--- a/apps/web-app/src/hooks/useStellarWallet.ts
+++ b/apps/web-app/src/hooks/useStellarWallet.ts
@@ -2,10 +2,38 @@
 
 import { getStellarWalletKit } from "@/lib/helpers/stellar/wallet";
 import { useStellarWalletStore } from "@/stores/stellarWalletStore";
+import { useQueryClient } from "@tanstack/react-query";
+
+/**
+ * React Query key prefixes that scope to the connected wallet's address.
+ * These are removed from the cache on wallet disconnect so that connecting a
+ * second wallet in the same session never flashes the previous wallet's data.
+ *
+ * Protocol-level keys (pool configs, oracle prices, vault APYs, etc.) are
+ * intentionally omitted — they contain no user data and can stay cached.
+ */
+const USER_SCOPED_QUERY_PREFIXES: readonly string[] = [
+  "backstopDeposit",
+  "backstopWalletBalance",
+  "balances",
+  "borrowLimit",
+  "cetesBalance",
+  "etherfuse-assets",
+  "health-factor",
+  "kyc-status",
+  "portfolio-value",
+  "repayWalletBalance",
+  "stellar-balances",
+  "tokenBalance",
+  "userCollateral",
+  "userDebt",
+  "vaultBalance",
+];
 
 export function useStellarWallet() {
   const { address, walletName, setWallet, clearWallet } =
     useStellarWalletStore();
+  const queryClient = useQueryClient();
 
   const connect = async () => {
     const Kit = await getStellarWalletKit();
@@ -18,6 +46,28 @@ export function useStellarWallet() {
   const disconnect = async () => {
     const Kit = await getStellarWalletKit();
     await Kit.disconnect();
+
+    // Capture the disconnecting address before clearing the store so we can
+    // also remove address-tagged keys that don't use one of the known prefixes
+    // (e.g. ["orchestrator", "position", poolId, address]).
+    const previousAddress = address;
+
+    queryClient.removeQueries({
+      predicate: (query) => {
+        const first = query.queryKey[0];
+        if (
+          typeof first === "string" &&
+          USER_SCOPED_QUERY_PREFIXES.includes(first)
+        ) {
+          return true;
+        }
+        if (previousAddress) {
+          return query.queryKey.some((k) => k === previousAddress);
+        }
+        return false;
+      },
+    });
+
     clearWallet();
   };
 


### PR DESCRIPTION
Closes #208

## Summary
\`useStellarWallet.disconnect()\` previously only cleared the Zustand wallet store; user-specific cached queries (balances, borrow positions, backstop state, etc.) stayed in memory and briefly flashed across features when a second wallet connected in the same session.

## Fix
\`disconnect()\` now calls \`queryClient.removeQueries(...)\` with a predicate that removes:

1. Any query whose first key is a known **user-scoped prefix** (explicit allowlist, documented in the source).
2. Any query whose key array **contains the disconnecting address** — catches trailing-address keys like \`['orchestrator', 'position', poolId, addr]\` that don't fit the prefix list.

Protocol-level queries (pool configs, oracle prices, vault APY) are intentionally left cached — they hold no user data and re-fetching them on every reconnect would add unnecessary latency.

## Documented user-scoped prefixes
\`backstopDeposit\`, \`backstopWalletBalance\`, \`balances\`, \`borrowLimit\`, \`cetesBalance\`, \`etherfuse-assets\`, \`health-factor\`, \`kyc-status\`, \`portfolio-value\`, \`repayWalletBalance\`, \`stellar-balances\`, \`tokenBalance\`, \`userCollateral\`, \`userDebt\`, \`vaultBalance\`.

## Acceptance criteria
- [x] \`useStellarWallet.ts\` calls \`queryClient.removeQueries()\` for all address-scoped keys on disconnect
- [x] User-scoped prefixes documented in the source (and PR body)
- [x] Protocol queries unaffected
- [ ] Connect wallet A → disconnect → connect wallet B → wallet B's data shows immediately, no flash of wallet A's data *(manual verification — flagged for reviewer)*