### PR TITLE
fix: replace blind Stellar transaction timeouts with confirmation polling

### DIFF
--- a/apps/web-app/src/features/backstop/hooks/useBackstop.ts
+++ b/apps/web-app/src/features/backstop/hooks/useBackstop.ts
@@ -16,6 +16,7 @@ import {
   getTokenBalance,
 } from "@/lib/helpers/stellar/lending";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
+import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
 
@@ -112,11 +113,11 @@ export function useBackstop(contractId: string) {
           networkPassphrase: passphrase,
           address,
         });
-        await sorobanServer.sendTransaction(
+        const sendResult = await sorobanServer.sendTransaction(
           TransactionBuilder.fromXDR(signedDeposit.signedTxXdr, passphrase)
         );
 
-        await new Promise((r) => setTimeout(r, 3000));
+        await waitForTransaction(sendResult.hash, sorobanServer);
         await refetchAll();
         showSuccess(`Successfully deposited ${amount} tokens to backstop`);
       } catch (err) {
@@ -158,11 +159,11 @@ export function useBackstop(contractId: string) {
           networkPassphrase: passphrase,
           address,
         });
-        await sorobanServer.sendTransaction(
+        const sendResult = await sorobanServer.sendTransaction(
           TransactionBuilder.fromXDR(signed.signedTxXdr, passphrase)
         );
 
-        await new Promise((r) => setTimeout(r, 3000));
+        await waitForTransaction(sendResult.hash, sorobanServer);
         await refetchAll();
         showSuccess(
           `Withdrawal queued. You can withdraw after ${WITHDRAWAL_QUEUE_DAYS} days.`
@@ -202,11 +203,11 @@ export function useBackstop(contractId: string) {
           networkPassphrase: passphrase,
           address,
         });
-        await sorobanServer.sendTransaction(
+        const sendResult = await sorobanServer.sendTransaction(
           TransactionBuilder.fromXDR(signed.signedTxXdr, passphrase)
         );
 
-        await new Promise((r) => setTimeout(r, 3000));
+        await waitForTransaction(sendResult.hash, sorobanServer);
         await refetchAll();
         showSuccess(`Successfully withdrew ${amount} tokens from backstop`);
       } catch (err) {

--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -15,6 +15,7 @@ import {
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
 import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
+import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
 import { usePools, usePoolAction } from "@/lib/orchestrator";
 import type { PoolInfo } from "@/lib/orchestrator";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
@@ -232,9 +233,10 @@ export function useLend() {
             networkPassphrase: passphrase,
             address,
           });
-          await sorobanServer.sendTransaction(
+          const sendResult = await sorobanServer.sendTransaction(
             TransactionBuilder.fromXDR(signedDeposit.signedTxXdr, passphrase)
           );
+          await waitForTransaction(sendResult.hash, sorobanServer);
         } else {
           if (!selectedPool.bTokenRate)
             throw new Error("Unable to calculate bTokens. Please try again.");
@@ -251,12 +253,12 @@ export function useLend() {
             networkPassphrase: passphrase,
             address,
           });
-          await sorobanServer.sendTransaction(
+          const sendResult = await sorobanServer.sendTransaction(
             TransactionBuilder.fromXDR(signedWithdraw.signedTxXdr, passphrase)
           );
+          await waitForTransaction(sendResult.hash, sorobanServer);
         }
 
-        await new Promise((r) => setTimeout(r, 3000));
         await loadBTokenBalance();
         await refetchPools();
         showSuccess(

--- a/apps/web-app/src/lib/helpers/stellar/waitForTransaction.ts
+++ b/apps/web-app/src/lib/helpers/stellar/waitForTransaction.ts
@@ -1,0 +1,59 @@
+import { rpc } from "@stellar/stellar-sdk";
+
+export interface WaitForTransactionOptions {
+  maxAttempts?: number;
+  intervalMs?: number;
+}
+
+export class TransactionFailedError extends Error {
+  constructor(hash: string, status: string, message?: string) {
+    super(
+      message ?? `Transaction ${hash} failed on chain with status ${status}.`
+    );
+    this.name = "TransactionFailedError";
+  }
+}
+
+export class TransactionTimeoutError extends Error {
+  constructor(hash: string, maxAttempts: number, intervalMs: number) {
+    super(
+      `Timed out waiting for transaction ${hash} confirmation after ${maxAttempts} attempts at ${intervalMs}ms intervals. The transaction may still be pending.`
+    );
+    this.name = "TransactionTimeoutError";
+  }
+}
+
+export async function waitForTransaction(
+  txHash: string,
+  server: rpc.Server,
+  opts: WaitForTransactionOptions = {}
+): Promise<unknown> {
+  const { maxAttempts = 20, intervalMs = 2000 } = opts;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await server.getTransaction(txHash);
+
+    if (result.status === "SUCCESS") {
+      return result;
+    }
+
+    if (result.status === "FAILED") {
+      const errorDetails =
+        result.result && typeof result.result === "object"
+          ? JSON.stringify(result.result)
+          : String((result as any).error ?? result.status);
+
+      throw new TransactionFailedError(
+        txHash,
+        result.status,
+        `Transaction ${txHash} failed on chain. ${errorDetails}`
+      );
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  throw new TransactionTimeoutError(txHash, maxAttempts, intervalMs);
+}


### PR DESCRIPTION
Closes #212

---

This PR adds a `waitForTransaction` utility to poll Stellar transaction status until it reaches `SUCCESS` or `FAILED`, replacing blind 3-second delays in `useBackstop` and `useLend`. This ensures UI updates only after actual confirmation and surfaces on-chain failures or polling timeouts correctly.