### PR TITLE
feat(backstop): live countdown for withdrawal queue expiry

### DIFF
--- a/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
+++ b/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { BackstopInfoAlert } from "./BackstopInfoAlert";
+import { QueueCountdown } from "./QueueCountdown";
 
 type ActionTab = "deposit" | "withdraw";
 
@@ -15,6 +16,7 @@ interface BackstopActionPanelProps {
   backstopTokenConfigured: boolean;
   inWithdrawalQueue: boolean;
   queueExpired: boolean;
+  queueExpiresAt: Date | null;
   onDeposit: (amount: string) => Promise<void>;
   onInitiateWithdrawal: (amount: string) => Promise<void>;
   onWithdraw: (amount: string) => Promise<void>;
@@ -30,6 +32,7 @@ export function BackstopActionPanel({
   backstopTokenConfigured,
   inWithdrawalQueue,
   queueExpired,
+  queueExpiresAt,
   onDeposit,
   onInitiateWithdrawal,
   onWithdraw,
@@ -153,7 +156,12 @@ export function BackstopActionPanel({
             <>
               <BackstopInfoAlert variant="warning">
                 To withdraw, you must first queue your withdrawal and wait{" "}
-                <span className="font-semibold text-amber-400">17 days</span>.
+                {inWithdrawalQueue && queueExpiresAt ? (
+                  <QueueCountdown expiresAt={queueExpiresAt} />
+                ) : (
+                  <span className="font-semibold text-amber-400">17 days</span>
+                )}
+                .
               </BackstopInfoAlert>
 
               <div>

--- a/apps/web-app/src/features/backstop/components/ui/QueueCountdown.tsx
+++ b/apps/web-app/src/features/backstop/components/ui/QueueCountdown.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useCountdown } from "@/hooks/useCountdown";
+
+interface QueueCountdownProps {
+  expiresAt: Date;
+}
+
+export function QueueCountdown({ expiresAt }: QueueCountdownProps) {
+  const { days, hours, minutes, seconds, expired } = useCountdown(expiresAt);
+
+  if (expired) {
+    return (
+      <span className="font-semibold text-green-400">Ready to withdraw</span>
+    );
+  }
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+
+  return (
+    <span className="font-semibold text-amber-400">
+      {parts.join(" ")} remaining
+    </span>
+  );
+}

--- a/apps/web-app/src/features/lending/components/ui/BackstopPanel.tsx
+++ b/apps/web-app/src/features/lending/components/ui/BackstopPanel.tsx
@@ -141,6 +141,7 @@ export function BackstopPanel() {
           backstopTokenConfigured={backstopTokenConfigured}
           inWithdrawalQueue={inWithdrawalQueue}
           queueExpired={queueExpired}
+          queueExpiresAt={queueExpiresAt}
           onDeposit={handleDeposit}
           onInitiateWithdrawal={handleInitiateWithdrawal}
           onWithdraw={handleWithdraw}

--- a/apps/web-app/src/hooks/useCountdown.ts
+++ b/apps/web-app/src/hooks/useCountdown.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Countdown {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  expired: boolean;
+}
+
+export function useCountdown(target: Date | null): Countdown {
+  const calc = (): Countdown => {
+    if (!target)
+      return { days: 0, hours: 0, minutes: 0, seconds: 0, expired: true };
+    const diff = target.getTime() - Date.now();
+    if (diff <= 0)
+      return { days: 0, hours: 0, minutes: 0, seconds: 0, expired: true };
+    const totalSeconds = Math.floor(diff / 1000);
+    return {
+      days: Math.floor(totalSeconds / 86400),
+      hours: Math.floor((totalSeconds % 86400) / 3600),
+      minutes: Math.floor((totalSeconds % 3600) / 60),
+      seconds: totalSeconds % 60,
+      expired: false,
+    };
+  };
+
+  const [state, setState] = useState<Countdown>(calc);
+
+  useEffect(() => {
+    if (!target) return;
+    const id = setInterval(() => setState(calc()), 1000);
+    return () => clearInterval(id);
+  }, [target]);
+
+  return state;
+}


### PR DESCRIPTION
Closes #210 
- Add useCountdown hook (1s interval, returns days/hours/minutes/seconds/expired)
- Add QueueCountdown component (shows remaining time or 'Ready to withdraw')
- Replace static '17 days' text in BackstopActionPanel with live QueueCountdown
- Pass queueExpiresAt prop through BackstopPanel → BackstopActionPanel