### PR TITLE
fix(pools): split Blend supply and collateral into per-action limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
   verify:
     name: Lint · Typecheck · Build · Test
     runs-on: ubuntu-latest
+    # `src/lib/env.client.ts` validates these at import time and throws when
+    # they are missing, which the production build hits while prerendering.
+    # They are public testnet endpoints, not secrets — CI only needs the build
+    # to resolve, never to reach the network.
+    env:
+      NEXT_PUBLIC_STELLAR_NETWORK: TESTNET
+      NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      NEXT_PUBLIC_STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -35,6 +35,7 @@
     "axios": "^1.7.9",
     "chart.js": "^4.4.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.4.0",
     "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
     "lossless-json": "^1.0.4",

--- a/apps/web-app/src/app/api/analytics/earnings/route.ts
+++ b/apps/web-app/src/app/api/analytics/earnings/route.ts
@@ -139,15 +139,20 @@ export async function GET(req: NextRequest) {
     portfolioUsd > 0 ? (totalEarned / portfolioUsd) * 100 : 0;
 
   // Per-asset breakdown (realistic token list)
-  const byAsset: EarningsByAsset[] = [
-    { asset: "USDC", source: "vault", earned: sources[0].earned * 0.6 },
-    { asset: "XLM", source: "vault", earned: sources[0].earned * 0.4 },
-    { asset: "USDC", source: "lending", earned: sources[1].earned * 0.7 },
-    { asset: "EURC", source: "lending", earned: sources[1].earned * 0.3 },
-    { asset: "XLM/USDC", source: "pools", earned: sources[2].earned * 0.55 },
-    { asset: "EURC/USDC", source: "pools", earned: sources[2].earned * 0.45 },
-    { asset: "CETES", source: "rwa", earned: sources[3].earned },
-  ].filter((r) => r.earned > 0.000001);
+  // `satisfies` restores contextual typing the trailing .filter() would
+  // otherwise swallow, so each `source` narrows to EarningsSourceId instead of
+  // widening to string — and a typo in one is caught here.
+  const byAsset: EarningsByAsset[] = (
+    [
+      { asset: "USDC", source: "vault", earned: sources[0].earned * 0.6 },
+      { asset: "XLM", source: "vault", earned: sources[0].earned * 0.4 },
+      { asset: "USDC", source: "lending", earned: sources[1].earned * 0.7 },
+      { asset: "EURC", source: "lending", earned: sources[1].earned * 0.3 },
+      { asset: "XLM/USDC", source: "pools", earned: sources[2].earned * 0.55 },
+      { asset: "EURC/USDC", source: "pools", earned: sources[2].earned * 0.45 },
+      { asset: "CETES", source: "rwa", earned: sources[3].earned },
+    ] satisfies EarningsByAsset[]
+  ).filter((r) => r.earned > 0.000001);
 
   const response: EarningsApiResponse = {
     totalEarned,

--- a/apps/web-app/src/app/api/analytics/metrics/route.ts
+++ b/apps/web-app/src/app/api/analytics/metrics/route.ts
@@ -178,16 +178,21 @@ export async function GET(req: NextRequest) {
   };
 
   // IL positions (for any LP positions)
-  const ilPositions: ILPosition[] = [
-    {
-      poolId: "xlm-usdc",
-      assets: ["XLM", "USDC"],
-      ilPct: -2.3,
-      ilUsd: totalValue * 0.25 * 0.023,
-      hodlValue: totalValue * 0.25 + totalValue * 0.25 * 0.023,
-      currentValue: totalValue * 0.25,
-    },
-  ].filter(() => totalValue > 0);
+  // `satisfies` restores contextual typing the trailing .filter() would
+  // otherwise swallow, so `assets` stays the [string, string] pair ILPosition
+  // declares instead of widening to string[].
+  const ilPositions: ILPosition[] = (
+    [
+      {
+        poolId: "xlm-usdc",
+        assets: ["XLM", "USDC"],
+        ilPct: -2.3,
+        ilUsd: totalValue * 0.25 * 0.023,
+        hodlValue: totalValue * 0.25 + totalValue * 0.25 * 0.023,
+        currentValue: totalValue * 0.25,
+      },
+    ] satisfies ILPosition[]
+  ).filter(() => totalValue > 0);
 
   // Yield forecast
   const yieldForecast: YieldForecast = {

--- a/apps/web-app/src/components/navigation/MobileHeader.tsx
+++ b/apps/web-app/src/components/navigation/MobileHeader.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 import { NAV_ITEMS } from "./sidebarConfig";
 import { useWalletType } from "@/hooks/useWalletType";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
-import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { truncateAddress } from "@/lib/utils";
 import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
 import { clientEnv } from "@/lib/env.client";
@@ -26,6 +25,16 @@ export function MobileHeader() {
   const { unreadCount } = useActivityFeed();
   const menuRef = useRef<HTMLDivElement>(null);
   const walletButtonRef = useRef<HTMLDivElement>(null);
+
+  // Close the menu on navigation. Adjusting state during render is React's
+  // documented pattern for resetting state when a value changes; doing it in
+  // an effect renders the menu open first and then immediately re-renders it
+  // closed, which is the cascading render the lint rule flags.
+  const [menuPathname, setMenuPathname] = useState(pathname);
+  if (pathname !== menuPathname) {
+    setMenuPathname(pathname);
+    setIsOpen(false);
+  }
 
   const isConnected = isStellarConnected;
   const activeAddress = stellarAddress ?? "";
@@ -62,10 +71,6 @@ export function MobileHeader() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen, walletDropdownOpen]);
-
-  useEffect(() => {
-    setIsOpen(false);
-  }, [pathname]);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? "hidden" : "";

--- a/apps/web-app/src/components/navigation/sidebarConfig.ts
+++ b/apps/web-app/src/components/navigation/sidebarConfig.ts
@@ -11,6 +11,7 @@ import {
   PieChart,
   Zap,
   Bell,
+  Workflow,
 } from "lucide-react";
 
 export const NAV_ITEMS = [

--- a/apps/web-app/src/features/pools/components/PoolActionModal.tsx
+++ b/apps/web-app/src/features/pools/components/PoolActionModal.tsx
@@ -27,6 +27,27 @@ const ACTION_LABELS: Record<PoolAction, string> = {
   withdrawCollateral: "Withdraw Collateral",
 };
 
+/** What the ceiling for each action represents, for the over-max message. */
+const MAX_SOURCE_LABELS: Record<PoolAction, string> = {
+  deposit: "your wallet balance",
+  supplyCollateral: "your wallet balance",
+  withdraw: "your supplied balance",
+  withdrawCollateral: "your withdrawable collateral",
+  borrow: "your borrow capacity",
+  repay: "your outstanding debt",
+  claimRewards: "",
+};
+
+/** Smallest of the defined operands; `undefined` means "no ceiling here". */
+function minUnits(...values: (bigint | undefined)[]): bigint | undefined {
+  let min: bigint | undefined;
+  for (const value of values) {
+    if (value === undefined) continue;
+    if (min === undefined || value < min) min = value;
+  }
+  return min;
+}
+
 export function PoolActionModal({
   isOpen,
   onClose,
@@ -46,26 +67,47 @@ export function PoolActionModal({
   const tokenCode = token?.code ?? "Token";
   const needsAmount = action !== "claimRewards";
 
-  const maxAmount = (() => {
-    if (!needsAmount) return "";
+  const walletUnits =
+    tokenBalance != null ? toSmallestUnit(tokenBalance, decimals) : undefined;
+
+  /**
+   * Ceiling for this action in smallest units, or `undefined` when no ceiling
+   * is known — the adapter reports a per-action limit because each request
+   * moves one specific balance, so withdraw and withdrawCollateral never share
+   * a max even on the same reserve.
+   */
+  const maxUnits = (() => {
+    if (!needsAmount) return undefined;
     switch (action) {
       case "deposit":
       case "supplyCollateral":
-        return tokenBalance ?? "0";
-      case "withdraw":
-      case "withdrawCollateral":
-        return position?.depositedFormatted ?? "0";
+        return walletUnits;
       case "repay":
-        if (pool.type === "blend" && position?.metadata?.liabilities != null) {
-          const raw = String(position.metadata.liabilities);
-          if (raw === "0") return "0";
-          return fromSmallestUnit(raw, decimals);
-        }
-        return "0";
+        // Bounded by the debt and by what the wallet can actually pay.
+        return minUnits(position?.limits?.repay, walletUnits);
       default:
-        return "";
+        return position?.limits?.[action];
     }
   })();
+
+  const maxAmount =
+    maxUnits !== undefined
+      ? fromSmallestUnit(maxUnits.toString(), decimals)
+      : "";
+
+  const amountUnits = amount.trim() ? toSmallestUnit(amount, decimals) : 0n;
+  const isPositive = amountUnits > 0n;
+  const exceedsMax =
+    isPositive && maxUnits !== undefined && amountUnits > maxUnits;
+
+  // Only the over-max case gets a message. A blank or still-being-typed amount
+  // just leaves the button disabled, so "0." does not flash an error mid-entry.
+  const validationError =
+    needsAmount && exceedsMax
+      ? `Amount exceeds ${MAX_SOURCE_LABELS[action]} (max ${maxAmount} ${tokenCode}).`
+      : null;
+
+  const canSubmit = needsAmount ? isPositive && !exceedsMax : true;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -89,11 +131,11 @@ export function PoolActionModal({
     };
 
     if (needsAmount) {
-      const num = parseFloat(amount);
-      if (isNaN(num) || num <= 0) return;
-      const amountBigInt = toSmallestUnit(amount, decimals);
+      // Same guard the submit button uses — an over-max amount never reaches
+      // the wallet or a doomed simulation.
+      if (!canSubmit) return;
       mutate.mutate(
-        { poolId, action, amount: amountBigInt, tokenIndex: 0 },
+        { poolId, action, amount: amountUnits, tokenIndex: 0 },
         { onSuccess }
       );
     } else {
@@ -167,7 +209,7 @@ export function PoolActionModal({
                     disabled={mutate.isPending}
                     className="flex-1 px-4 py-3 rounded-xl border border-[#334EAC]/30 bg-[#f8fafc] text-[#081F5C] focus:outline-none focus:ring-2 focus:ring-[#334EAC]/50 focus:border-[#334EAC]"
                   />
-                  {maxAmount !== "" && Number(maxAmount) > 0 && (
+                  {maxUnits !== undefined && maxUnits > 0n && (
                     <button
                       type="button"
                       onClick={() => setAmount(maxAmount)}
@@ -178,6 +220,17 @@ export function PoolActionModal({
                     </button>
                   )}
                 </div>
+                {maxUnits !== undefined && (
+                  <p className="text-xs text-[#7096D1]">
+                    Max {maxAmount} {tokenCode} &middot;{" "}
+                    {MAX_SOURCE_LABELS[action]}
+                  </p>
+                )}
+                {validationError && (
+                  <p role="alert" className="text-xs font-medium text-red-600">
+                    {validationError}
+                  </p>
+                )}
               </div>
             ) : (
               <p className="text-[#7096D1] text-center py-2">
@@ -196,11 +249,7 @@ export function PoolActionModal({
               </button>
               <button
                 type="submit"
-                disabled={
-                  mutate.isPending ||
-                  !address ||
-                  (needsAmount && (!amount || parseFloat(amount) <= 0))
-                }
+                disabled={mutate.isPending || !address || !canSubmit}
                 className="flex-1 px-4 py-3 rounded-xl bg-[#334EAC] text-white font-semibold hover:bg-[#294cab] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {mutate.isPending ? (

--- a/apps/web-app/src/features/pools/components/pages/PoolDetail.tsx
+++ b/apps/web-app/src/features/pools/components/pages/PoolDetail.tsx
@@ -7,7 +7,6 @@ import Image from "next/image";
 import { orchestrator, useUserPosition } from "@/lib/orchestrator";
 import { getTokenIcon } from "@/lib/helpers/tokenUtils";
 import type { PoolAction, TokenInfo } from "@/lib/orchestrator";
-import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { useWallet } from "@/hooks/useWallet";
 import { usePoolDetail } from "@/features/pools/hooks/usePoolDetail";
 import { PageContainer } from "@/components/ui/PageContainer";
@@ -70,6 +69,7 @@ const PoolDetail: React.FC<PoolDetailProps> = ({ params }) => {
   }
 
   const { token1, token2, tvlFormatted, apyFormatted, typeLabel } = pool;
+  const tokenCode = pool.tokens[0]?.code ?? "";
 
   return (
     <PageContainer maxWidth="3xl" className="min-h-screen">
@@ -178,17 +178,37 @@ const PoolDetail: React.FC<PoolDetailProps> = ({ params }) => {
               Tu posición
             </h3>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div>
-                <p className="text-white/40 text-xs mb-1">
-                  {pool.type === "blend"
-                    ? "Total (incl. intereses)"
-                    : "Depositado"}
-                </p>
-                <p className="text-white text-lg font-bold">
-                  {position?.depositedFormatted ?? "0"}{" "}
-                  {pool.tokens[0]?.code ?? ""}
-                </p>
-              </div>
+              {/* Supply and collateral are separate on-chain balances — each is
+                  withdrawn by its own action, so they are never summed here. */}
+              {pool.type === "blend" ? (
+                <>
+                  <div>
+                    <p className="text-white/40 text-xs mb-1">Suministrado</p>
+                    <p className="text-white text-lg font-bold">
+                      {position?.suppliedFormatted ?? "0"} {tokenCode}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-white/40 text-xs mb-1">Colateral</p>
+                    <p className="text-white text-lg font-bold">
+                      {position?.collateralFormatted ?? "0"} {tokenCode}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-white/40 text-xs mb-1">Prestado</p>
+                    <p className="text-white text-lg font-bold">
+                      {position?.liabilitiesFormatted ?? "0"} {tokenCode}
+                    </p>
+                  </div>
+                </>
+              ) : (
+                <div>
+                  <p className="text-white/40 text-xs mb-1">Depositado</p>
+                  <p className="text-white text-lg font-bold">
+                    {position?.depositedFormatted ?? "0"} {tokenCode}
+                  </p>
+                </div>
+              )}
               {pool.type !== "blend" &&
                 position?.rewardsFormatted != null &&
                 position.rewardsFormatted !== "0" && (
@@ -196,20 +216,6 @@ const PoolDetail: React.FC<PoolDetailProps> = ({ params }) => {
                     <p className="text-white/40 text-xs mb-1">Recompensas</p>
                     <p className="text-white text-lg font-bold">
                       {position.rewardsFormatted}
-                    </p>
-                  </div>
-                )}
-              {pool.type === "blend" &&
-                position?.metadata?.liabilities != null &&
-                String(position.metadata.liabilities) !== "0" && (
-                  <div>
-                    <p className="text-white/40 text-xs mb-1">Prestado</p>
-                    <p className="text-white text-lg font-bold">
-                      {fromSmallestUnit(
-                        String(position.metadata.liabilities),
-                        pool.tokens[0]?.decimals ?? 7
-                      )}{" "}
-                      {pool.tokens[0]?.code ?? ""}
                     </p>
                   </div>
                 )}

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
@@ -11,6 +11,10 @@ export const getApiKey = (): string | null => {
   if (envKeyStr && envKeyStr.trim() !== "") {
     return envKeyStr.trim();
   }
+  // Callers reach this during render (see useLimitOrderMonitor), which also
+  // runs on the server during static prerendering — where localStorage does
+  // not exist. Fall back to "no key configured" instead of throwing.
+  if (typeof window === "undefined") return null;
   const localKey = localStorage.getItem("soroswap_api_key");
   if (localKey && localKey.trim() !== "") {
     return localKey.trim();
@@ -19,6 +23,7 @@ export const getApiKey = (): string | null => {
 };
 
 export const setApiKey = (apiKey: string): void => {
+  if (typeof window === "undefined") return;
   localStorage.setItem("soroswap_api_key", apiKey);
 };
 

--- a/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
@@ -1,9 +1,12 @@
 import {
   PoolV2,
   PoolContractV2,
+  PositionsEstimate,
   RequestType,
   TokenMetadata,
+  type PoolUser,
   type Request,
+  type Reserve,
 } from "@blend-capital/blend-sdk";
 import { TransactionBuilder, rpc, xdr, Horizon } from "@stellar/stellar-sdk";
 
@@ -12,6 +15,7 @@ import { rpcUrl, networkPassphrase, horizonUrl } from "@/lib/constants/network";
 import type { BasePoolAdapter } from "../types/adapter.types";
 import type {
   PoolAction,
+  PoolActionLimits,
   PoolInfo,
   PoolPosition,
   PoolType,
@@ -209,14 +213,30 @@ export class BlendPoolAdapter implements BasePoolAdapter {
 
       const decimals = reserve.config.decimals;
 
+      // Display total only. Supply and collateral are two separate on-chain
+      // balances and no single request moves both — action amounts come from
+      // `limits`, never from here.
       const deposited = supplied + collateral;
+
+      const limits = await deriveLimits(pool, reserve, poolUser, {
+        supplied,
+        collateral,
+        liabilities,
+      });
 
       return {
         poolId: fullId,
         deposited,
         depositedFormatted: formatUnits(deposited, decimals),
+        supplied,
+        suppliedFormatted: formatUnits(supplied, decimals),
+        collateral,
+        collateralFormatted: formatUnits(collateral, decimals),
+        liabilities,
+        liabilitiesFormatted: formatUnits(liabilities, decimals),
         rewards: 0n,
         rewardsFormatted: "0",
+        limits,
         metadata: {
           supplied: supplied.toString(),
           collateral: collateral.toString(),
@@ -396,10 +416,157 @@ function emptyPosition(poolId: string): PoolPosition {
     poolId,
     deposited: 0n,
     depositedFormatted: "0",
+    supplied: 0n,
+    suppliedFormatted: "0",
+    collateral: 0n,
+    collateralFormatted: "0",
+    liabilities: 0n,
+    liabilitiesFormatted: "0",
     rewards: 0n,
     rewardsFormatted: "0",
+    limits: {},
     metadata: {},
   };
+}
+
+/**
+ * Fraction of the user's remaining borrow headroom a Max button is allowed to
+ * offer. Borrowing (or un-collateralizing) right up to the cap lands the
+ * position at a health factor of exactly 1 — instantly liquidatable, and in
+ * practice rejected at simulation because interest accrues between the moment
+ * the position is read and the moment the transaction is submitted.
+ */
+const HEADROOM_SAFETY_MARGIN = 0.995;
+
+/** Denominator used by Blend for fixed-point config values such as max_util. */
+const FIXED_7 = 10_000_000n;
+
+interface ReserveBalances {
+  supplied: bigint;
+  collateral: bigint;
+  liabilities: bigint;
+}
+
+/**
+ * Derive the maximum submittable amount for each action against one reserve.
+ *
+ * Every entry is bucket-aware: a Blend `submit` request moves exactly one
+ * balance, so `withdraw` is bounded by the non-collateralized supply and
+ * `withdrawCollateral` by the collateral — never by their sum.
+ *
+ * Capacity-derived ceilings (borrow, and the health bound on collateral
+ * withdrawal) need oracle prices. When the oracle is unavailable the
+ * balance- and liquidity-derived ceilings are still returned, so a price
+ * outage degrades the caps rather than removing them.
+ */
+async function deriveLimits(
+  pool: PoolV2,
+  reserve: Reserve,
+  poolUser: PoolUser,
+  balances: ReserveBalances
+): Promise<PoolActionLimits> {
+  const decimals = reserve.config.decimals;
+  const totalSupply = reserve.totalSupply();
+  const totalLiabilities = reserve.totalLiabilities();
+
+  // Cash actually sitting in the reserve — the pool cannot pay out more.
+  const availableLiquidity = clampToZero(totalSupply - totalLiabilities);
+
+  // Blend rejects any borrow that pushes the reserve past its max utilization.
+  // A reserve missing the config falls back to full utilization rather than
+  // throwing away the whole position read.
+  const maxUtil = Number.isFinite(reserve.config.max_util)
+    ? BigInt(Math.trunc(reserve.config.max_util))
+    : FIXED_7;
+  const borrowableLiquidity = clampToZero(
+    (totalSupply * maxUtil) / FIXED_7 - totalLiabilities
+  );
+
+  const limits: PoolActionLimits = {
+    withdraw: minBigInt(balances.supplied, availableLiquidity),
+    withdrawCollateral: minBigInt(balances.collateral, availableLiquidity),
+    repay: balances.liabilities,
+    borrow: borrowableLiquidity,
+  };
+
+  let headroom: number | undefined;
+  let price: number | undefined;
+  try {
+    const oracle = await pool.loadOracle();
+    price = oracle.getPriceFloat(reserve.assetId);
+    // borrowCap is effective collateral minus effective liabilities, in the
+    // oracle's denomination — i.e. how much more effective debt fits.
+    const estimate = PositionsEstimate.build(pool, oracle, poolUser.positions);
+    headroom = Math.max(0, estimate.borrowCap) * HEADROOM_SAFETY_MARGIN;
+  } catch {
+    // No prices: keep the liquidity/balance ceilings derived above.
+    return limits;
+  }
+
+  if (headroom === undefined || price === undefined || price <= 0) {
+    return limits;
+  }
+
+  // Each asset unit borrowed adds `price / l_factor` of effective liability.
+  const liabilityFactor = reserve.getLiabilityFactor();
+  if (liabilityFactor > 0) {
+    limits.borrow = minBigInt(
+      borrowableLiquidity,
+      assetsToSmallestUnits(headroom / (price * liabilityFactor), decimals)
+    );
+  }
+
+  // Each collateral unit withdrawn removes `price * c_factor` of effective
+  // collateral, so the same headroom bounds it. A reserve with no collateral
+  // factor contributes no effective collateral and so is unconstrained here.
+  const collateralFactor = reserve.getCollateralFactor();
+  if (collateralFactor > 0) {
+    limits.withdrawCollateral = minBigInt(
+      limits.withdrawCollateral,
+      assetsToSmallestUnits(headroom / (price * collateralFactor), decimals)
+    );
+  }
+
+  return limits;
+}
+
+function clampToZero(value: bigint): bigint {
+  return value > 0n ? value : 0n;
+}
+
+/**
+ * Smallest of the defined operands. `undefined` means "no ceiling from this
+ * source" and is skipped, so an unusable float never silently becomes a zero
+ * cap that blocks the action.
+ */
+function minBigInt(...values: (bigint | undefined)[]): bigint | undefined {
+  let min: bigint | undefined;
+  for (const value of values) {
+    if (value === undefined) continue;
+    if (min === undefined || value < min) min = value;
+  }
+  return min;
+}
+
+/**
+ * Floor a floating-point asset amount into smallest units.
+ *
+ * Returns undefined for values `toFixed` cannot render as plain decimal
+ * (non-finite, or >= 1e21) so the caller falls back to another ceiling rather
+ * than to a bogus number.
+ */
+function assetsToSmallestUnits(
+  value: number,
+  decimals: number
+): bigint | undefined {
+  if (!Number.isFinite(value) || value >= 1e21) return undefined;
+  if (value <= 0) return 0n;
+
+  // One extra digit then truncate, so the result floors instead of rounding up
+  // past the cap it represents.
+  const [intPart, fracPart = ""] = value.toFixed(decimals + 1).split(".");
+  const digits = fracPart.slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(`${intPart}${digits}`);
 }
 
 function formatUnits(value: bigint, decimals: number): string {

--- a/apps/web-app/src/lib/orchestrator/adapters/NekoLendingAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/NekoLendingAdapter.ts
@@ -233,23 +233,27 @@ export class NekoLendingAdapter implements BasePoolAdapter {
       const raw =
         balanceTx.result != null ? BigInt(String(balanceTx.result)) : 0n;
 
+      const formatted = fromSmallestUnit(raw.toString(), decimals);
+
       return {
         poolId: `neko:${assetCode}`,
         deposited: raw,
-        depositedFormatted: fromSmallestUnit(raw.toString(), decimals),
+        depositedFormatted: formatted,
+        // Neko lending has no collateral bucket: the whole b-token balance is
+        // a plain supply, and `withdraw` is the only action that moves it.
+        supplied: raw,
+        suppliedFormatted: formatted,
+        collateral: 0n,
+        collateralFormatted: "0",
+        liabilities: 0n,
+        liabilitiesFormatted: "0",
         rewards: 0n,
         rewardsFormatted: "0",
+        limits: { withdraw: raw },
         metadata: { bTokenBalance: raw.toString() },
       };
     } catch {
-      return {
-        poolId: `neko:${assetCode}`,
-        deposited: 0n,
-        depositedFormatted: "0",
-        rewards: 0n,
-        rewardsFormatted: "0",
-        metadata: {},
-      };
+      return emptyPosition(`neko:${assetCode}`);
     }
   }
 
@@ -414,4 +418,22 @@ export class NekoLendingAdapter implements BasePoolAdapter {
   supportsAction(action: PoolAction): boolean {
     return SUPPORTED_ACTIONS.includes(action);
   }
+}
+
+function emptyPosition(poolId: string): PoolPosition {
+  return {
+    poolId,
+    deposited: 0n,
+    depositedFormatted: "0",
+    supplied: 0n,
+    suppliedFormatted: "0",
+    collateral: 0n,
+    collateralFormatted: "0",
+    liabilities: 0n,
+    liabilitiesFormatted: "0",
+    rewards: 0n,
+    rewardsFormatted: "0",
+    limits: {},
+    metadata: {},
+  };
 }

--- a/apps/web-app/src/lib/orchestrator/adapters/SoroswapPoolAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/SoroswapPoolAdapter.ts
@@ -83,8 +83,15 @@ function emptyPosition(poolId: string): PoolPosition {
     poolId,
     deposited: 0n,
     depositedFormatted: "0",
+    supplied: 0n,
+    suppliedFormatted: "0",
+    collateral: 0n,
+    collateralFormatted: "0",
+    liabilities: 0n,
+    liabilitiesFormatted: "0",
     rewards: 0n,
     rewardsFormatted: "0",
+    limits: {},
     metadata: {},
   };
 }
@@ -219,16 +226,26 @@ export class SoroswapPoolAdapter implements BasePoolAdapter {
         ? position.tokenBAmountEquivalent
         : position.tokenAAmountEquivalent;
       const deposited = BigInt(depositedRaw);
+      const depositedFormatted = fromSmallestUnit(
+        deposited.toString(),
+        tokenA.decimals
+      );
 
       return {
         poolId: fullId,
         deposited,
-        depositedFormatted: fromSmallestUnit(
-          deposited.toString(),
-          tokenA.decimals
-        ),
+        depositedFormatted,
+        // An AMM pool has no lending buckets: the LP position is a plain
+        // supply, and `withdraw` is the only action that moves it.
+        supplied: deposited,
+        suppliedFormatted: depositedFormatted,
+        collateral: 0n,
+        collateralFormatted: "0",
+        liabilities: 0n,
+        liabilitiesFormatted: "0",
         rewards: 0n,
         rewardsFormatted: "0",
+        limits: { withdraw: deposited },
         metadata: {
           lpShares: position.userPosition,
           userSharesPct: position.userShares,

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/BlendPoolAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/BlendPoolAdapter.test.ts
@@ -17,6 +17,7 @@ const {
   submitMock,
   claimMock,
   PoolContractV2Mock,
+  positionsEstimateBuildMock,
   fromXDRMock,
   loadAccountMock,
   prepareTransactionMock,
@@ -24,6 +25,7 @@ const {
 } = vi.hoisted(() => {
   const submitMock = vi.fn(() => "OP_XDR");
   const claimMock = vi.fn(() => "CLAIM_XDR");
+  const positionsEstimateBuildMock = vi.fn();
   const builder = {
     addOperation: vi.fn(() => builder),
     setTimeout: vi.fn(() => builder),
@@ -37,6 +39,7 @@ const {
     PoolContractV2Mock: vi.fn(function () {
       return { submit: submitMock, claim: claimMock };
     }),
+    positionsEstimateBuildMock,
     fromXDRMock: vi.fn(() => ({ __op: true })),
     loadAccountMock: vi.fn(async () => ({ __account: true })),
     prepareTransactionMock: vi.fn(async () => ({
@@ -57,6 +60,7 @@ vi.mock("@blend-capital/blend-sdk", () => ({
   },
   PoolV2: { load: poolLoadMock },
   PoolContractV2: PoolContractV2Mock,
+  PositionsEstimate: { build: positionsEstimateBuildMock },
   TokenMetadata: { load: tokenMetaLoadMock },
 }));
 
@@ -221,24 +225,94 @@ describe("BlendPoolAdapter – claimRewards", () => {
   });
 });
 
+/**
+ * Reserve stub with plausible Blend values: 7 decimals, 1 000 units supplied,
+ * nothing borrowed, 95% max utilization, c_factor 0.9 and l_factor 0.8
+ * (`getLiabilityFactor` returns the 1/l_factor multiplier the SDK exposes).
+ */
+function makeReserve(overrides: Record<string, unknown> = {}) {
+  return {
+    assetId: ASSET,
+    config: { decimals: 7, max_util: 9_500_000 },
+    totalSupply: () => 10_000_000_000n,
+    totalLiabilities: () => 0n,
+    getCollateralFactor: () => 0.9,
+    getLiabilityFactor: () => 1 / 0.8,
+    ...overrides,
+  };
+}
+
+function makePoolUser(overrides: Record<string, unknown> = {}) {
+  return {
+    positions: {
+      supply: new Map(),
+      collateral: new Map(),
+      liabilities: new Map(),
+    },
+    getSupply: () => 5_000_000n,
+    getCollateral: () => 2_000_000n,
+    getLiabilities: () => 0n,
+    estimateEmissions: () => ({ claimedTokens: 3n }),
+    ...overrides,
+  };
+}
+
+/**
+ * @param oracle - `null` makes `loadOracle` reject, standing in for a price
+ *   feed outage.
+ */
+function mockPool({
+  reserve = makeReserve(),
+  poolUser = makePoolUser(),
+  price = 1,
+  borrowCap = 1_000,
+  oracle = {} as Record<string, unknown> | null,
+}: {
+  reserve?: Record<string, unknown>;
+  poolUser?: Record<string, unknown>;
+  price?: number | undefined;
+  borrowCap?: number;
+  oracle?: Record<string, unknown> | null;
+} = {}) {
+  positionsEstimateBuildMock.mockReturnValue({ borrowCap });
+  poolLoadMock.mockResolvedValue({
+    reserves: new Map([[ASSET, reserve]]),
+    loadUser: async () => poolUser,
+    loadOracle: async () =>
+      oracle === null
+        ? Promise.reject(new Error("oracle unavailable"))
+        : { getPriceFloat: () => price, ...oracle },
+  });
+}
+
 describe("BlendPoolAdapter – getUserPosition amount formatting", () => {
-  it("sums supply + collateral and formats by reserve decimals", async () => {
-    const reserve = { config: { decimals: 7 } };
-    const poolUser = {
-      getSupply: () => 5_000_000n,
-      getCollateral: () => 2_000_000n,
-      getLiabilities: () => 0n,
-      estimateEmissions: () => ({ claimedTokens: 3n }),
-    };
-    poolLoadMock.mockResolvedValue({
-      reserves: new Map([[ASSET, reserve]]),
-      loadUser: async () => poolUser,
+  it("exposes supply, collateral and liabilities as separate balances", async () => {
+    mockPool({
+      poolUser: makePoolUser({
+        getSupply: () => 5_000_000n,
+        getCollateral: () => 2_000_000n,
+        getLiabilities: () => 1_000_000n,
+      }),
     });
 
     const adapter = new BlendPoolAdapter(POOL);
     const pos = await adapter.getUserPosition(RAW, USER);
 
     expect(pos.poolId).toBe(`blend:${POOL}:${ASSET}`);
+    expect(pos.supplied).toBe(5_000_000n);
+    expect(pos.suppliedFormatted).toBe("0.5");
+    expect(pos.collateral).toBe(2_000_000n);
+    expect(pos.collateralFormatted).toBe("0.2");
+    expect(pos.liabilities).toBe(1_000_000n);
+    expect(pos.liabilitiesFormatted).toBe("0.1");
+  });
+
+  it("keeps deposited as the display-only sum of both supply buckets", async () => {
+    mockPool();
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
     expect(pos.deposited).toBe(7_000_000n);
     expect(pos.depositedFormatted).toBe("0.7");
     expect(pos.metadata).toMatchObject({
@@ -257,9 +331,129 @@ describe("BlendPoolAdapter – getUserPosition amount formatting", () => {
       poolId: `blend:${POOL}:${ASSET}`,
       deposited: 0n,
       depositedFormatted: "0",
+      supplied: 0n,
+      suppliedFormatted: "0",
+      collateral: 0n,
+      collateralFormatted: "0",
+      liabilities: 0n,
+      liabilitiesFormatted: "0",
       rewards: 0n,
       rewardsFormatted: "0",
+      limits: {},
       metadata: {},
     });
+  });
+});
+
+describe("BlendPoolAdapter – getUserPosition action limits", () => {
+  it("caps withdraw at the supply bucket and withdrawCollateral at the collateral bucket", async () => {
+    // The regression from issue #296: a user with both balances used to be
+    // offered their sum for either action.
+    mockPool();
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.withdraw).toBe(5_000_000n);
+    expect(pos.limits.withdrawCollateral).toBe(2_000_000n);
+    expect(pos.limits.withdraw).not.toBe(pos.deposited);
+    expect(pos.limits.withdrawCollateral).not.toBe(pos.deposited);
+  });
+
+  it("caps repay at the outstanding liabilities", async () => {
+    mockPool({
+      poolUser: makePoolUser({ getLiabilities: () => 3_300_000n }),
+    });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.repay).toBe(3_300_000n);
+  });
+
+  it("derives a borrow limit from headroom, price and the liability factor", async () => {
+    // 1000 of headroom at a price of 2 with an l_factor of 0.8 leaves
+    // 1000 * 0.995 / (2 * 1.25) = 398 assets = 3_980_000_000 units.
+    mockPool({ price: 2, borrowCap: 1_000 });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.borrow).toBe(3_980_000_000n);
+  });
+
+  it("caps borrow at the reserve's max-utilization liquidity", async () => {
+    // 95% of a 1 000-unit supply, minus 900 already borrowed, leaves 50 units —
+    // below the capacity the user's collateral would otherwise allow.
+    mockPool({
+      reserve: makeReserve({ totalLiabilities: () => 9_000_000_000n }),
+      borrowCap: 1_000_000,
+    });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.borrow).toBe(500_000_000n);
+  });
+
+  it("caps withdraw at the cash actually left in the reserve", async () => {
+    mockPool({
+      reserve: makeReserve({ totalLiabilities: () => 9_000_000_000n }),
+      poolUser: makePoolUser({ getSupply: () => 5_000_000_000n }),
+    });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.withdraw).toBe(1_000_000_000n);
+  });
+
+  it("bounds collateral withdrawal by the headroom it would consume", async () => {
+    // 10 of headroom at price 1 with a 0.9 collateral factor releases
+    // 10 * 0.995 / 0.9 = 11.055... assets, under the 20-unit balance.
+    mockPool({
+      poolUser: makePoolUser({ getCollateral: () => 200_000_000n }),
+      price: 1,
+      borrowCap: 10,
+    });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.withdrawCollateral).toBe(110_555_555n);
+  });
+
+  it("offers no borrow or collateral withdrawal to an underwater position", async () => {
+    mockPool({ borrowCap: -50 });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.borrow).toBe(0n);
+    expect(pos.limits.withdrawCollateral).toBe(0n);
+    // The supply bucket carries no collateral factor, so it stays withdrawable.
+    expect(pos.limits.withdraw).toBe(5_000_000n);
+  });
+
+  it("keeps the bucket split when the oracle is unavailable", async () => {
+    mockPool({ oracle: null });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.withdraw).toBe(5_000_000n);
+    expect(pos.limits.withdrawCollateral).toBe(2_000_000n);
+    // Falls back to the liquidity ceiling rather than removing the cap.
+    expect(pos.limits.borrow).toBe(9_500_000_000n);
+  });
+
+  it("falls back to the liquidity ceiling when the asset has no price", async () => {
+    mockPool({ oracle: { getPriceFloat: () => undefined } });
+
+    const adapter = new BlendPoolAdapter(POOL);
+    const pos = await adapter.getUserPosition(RAW, USER);
+
+    expect(pos.limits.borrow).toBe(9_500_000_000n);
+    expect(pos.limits.withdrawCollateral).toBe(2_000_000n);
   });
 });

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/NekoLendingAdapter.test.ts
@@ -226,6 +226,19 @@ describe("NekoLendingAdapter – getUserPosition", () => {
     });
   });
 
+  it("reports the balance as plain supply with no collateral or debt", async () => {
+    const adapter = new NekoLendingAdapter();
+    const position = await adapter.getUserPosition("USDC", "GUSER");
+
+    // Neko has no collateral bucket, so the shape degrades to supply-only and
+    // `withdraw` keeps the exact ceiling it had before issue #296.
+    expect(position.supplied).toBe(15_000_000n);
+    expect(position.suppliedFormatted).toBe("1.5");
+    expect(position.collateral).toBe(0n);
+    expect(position.liabilities).toBe(0n);
+    expect(position.limits).toEqual({ withdraw: 15_000_000n });
+  });
+
   it("falls back to an empty position when the balance call fails", async () => {
     clientMethods.get_b_token_balance.mockRejectedValue(new Error("boom"));
     const adapter = new NekoLendingAdapter();
@@ -235,6 +248,10 @@ describe("NekoLendingAdapter – getUserPosition", () => {
       poolId: "neko:USDC",
       deposited: 0n,
       depositedFormatted: "0",
+      supplied: 0n,
+      collateral: 0n,
+      liabilities: 0n,
+      limits: {},
       metadata: {},
     });
   });

--- a/apps/web-app/src/lib/orchestrator/adapters/__tests__/SoroswapPoolAdapter.test.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/__tests__/SoroswapPoolAdapter.test.ts
@@ -302,6 +302,12 @@ describe("SoroswapPoolAdapter – getUserPosition", () => {
       depositedFormatted: "0",
       rewards: 0n,
     });
+    // No lending buckets and no derivable ceilings — an absent limit means
+    // "unknown", which callers must not render as a zero max.
+    expect(position.supplied).toBe(0n);
+    expect(position.collateral).toBe(0n);
+    expect(position.liabilities).toBe(0n);
+    expect(position.limits).toEqual({});
   });
 
   it("swallows lookup failures and returns a zeroed empty position", async () => {

--- a/apps/web-app/src/lib/orchestrator/types/pool.types.ts
+++ b/apps/web-app/src/lib/orchestrator/types/pool.types.ts
@@ -37,16 +37,56 @@ export interface PoolInfo {
   metadata: Record<string, unknown>;
 }
 
+/**
+ * Per-action ceiling on the amount a user may submit, in the smallest units of
+ * the pool's asset.
+ *
+ * An action is present only when the adapter can derive a real ceiling for it.
+ * An absent action means "no known cap" — callers must not treat that as zero,
+ * and must not offer a Max button for it.
+ *
+ * Ceilings are bucket-aware: on a lending pool each action moves one specific
+ * on-chain balance, so `withdraw` and `withdrawCollateral` have separate
+ * ceilings even when they target the same reserve.
+ */
+export type PoolActionLimits = Partial<Record<PoolAction, bigint>>;
+
 export interface PoolPosition {
   poolId: string;
 
+  /**
+   * Aggregate of every balance the user has supplied to the pool
+   * (`supplied + collateral` on a lending pool).
+   *
+   * This is a display total only. It spans two distinct on-chain balances and
+   * no single action can move all of it — never derive an action amount from
+   * it, use `limits` instead.
+   */
   deposited: bigint;
 
   depositedFormatted: string;
 
+  /** Non-collateralized supply. Withdrawable via `withdraw`. */
+  supplied: bigint;
+
+  suppliedFormatted: string;
+
+  /** Collateralized supply. Withdrawable via `withdrawCollateral`. */
+  collateral: bigint;
+
+  collateralFormatted: string;
+
+  /** Outstanding debt. Settled via `repay`. */
+  liabilities: bigint;
+
+  liabilitiesFormatted: string;
+
   rewards: bigint;
 
   rewardsFormatted: string;
+
+  /** Maximum submittable amount per action. See {@link PoolActionLimits}. */
+  limits: PoolActionLimits;
 
   metadata: Record<string, unknown>;
 }

--- a/apps/web-app/src/lib/strategy/definitions.ts
+++ b/apps/web-app/src/lib/strategy/definitions.ts
@@ -47,7 +47,7 @@ type ParseResult<T> =
  * this instead of calling paramsSchema.parse() directly.
  */
 function safeParseParams<T>(
-  schema: z.ZodType<T>,
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
   input: unknown
 ): ParseResult<T> {
   const result = schema.safeParse(input);

--- a/apps/web-app/src/lib/strategy/types.ts
+++ b/apps/web-app/src/lib/strategy/types.ts
@@ -92,7 +92,12 @@ export interface StrategyStepDefinition<TParams = Record<string, unknown>> {
   readonly protocol: string;
   /** How prepare()'s xdr gets submitted — the engine branches on this once, centrally. */
   readonly submissionMode: "rpc" | "soroswapApi";
-  readonly paramsSchema: z.ZodType<TParams>;
+  /**
+   * Parses untrusted `unknown` input into TParams. The input type is left open
+   * rather than pinned to TParams so schemas that use `.default()` — whose
+   * input type has those keys optional — still satisfy this.
+   */
+  readonly paramsSchema: z.ZodType<TParams, z.ZodTypeDef, unknown>;
 
   /** Declares this step's output ports so downstream steps can bind to them. */
   describeOutputs(params: TParams): StepPort[];

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -13,6 +13,13 @@ import { defineConfig } from "vitest/config";
  * environment per-file with a `// @vitest-environment jsdom` docblock, so the
  * default (node) stays fast for the pure-logic and adapter suites.
  *
+ * `test.env` supplies the four required `NEXT_PUBLIC_STELLAR_*` vars that
+ * `src/lib/env.client.ts` validates at import time. That module throws on
+ * missing config by design, and Vitest — unlike Next.js — does not read
+ * `.env.local`, so without these every suite that transitively imports it
+ * fails. Pinning public testnet values here keeps the suite hermetic: it
+ * behaves identically on a fresh clone and in CI, with no secrets involved.
+ *
  * `esbuild.jsx` overrides the `jsx: "preserve"` this project's shared
  * tsconfig sets for Next.js's own SWC-based build pipeline — Vitest's
  * esbuild transform needs an actual JSX transform (not "preserve") to parse
@@ -26,5 +33,14 @@ export default defineConfig({
   },
   oxc: {
     jsx: { runtime: "automatic" },
+  },
+  test: {
+    env: {
+      NEXT_PUBLIC_STELLAR_NETWORK: "TESTNET",
+      NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE:
+        "Test SDF Network ; September 2015",
+      NEXT_PUBLIC_STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+      NEXT_PUBLIC_STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "axios": "^1.7.9",
         "chart.js": "^4.4.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.4.0",
         "json-schema": "^0.4.0",
         "lodash": "^4.17.21",
         "lossless-json": "^1.0.4",
@@ -10583,10 +10584,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/backstop": {
-      "resolved": "packages/contracts/backstop",
-      "link": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -11651,6 +11648,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -11709,10 +11716,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/defindex-vault": {
-      "resolved": "packages/contracts/defindex-vault",
-      "link": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -14521,10 +14524,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/lending": {
-      "resolved": "packages/contracts/lending",
-      "link": true
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -15563,10 +15562,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/oracle": {
-      "resolved": "packages/contracts/oracle",
-      "link": true
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -19372,6 +19367,7 @@
       }
     },
     "packages/contracts/backstop": {
+      "name": "@neko/backstop",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19405,6 +19401,7 @@
       }
     },
     "packages/contracts/defindex-vault": {
+      "name": "@neko/defindex-vault",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19438,6 +19435,7 @@
       }
     },
     "packages/contracts/lending": {
+      "name": "@neko/lending",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19471,6 +19469,7 @@
       }
     },
     "packages/contracts/oracle": {
+      "name": "@neko/oracle",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",

--- a/packages/contracts/backstop/package.json
+++ b/packages/contracts/backstop/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "backstop",
+  "name": "@neko/backstop",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/defindex-vault/package.json
+++ b/packages/contracts/defindex-vault/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "defindex-vault",
+  "name": "@neko/defindex-vault",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/lending/package.json
+++ b/packages/contracts/lending/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "lending",
+  "name": "@neko/lending",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/oracle/package.json
+++ b/packages/contracts/oracle/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "oracle",
+  "name": "@neko/oracle",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Closes #296

Two commits: the first restores a green CI pipeline, the second is the #296 fix. CI was red on `dev`, so the fix had to come along for this PR to get any signal at all.

| Step | On `dev` | This branch |
|---|---|---|
| Lint | pass | pass |
| Typecheck | **51 errors** | pass |
| Build | (never ran) — **failed** | pass |
| Test | (never ran) — **16/29 suites failed** | pass (332 tests) |

---

# 1. `fix(ci): restore a green pipeline`

CI stopped at **Typecheck**, which masked two further breakages behind it: **Build** also failed, and **Test** failed for every suite.

## Root cause of 32 of the 51 typecheck errors

The four contract client packages declare themselves as `lending`, `oracle`, `backstop` and `defindex-vault`, but the app imports and depends on them as `@neko/*`. The name mismatch breaks the npm workspace graph, so turbo's `typecheck.dependsOn: ["^build"]` never built them — and since their `dist/` is gitignored, a fresh CI checkout had nothing to resolve.

```
# before
web-app#typecheck | deps: ["@neko/config#build"]

# after
web-app#typecheck | deps: ["@neko/backstop#build", "@neko/config#build",
                           "@neko/defindex-vault#build", "@neko/lending#build",
                           "@neko/oracle#build"]
```

`@neko/config` was unaffected because its name already matched — that is the convention the other four are restored to. The lockfile carried both scoped and unscoped links to the same directories; regenerating drops the duplicates. Nothing imports the unscoped names.

This alone cleared 37 of the 51 errors: the five implicit-any errors (`TS7006`/`TS7031`) were downstream of the unresolved types, not separate defects.

## Remaining typecheck errors

- **`date-fns`** was imported by `ActivityFeedItem` but never declared as a dependency.
- **Merge artifacts:** `MobileHeader` imported `useStellarWallet` twice; `sidebarConfig` used the `Workflow` icon without importing it.
- **Zod input variance (9 errors).** `strategy/types.ts` typed `paramsSchema` as `z.ZodType<TParams>`, which in zod 3 pins the *input* type to the output type. Schemas using `.default()` have an optional input for those keys and so could not satisfy it. These schemas parse untrusted `unknown` input — `safeParseParams(schema, input: unknown)` — so the input parameter is now `unknown`, which is what it always meant.
- **Two analytics routes** assigned an array literal through a trailing `.filter()`. The contextual type applies to the filter's *result*, not the literal, so `source` widened to `string` and `assets` to `string[]`. `satisfies` restores it and validates the literals — a typo in a `source` is now a compile error.

## Build

`/swap` prerendering crashed with `ReferenceError: localStorage is not defined`. `getApiKey()` reads `localStorage` unguarded, and `useLimitOrderMonitor` calls it **during render**, which also runs on the server during static prerendering. Guarded at the source rather than at the call site, matching how `storage.ts` and `walletKit.ts` already handle this.

## Test

`env.client.ts` validates the required `NEXT_PUBLIC_STELLAR_*` vars at import time and throws when absent. That fail-fast behaviour is deliberate and kept, but Vitest — unlike Next.js — does not read `.env.local`, so all 16 suites that transitively import it failed. Pinning public testnet values in `vitest.config.ts` makes the suite hermetic. The production build needs the same vars while prerendering, so the workflow now sets them at job level; they are public endpoints, not secrets.

## One unmasked lint error

Fixing the duplicate import in `MobileHeader` surfaced an error that had been hidden: with the redeclaration present, the React Compiler lint rule bailed out on the whole file. The pathname effect called `setState` synchronously; it now resets during render — React's documented pattern — which also avoids rendering the menu open for a frame before closing it.

---

# 2. `fix(pools): split Blend supply and collateral into per-action limits`

## Problem

`BlendPoolAdapter.getUserPosition()` collapsed two distinct on-chain balances into `deposited = supplied + collateral`, and `PoolActionModal` derived the **Max** amount for both `withdraw` and `withdrawCollateral` from that sum. Each Blend request moves only its own bucket, so a user with 100 supplied and 100 collateral in one reserve was offered a Max of 200 for either action — and the transaction died in `prepareTransaction` simulation with a raw contract error.

`borrow` fell through to `default: return ""`: no Max, no cap, no validation, with `parseFloat(amount) > 0` as the only submit guard. `repay` returned `"0"` for every non-Blend adapter.

## Approach

The position model itself was lossy, so this fixes the model rather than clamping at the call site.

`PoolPosition` gains `supplied` / `collateral` / `liabilities` (plus formatted variants) as first-class fields and a per-action `limits` map, replacing the stringly-typed `metadata` leftovers that nothing downstream read. Each ceiling is derived from the balance its `RequestType` actually touches:

| Action | Ceiling |
|---|---|
| `withdraw` | supply bucket, capped by reserve cash |
| `withdrawCollateral` | collateral bucket, capped by cash **and** by the borrow headroom it would consume (`price × c_factor`) |
| `borrow` | `borrowCap / (price × l_factor)` from `PositionsEstimate`, capped by max-utilization liquidity |
| `repay` | outstanding liabilities, and in the modal the wallet balance |

An absent limit means "no known cap", never zero — callers must not render it as a zero max.

Two deliberate calls worth reviewing:

- **Oracle degradation.** Capacity ceilings need prices. When the oracle is unavailable or an asset is unpriced, the bucket and liquidity ceilings still apply, so a price outage degrades the caps instead of removing them — the bucket split, which is the actual bug, survives.
- **Safety margin.** Max stops at 99.5% of headroom. Borrowing to exactly the cap lands the position at a health factor of 1 — instantly liquidatable, and rejected at simulation anyway once interest accrues between the position read and submission.

## Changes

- `types/pool.types.ts` — extend `PoolPosition`, add `PoolActionLimits`
- `adapters/BlendPoolAdapter.ts` — stop conflating the buckets; new `deriveLimits` surfaces capacity from data the adapter already loads
- `adapters/NekoLendingAdapter.ts` — reports its b-token balance as plain supply with the exact `withdraw` ceiling it already had
- `adapters/SoroswapPoolAdapter.ts` — the LP position from #283 is a plain supply with no collateral or debt, so it reports `limits.withdraw` and zeroes the lending buckets
- `features/pools/components/PoolActionModal.tsx` — per-action max; amounts compared in smallest units via `toSmallestUnit` instead of `parseFloat`; over-max submission blocked with a readable message, so no wallet prompt and no failed simulation
- `features/pools/components/pages/PoolDetail.tsx` — shows supplied, collateral and liabilities separately

`deposited` stays as a documented display-only total, so the dashboard, lending and `MyBalances` consumers are untouched.

## Acceptance criteria

- [x] `withdraw` Max reflects withdrawable supply only; `withdrawCollateral` Max reflects withdrawable collateral only
- [x] `borrow` has a capacity-derived max and blocks submission above it
- [x] Amounts above the max are rejected client-side with a readable message — no wallet prompt, no failed simulation
- [x] `repay` max is derived for any adapter that supports repay, not Blend only
- [x] `PoolDetail` shows supplied, collateral and liabilities as separate figures
- [x] `NekoLendingAdapter` and `SoroswapPoolAdapter` flows are unchanged; new adapter unit tests cover the bucket split

## Rebase note

One conflict when rebasing onto current `dev`, in `SoroswapPoolAdapter.getUserPosition`, where #283 landed a real LP-position read while this branch still had the zeroed stub. Resolved by keeping the real implementation and conforming it to the extended shape, so SoroSwap's new `withdraw` action gets a working Max too.

---

## Testing

Verified with a cold turbo cache and no `.env.local`, matching what CI sees: lint, typecheck, build and test all pass. **332 tests**, including the suites that landed with #284, #285, #287 and #291.

11 new `BlendPoolAdapter` cases cover the bucket split, the liquidity and max-utilization caps, the health bound on collateral withdrawal, an underwater position, and both oracle-degradation paths. Neko and SoroSwap gained assertions on the new shape so the no-regression criterion is actually enforced.

Reproduction from #296 now behaves: with both balances in one reserve, Withdraw offers only the supplied figure and Withdraw Collateral only the collateral figure.

Reviewers: `package-lock.json` is regenerated in the CI commit. The substantive part is small — the `@neko/*` links now point at the renamed packages, the duplicate unscoped entries are gone, plus `date-fns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)