### PR TITLE
fix(ci): restore a green pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
   verify:
     name: Lint · Typecheck · Build · Test
     runs-on: ubuntu-latest
+    # `src/lib/env.client.ts` validates these at import time and throws when
+    # they are missing, which the production build hits while prerendering.
+    # They are public testnet endpoints, not secrets — CI only needs the build
+    # to resolve, never to reach the network.
+    env:
+      NEXT_PUBLIC_STELLAR_NETWORK: TESTNET
+      NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      NEXT_PUBLIC_STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -35,6 +35,7 @@
     "axios": "^1.7.9",
     "chart.js": "^4.4.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.4.0",
     "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
     "lossless-json": "^1.0.4",

--- a/apps/web-app/src/app/api/analytics/earnings/route.ts
+++ b/apps/web-app/src/app/api/analytics/earnings/route.ts
@@ -139,15 +139,20 @@ export async function GET(req: NextRequest) {
     portfolioUsd > 0 ? (totalEarned / portfolioUsd) * 100 : 0;
 
   // Per-asset breakdown (realistic token list)
-  const byAsset: EarningsByAsset[] = [
-    { asset: "USDC", source: "vault", earned: sources[0].earned * 0.6 },
-    { asset: "XLM", source: "vault", earned: sources[0].earned * 0.4 },
-    { asset: "USDC", source: "lending", earned: sources[1].earned * 0.7 },
-    { asset: "EURC", source: "lending", earned: sources[1].earned * 0.3 },
-    { asset: "XLM/USDC", source: "pools", earned: sources[2].earned * 0.55 },
-    { asset: "EURC/USDC", source: "pools", earned: sources[2].earned * 0.45 },
-    { asset: "CETES", source: "rwa", earned: sources[3].earned },
-  ].filter((r) => r.earned > 0.000001);
+  // `satisfies` restores contextual typing the trailing .filter() would
+  // otherwise swallow, so each `source` narrows to EarningsSourceId instead of
+  // widening to string — and a typo in one is caught here.
+  const byAsset: EarningsByAsset[] = (
+    [
+      { asset: "USDC", source: "vault", earned: sources[0].earned * 0.6 },
+      { asset: "XLM", source: "vault", earned: sources[0].earned * 0.4 },
+      { asset: "USDC", source: "lending", earned: sources[1].earned * 0.7 },
+      { asset: "EURC", source: "lending", earned: sources[1].earned * 0.3 },
+      { asset: "XLM/USDC", source: "pools", earned: sources[2].earned * 0.55 },
+      { asset: "EURC/USDC", source: "pools", earned: sources[2].earned * 0.45 },
+      { asset: "CETES", source: "rwa", earned: sources[3].earned },
+    ] satisfies EarningsByAsset[]
+  ).filter((r) => r.earned > 0.000001);
 
   const response: EarningsApiResponse = {
     totalEarned,

--- a/apps/web-app/src/app/api/analytics/metrics/route.ts
+++ b/apps/web-app/src/app/api/analytics/metrics/route.ts
@@ -178,16 +178,21 @@ export async function GET(req: NextRequest) {
   };
 
   // IL positions (for any LP positions)
-  const ilPositions: ILPosition[] = [
-    {
-      poolId: "xlm-usdc",
-      assets: ["XLM", "USDC"],
-      ilPct: -2.3,
-      ilUsd: totalValue * 0.25 * 0.023,
-      hodlValue: totalValue * 0.25 + totalValue * 0.25 * 0.023,
-      currentValue: totalValue * 0.25,
-    },
-  ].filter(() => totalValue > 0);
+  // `satisfies` restores contextual typing the trailing .filter() would
+  // otherwise swallow, so `assets` stays the [string, string] pair ILPosition
+  // declares instead of widening to string[].
+  const ilPositions: ILPosition[] = (
+    [
+      {
+        poolId: "xlm-usdc",
+        assets: ["XLM", "USDC"],
+        ilPct: -2.3,
+        ilUsd: totalValue * 0.25 * 0.023,
+        hodlValue: totalValue * 0.25 + totalValue * 0.25 * 0.023,
+        currentValue: totalValue * 0.25,
+      },
+    ] satisfies ILPosition[]
+  ).filter(() => totalValue > 0);
 
   // Yield forecast
   const yieldForecast: YieldForecast = {

--- a/apps/web-app/src/components/navigation/MobileHeader.tsx
+++ b/apps/web-app/src/components/navigation/MobileHeader.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 import { NAV_ITEMS } from "./sidebarConfig";
 import { useWalletType } from "@/hooks/useWalletType";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
-import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { truncateAddress } from "@/lib/utils";
 import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
 import { clientEnv } from "@/lib/env.client";
@@ -26,6 +25,16 @@ export function MobileHeader() {
   const { unreadCount } = useActivityFeed();
   const menuRef = useRef<HTMLDivElement>(null);
   const walletButtonRef = useRef<HTMLDivElement>(null);
+
+  // Close the menu on navigation. Adjusting state during render is React's
+  // documented pattern for resetting state when a value changes; doing it in
+  // an effect renders the menu open first and then immediately re-renders it
+  // closed, which is the cascading render the lint rule flags.
+  const [menuPathname, setMenuPathname] = useState(pathname);
+  if (pathname !== menuPathname) {
+    setMenuPathname(pathname);
+    setIsOpen(false);
+  }
 
   const isConnected = isStellarConnected;
   const activeAddress = stellarAddress ?? "";
@@ -62,10 +71,6 @@ export function MobileHeader() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen, walletDropdownOpen]);
-
-  useEffect(() => {
-    setIsOpen(false);
-  }, [pathname]);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? "hidden" : "";

--- a/apps/web-app/src/components/navigation/sidebarConfig.ts
+++ b/apps/web-app/src/components/navigation/sidebarConfig.ts
@@ -11,6 +11,7 @@ import {
   PieChart,
   Zap,
   Bell,
+  Workflow,
 } from "lucide-react";
 
 export const NAV_ITEMS = [

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/utils.ts
@@ -11,6 +11,10 @@ export const getApiKey = (): string | null => {
   if (envKeyStr && envKeyStr.trim() !== "") {
     return envKeyStr.trim();
   }
+  // Callers reach this during render (see useLimitOrderMonitor), which also
+  // runs on the server during static prerendering — where localStorage does
+  // not exist. Fall back to "no key configured" instead of throwing.
+  if (typeof window === "undefined") return null;
   const localKey = localStorage.getItem("soroswap_api_key");
   if (localKey && localKey.trim() !== "") {
     return localKey.trim();
@@ -19,6 +23,7 @@ export const getApiKey = (): string | null => {
 };
 
 export const setApiKey = (apiKey: string): void => {
+  if (typeof window === "undefined") return;
   localStorage.setItem("soroswap_api_key", apiKey);
 };
 

--- a/apps/web-app/src/lib/strategy/definitions.ts
+++ b/apps/web-app/src/lib/strategy/definitions.ts
@@ -47,7 +47,7 @@ type ParseResult<T> =
  * this instead of calling paramsSchema.parse() directly.
  */
 function safeParseParams<T>(
-  schema: z.ZodType<T>,
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
   input: unknown
 ): ParseResult<T> {
   const result = schema.safeParse(input);

--- a/apps/web-app/src/lib/strategy/types.ts
+++ b/apps/web-app/src/lib/strategy/types.ts
@@ -92,7 +92,12 @@ export interface StrategyStepDefinition<TParams = Record<string, unknown>> {
   readonly protocol: string;
   /** How prepare()'s xdr gets submitted — the engine branches on this once, centrally. */
   readonly submissionMode: "rpc" | "soroswapApi";
-  readonly paramsSchema: z.ZodType<TParams>;
+  /**
+   * Parses untrusted `unknown` input into TParams. The input type is left open
+   * rather than pinned to TParams so schemas that use `.default()` — whose
+   * input type has those keys optional — still satisfy this.
+   */
+  readonly paramsSchema: z.ZodType<TParams, z.ZodTypeDef, unknown>;
 
   /** Declares this step's output ports so downstream steps can bind to them. */
   describeOutputs(params: TParams): StepPort[];

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -13,6 +13,13 @@ import { defineConfig } from "vitest/config";
  * environment per-file with a `// @vitest-environment jsdom` docblock, so the
  * default (node) stays fast for the pure-logic and adapter suites.
  *
+ * `test.env` supplies the four required `NEXT_PUBLIC_STELLAR_*` vars that
+ * `src/lib/env.client.ts` validates at import time. That module throws on
+ * missing config by design, and Vitest — unlike Next.js — does not read
+ * `.env.local`, so without these every suite that transitively imports it
+ * fails. Pinning public testnet values here keeps the suite hermetic: it
+ * behaves identically on a fresh clone and in CI, with no secrets involved.
+ *
  * `esbuild.jsx` overrides the `jsx: "preserve"` this project's shared
  * tsconfig sets for Next.js's own SWC-based build pipeline — Vitest's
  * esbuild transform needs an actual JSX transform (not "preserve") to parse
@@ -26,5 +33,14 @@ export default defineConfig({
   },
   oxc: {
     jsx: { runtime: "automatic" },
+  },
+  test: {
+    env: {
+      NEXT_PUBLIC_STELLAR_NETWORK: "TESTNET",
+      NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE:
+        "Test SDF Network ; September 2015",
+      NEXT_PUBLIC_STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+      NEXT_PUBLIC_STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "axios": "^1.7.9",
         "chart.js": "^4.4.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.4.0",
         "json-schema": "^0.4.0",
         "lodash": "^4.17.21",
         "lossless-json": "^1.0.4",
@@ -10583,10 +10584,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/backstop": {
-      "resolved": "packages/contracts/backstop",
-      "link": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -11651,6 +11648,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -11709,10 +11716,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/defindex-vault": {
-      "resolved": "packages/contracts/defindex-vault",
-      "link": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -14521,10 +14524,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/lending": {
-      "resolved": "packages/contracts/lending",
-      "link": true
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -15563,10 +15562,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/oracle": {
-      "resolved": "packages/contracts/oracle",
-      "link": true
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -19372,6 +19367,7 @@
       }
     },
     "packages/contracts/backstop": {
+      "name": "@neko/backstop",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19405,6 +19401,7 @@
       }
     },
     "packages/contracts/defindex-vault": {
+      "name": "@neko/defindex-vault",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19438,6 +19435,7 @@
       }
     },
     "packages/contracts/lending": {
+      "name": "@neko/lending",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
@@ -19471,6 +19469,7 @@
       }
     },
     "packages/contracts/oracle": {
+      "name": "@neko/oracle",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",

--- a/packages/contracts/backstop/package.json
+++ b/packages/contracts/backstop/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "backstop",
+  "name": "@neko/backstop",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/defindex-vault/package.json
+++ b/packages/contracts/defindex-vault/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "defindex-vault",
+  "name": "@neko/defindex-vault",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/lending/package.json
+++ b/packages/contracts/lending/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "lending",
+  "name": "@neko/lending",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/contracts/oracle/package.json
+++ b/packages/contracts/oracle/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "oracle",
+  "name": "@neko/oracle",
   "type": "module",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
CI has been failing on `dev`. It stopped at the **Typecheck** step, which masked two further breakages behind it: **Build** also failed, and **Test** failed for every suite. This fixes all four steps.

Verified with a cold turbo cache and no `.env.local`, matching what CI actually sees:

| Step | Before | After |
|---|---|---|
| Lint | pass | pass |
| Typecheck | **51 errors** | pass |
| Build | (never ran) — **failed** | pass |
| Test | (never ran) — **16/29 suites failed** | pass (321 tests) |

## Root cause of 32 of the 51 typecheck errors

The four contract client packages declare themselves as `lending`, `oracle`, `backstop` and `defindex-vault`, but the app imports and depends on them as `@neko/*`. The name mismatch breaks the npm workspace graph, so turbo's `typecheck.dependsOn: ["^build"]` never built them — and since their `dist/` is gitignored, a fresh CI checkout had nothing to resolve.

```
# before
web-app#typecheck | deps: ["@neko/config#build"]

# after
web-app#typecheck | deps: ["@neko/backstop#build", "@neko/config#build",
                           "@neko/defindex-vault#build", "@neko/lending#build",
                           "@neko/oracle#build"]
```

`@neko/config` was unaffected because its name already matched — that is the convention the other four are restored to. The lockfile carried both scoped and unscoped links to the same directories; regenerating drops the duplicates. Nothing imports the unscoped names.

This alone cleared 37 of the 51 errors: the five implicit-any errors (`TS7006`/`TS7031`) were downstream of the unresolved types, not separate defects.

## Remaining typecheck errors

- **`date-fns`** was imported by `ActivityFeedItem` but never declared as a dependency.
- **Merge artifacts:** `MobileHeader` imported `useStellarWallet` twice; `sidebarConfig` used the `Workflow` icon without importing it.
- **Zod input variance (9 errors).** `strategy/types.ts` typed `paramsSchema` as `z.ZodType<TParams>`, which in zod 3 pins the *input* type to the output type. Schemas using `.default()` have an optional input for those keys and so could not satisfy it. These schemas parse untrusted `unknown` input — `safeParseParams(schema, input: unknown)` — so the input parameter is now `unknown`, which is what it always meant.
- **Two analytics routes** assigned an array literal through a trailing `.filter()`. The contextual type applies to the filter's *result*, not the literal, so `source` widened to `string` and `assets` to `string[]`. `satisfies` restores the contextual type and validates the literals — a typo in a `source` is now a compile error.

## Build

`/swap` prerendering crashed with `ReferenceError: localStorage is not defined`. `getApiKey()` reads `localStorage` unguarded, and `useLimitOrderMonitor` calls it **during render**, which also runs on the server during static prerendering. Guarded at the source rather than at the call site, matching how `storage.ts` and `walletKit.ts` already handle this.

## Test

`env.client.ts` validates the required `NEXT_PUBLIC_STELLAR_*` vars at import time and throws when they are absent. That fail-fast behaviour is deliberate and worth keeping, but Vitest — unlike Next.js — does not read `.env.local`, so all 16 suites that transitively import it failed. Pinning public testnet values in `vitest.config.ts` makes the suite hermetic: identical on a fresh clone and in CI.

The production build needs the same vars while prerendering, so the workflow now sets them at the job level. They are public testnet endpoints, not secrets — CI only needs the build to resolve them, never to reach the network.

## One unmasked lint error

Fixing the duplicate import in `MobileHeader` surfaced a real error that had been hidden: with the redeclaration present, the React Compiler lint rule bailed out on the whole file. The pathname effect called `setState` synchronously (`Calling setState synchronously within an effect can trigger cascading renders`). It now resets during render — React's documented pattern for resetting state when a value changes — which also avoids rendering the menu open for a frame before closing it.

## Note for reviewers

`package-lock.json` is regenerated. The substantive part is small: the `@neko/*` links now point at the renamed packages and the duplicate unscoped entries are gone, plus `date-fns`.

Worth merging before other PRs — while CI is red on `dev`, no PR gets meaningful signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)