### PR TITLE
fix: anchor deadlines, cancellation, and failure states

### DIFF
--- a/apps/web-app/src/app/api/anchor/[provider]/assets/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/assets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { EtherfuseClient } from "@/lib/anchors/etherfuse";
 import { parseParam, parseQuery } from "@/lib/validation/parse";
 import { AssetsQuerySchema, ProviderSchema } from "@/lib/validation/schemas";
@@ -33,21 +34,14 @@ export async function GET(
       );
     }
 
-    const result = await client.getAssets("stellar", "mxn", wallet);
+    const result = await client.getAssets(
+      "stellar",
+      "mxn",
+      wallet,
+      request.signal
+    );
     return NextResponse.json(result);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/customers/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/customers/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
 import {
   CreateCustomerBodySchema,
@@ -24,23 +25,14 @@ export async function POST(
     const { email, country = "MX", publicKey } = parsed.data;
 
     const client = getAnchorClient(provider);
-    const customer = await client.createCustomer({ email, country, publicKey });
+    const customer = await client.createCustomer(
+      { email, country, publicKey },
+      request.signal
+    );
 
     return NextResponse.json(customer, { status: 201 });
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }
 
@@ -60,11 +52,14 @@ export async function GET(
     const { email, customerId, country = "MX" } = queryResult.data;
 
     const client = getAnchorClient(provider);
-    const customer = await client.getCustomer({
-      email: email || undefined,
-      customerId: customerId || undefined,
-      country,
-    });
+    const customer = await client.getCustomer(
+      {
+        email: email || undefined,
+        customerId: customerId || undefined,
+        country,
+      },
+      request.signal
+    );
 
     if (!customer) {
       return NextResponse.json(
@@ -75,18 +70,6 @@ export async function GET(
 
     return NextResponse.json(customer);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/fiat-accounts/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/fiat-accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
 import {
   CustomerIdQuerySchema,
@@ -24,32 +25,23 @@ export async function POST(
     const { customerId, publicKey, bankName, clabe, beneficiary } = parsed.data;
 
     const client = getAnchorClient(provider);
-    const result = await client.registerFiatAccount({
-      customerId,
-      publicKey: publicKey || undefined,
-      account: {
-        type: "spei",
-        clabe,
-        bankName: bankName || undefined,
-        beneficiary,
+    const result = await client.registerFiatAccount(
+      {
+        customerId,
+        publicKey: publicKey || undefined,
+        account: {
+          type: "spei",
+          clabe,
+          bankName: bankName || undefined,
+          beneficiary,
+        },
       },
-    });
+      request.signal
+    );
 
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }
 
@@ -69,21 +61,9 @@ export async function GET(
     const { customerId } = queryResult.data;
 
     const client = getAnchorClient(provider);
-    const accounts = await client.getFiatAccounts(customerId);
+    const accounts = await client.getFiatAccounts(customerId, request.signal);
     return NextResponse.json(accounts);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/kyc/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/kyc/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { AlfredPayClient } from "@/lib/anchors/alfredpay";
 import {
   parseJsonBody,
@@ -49,7 +50,10 @@ export async function GET(
           { status: 400 }
         );
       }
-      const requirements = await client.getKycRequirements(country);
+      const requirements = await client.getKycRequirements(
+        country,
+        request.signal
+      );
       return NextResponse.json(requirements);
     }
 
@@ -63,32 +67,28 @@ export async function GET(
       const kycUrl = await client.getKycUrl(
         customerId!,
         publicKey,
-        bankAccountId
+        bankAccountId,
+        request.signal
       );
       return NextResponse.json({ url: kycUrl });
     }
 
     if (type === "submission" && client instanceof AlfredPayClient) {
-      const submission = await client.getKycSubmission(customerId!);
+      const submission = await client.getKycSubmission(
+        customerId!,
+        request.signal
+      );
       return NextResponse.json({ submission });
     }
 
-    const status = await client.getKycStatus(customerId!, publicKey);
+    const status = await client.getKycStatus(
+      customerId!,
+      publicKey,
+      request.signal
+    );
     return NextResponse.json({ status });
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }
 
@@ -161,22 +161,30 @@ export async function POST(
           }
         }
 
-        const result = await client.submitKyc(formParsed.data.customerId, {
-          fields: formParsed.data.fields,
-          documents,
-          metadata: formParsed.data.metadata,
-        });
+        const result = await client.submitKyc(
+          formParsed.data.customerId,
+          {
+            fields: formParsed.data.fields,
+            documents,
+            metadata: formParsed.data.metadata,
+          },
+          request.signal
+        );
         return NextResponse.json(result);
       }
 
       const parsed = await parseJsonBody(request, KycSubmitJsonBodySchema);
       if ("error" in parsed) return parsed.error;
       const { customerId, data } = parsed.data;
-      const result = await client.submitKyc(customerId, {
-        fields: data.fields,
-        documents: data.documents ?? {},
-        metadata: data.metadata,
-      });
+      const result = await client.submitKyc(
+        customerId,
+        {
+          fields: data.fields,
+          documents: data.documents ?? {},
+          metadata: data.metadata,
+        },
+        request.signal
+      );
       return NextResponse.json(result);
     }
 
@@ -208,7 +216,8 @@ export async function POST(
         submissionId,
         fileType,
         file,
-        file.name
+        file.name,
+        request.signal
       );
       return NextResponse.json(result);
     }
@@ -221,18 +230,6 @@ export async function POST(
     if (error instanceof ZodError) {
       return zodErrorResponse(error);
     }
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
 import {
   OffRampBodySchema,
@@ -40,44 +41,38 @@ export async function POST(
       fiatAccountId = existingFiatAccountId;
     } else {
       const { bankName, clabe, beneficiary } = bankAccount!;
-      const fiatAccount = await client.registerFiatAccount({
-        customerId,
-        account: {
-          type: "spei",
-          clabe,
-          bankName: bankName || undefined,
-          beneficiary,
+      const fiatAccount = await client.registerFiatAccount(
+        {
+          customerId,
+          account: {
+            type: "spei",
+            clabe,
+            bankName: bankName || undefined,
+            beneficiary,
+          },
         },
-      });
+        request.signal
+      );
       fiatAccountId = fiatAccount.id;
     }
 
-    const transaction = await client.createOffRamp({
-      customerId,
-      quoteId,
-      stellarAddress,
-      fromCurrency,
-      toCurrency,
-      amount,
-      fiatAccountId,
-      memo,
-    });
+    const transaction = await client.createOffRamp(
+      {
+        customerId,
+        quoteId,
+        stellarAddress,
+        fromCurrency,
+        toCurrency,
+        amount,
+        fiatAccountId,
+        memo,
+      },
+      request.signal
+    );
 
     return NextResponse.json(transaction, { status: 201 });
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }
 
@@ -97,7 +92,10 @@ export async function GET(
     const { transactionId } = queryResult.data;
 
     const client = getAnchorClient(provider);
-    const transaction = await client.getOffRampTransaction(transactionId);
+    const transaction = await client.getOffRampTransaction(
+      transactionId,
+      request.signal
+    );
 
     if (!transaction) {
       return NextResponse.json(
@@ -108,18 +106,6 @@ export async function GET(
 
     return NextResponse.json(transaction);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { AnchorError } from "@/lib/anchors";
+import {
+  disconnectedResponse,
+  handleRouteError,
+  raceWithSignal,
+} from "@/lib/anchors/http";
 import { parseJsonBody, parseParam } from "@/lib/validation/parse";
 import {
   OffRampSignBodySchema,
@@ -9,6 +13,13 @@ import { rpc, Horizon, TransactionBuilder } from "@stellar/stellar-sdk";
 import { clientEnv } from "@/lib/env.client";
 
 export const dynamic = "force-dynamic";
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
 
 /**
  * POST /api/anchor/[provider]/offramp/sign
@@ -35,8 +46,11 @@ export async function POST(
 
     try {
       const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
-      const response = await sorobanServer.sendTransaction(
-        tx as Parameters<typeof sorobanServer.sendTransaction>[0]
+      const response = await raceWithSignal(
+        sorobanServer.sendTransaction(
+          tx as Parameters<typeof sorobanServer.sendTransaction>[0]
+        ),
+        request.signal
       );
       return NextResponse.json({
         success: true,
@@ -46,11 +60,14 @@ export async function POST(
       });
     } catch {
       try {
-        const response = await horizonServer.submitTransaction(
-          TransactionBuilder.fromXDR(
-            signedXdr,
-            networkPassphrase
-          ) as Parameters<typeof horizonServer.submitTransaction>[0]
+        const response = await raceWithSignal(
+          horizonServer.submitTransaction(
+            TransactionBuilder.fromXDR(
+              signedXdr,
+              networkPassphrase
+            ) as Parameters<typeof horizonServer.submitTransaction>[0]
+          ),
+          request.signal
         );
         return NextResponse.json({
           success: true,
@@ -62,12 +79,15 @@ export async function POST(
       }
     }
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
+    if (isAbortError(error)) {
+      return disconnectedResponse();
     }
+
+    const response = handleRouteError(error);
+    if (response.status !== 500) {
+      return response;
+    }
+
     return NextResponse.json(
       {
         error: "Failed to submit signed transaction",

--- a/apps/web-app/src/app/api/anchor/[provider]/onramp/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/onramp/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { parseJsonBody, parseParam, parseQuery } from "@/lib/validation/parse";
 import {
   OnRampBodySchema,
@@ -33,32 +34,23 @@ export async function POST(
     } = parsed.data;
 
     const client = getAnchorClient(provider);
-    const transaction = await client.createOnRamp({
-      customerId,
-      quoteId,
-      stellarAddress,
-      fromCurrency,
-      toCurrency,
-      amount,
-      memo,
-      bankAccountId,
-    });
+    const transaction = await client.createOnRamp(
+      {
+        customerId,
+        quoteId,
+        stellarAddress,
+        fromCurrency,
+        toCurrency,
+        amount,
+        memo,
+        bankAccountId,
+      },
+      request.signal
+    );
 
     return NextResponse.json(transaction, { status: 201 });
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }
 
@@ -78,7 +70,10 @@ export async function GET(
     const { transactionId } = queryResult.data;
 
     const client = getAnchorClient(provider);
-    const transaction = await client.getOnRampTransaction(transactionId);
+    const transaction = await client.getOnRampTransaction(
+      transactionId,
+      request.signal
+    );
 
     if (!transaction) {
       return NextResponse.json(
@@ -89,18 +84,6 @@ export async function GET(
 
     return NextResponse.json(transaction);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/quotes/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/quotes/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { parseJsonBody, parseParam } from "@/lib/validation/parse";
 import { ProviderSchema, QuoteBodySchema } from "@/lib/validation/schemas";
 
@@ -28,30 +29,21 @@ export async function POST(
     } = parsed.data;
 
     const client = getAnchorClient(provider);
-    const quote = await client.getQuote({
-      fromCurrency,
-      toCurrency,
-      fromAmount,
-      toAmount,
-      customerId,
-      stellarAddress,
-      resourceId,
-    });
+    const quote = await client.getQuote(
+      {
+        fromCurrency,
+        toCurrency,
+        fromAmount,
+        toAmount,
+        customerId,
+        stellarAddress,
+        resourceId,
+      },
+      request.signal
+    );
 
     return NextResponse.json(quote);
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/sandbox/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAnchorClient, AnchorError } from "@/lib/anchors";
+import { getAnchorClient } from "@/lib/anchors";
+import { handleRouteError } from "@/lib/anchors/http";
 import { EtherfuseClient } from "@/lib/anchors/etherfuse";
 import { AlfredPayClient } from "@/lib/anchors/alfredpay";
 import { parseJsonBody, parseParam } from "@/lib/validation/parse";
@@ -43,7 +44,10 @@ export async function POST(
             { status: 400 }
           );
         }
-        const statusCode = await client.simulateFiatReceived(body.orderId);
+        const statusCode = await client.simulateFiatReceived(
+          body.orderId,
+          request.signal
+        );
         return NextResponse.json({ success: statusCode === 200, statusCode });
       }
 
@@ -54,7 +58,7 @@ export async function POST(
             { status: 400 }
           );
         }
-        await client.completeKycSandbox(body.submissionId);
+        await client.completeKycSandbox(body.submissionId, request.signal);
         return NextResponse.json({
           success: true,
           message: "KYC marked as completed",
@@ -62,18 +66,6 @@ export async function POST(
       }
     }
   } catch (error) {
-    if (error instanceof AnchorError) {
-      return NextResponse.json(
-        { error: error.message, code: error.code },
-        { status: error.statusCode }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: "Internal server error",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
+    return handleRouteError(error);
   }
 }

--- a/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
@@ -67,8 +67,9 @@ const OnOffRamps: React.FC = () => {
     kycStatus,
     isCheckingKyc,
     isKycRequired,
-    isKycApproved,
+    kycPollOutcome,
     refetchKycStatus,
+    retryKycPoll,
     openKycFlow,
   } = useAnchorKyc(
     state.provider,
@@ -83,11 +84,13 @@ const OnOffRamps: React.FC = () => {
     transaction: onRampTx,
     isCreating: isCreatingOnRamp,
     isPolling: isPollingOnRamp,
+    pollOutcome: onRampPollOutcome,
+    retryPoll: retryOnRampPoll,
     startOnRamp,
   } = useOnRamp(state.provider);
 
   // Trustline check (Etherfuse on-ramp only — after order is created)
-  const { hasTrustline, isAddingTrustline, trustlineError, addTrustline } =
+  const { hasTrustline, isAddingTrustline, addTrustline } =
     useEtherfuseTrustline(
       state.provider,
       address,
@@ -98,12 +101,12 @@ const OnOffRamps: React.FC = () => {
   // Off-Ramp
   const {
     transaction: offRampTx,
-    phase: offRampPhase,
     isCreating: isCreatingOffRamp,
     isWaitingForXdr,
     isSigning,
     isPolling: isPollingOffRamp,
-    isDone: isOffRampDone,
+    pollOutcome: offRampPollOutcome,
+    retryPoll: retryOffRampPoll,
     startOffRamp,
   } = useOffRamp(state.provider, signTransaction);
 
@@ -251,6 +254,10 @@ const OnOffRamps: React.FC = () => {
   };
 
   const currentTx = isOnRamp ? onRampTx : offRampTx;
+  const currentPollOutcome = isOnRamp ? onRampPollOutcome : offRampPollOutcome;
+  const retryCurrentPoll = isOnRamp ? retryOnRampPoll : retryOffRampPoll;
+  const hasPollFailure =
+    currentPollOutcome === "timed-out" || currentPollOutcome === "unreachable";
   const isLoadingTx = isCreatingOnRamp || isCreatingOffRamp;
   const isPollingTx =
     isPollingOnRamp || isPollingOffRamp || isWaitingForXdr || isSigning;
@@ -300,6 +307,8 @@ const OnOffRamps: React.FC = () => {
               status={kycStatus}
               onStartKyc={() => void openKycFlow()}
               isLoading={isCheckingKyc}
+              pollOutcome={kycPollOutcome}
+              onRetryPoll={retryKycPoll}
             />
           )}
 
@@ -337,6 +346,7 @@ const OnOffRamps: React.FC = () => {
           {/* Active transaction status */}
           {currentTx &&
             (isPollingTx ||
+              hasPollFailure ||
               currentTx.status === "completed" ||
               ["failed", "expired", "cancelled"].includes(
                 currentTx.status
@@ -345,6 +355,8 @@ const OnOffRamps: React.FC = () => {
                 status={currentTx.status}
                 type={isOnRamp ? "onramp" : "offramp"}
                 transactionId={currentTx.id}
+                pollOutcome={currentPollOutcome}
+                onRetry={retryCurrentPoll}
                 onDone={() => {
                   dispatch({ type: "RESET" });
                   clearQuote();

--- a/apps/web-app/src/features/on-off-ramps/components/ui/KycBanner.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/ui/KycBanner.tsx
@@ -1,20 +1,52 @@
 "use client";
 
 import React from "react";
-import { ShieldAlert, ShieldCheck, Clock } from "lucide-react";
+import { ShieldAlert, ShieldCheck, Clock, WifiOff } from "lucide-react";
 import type { KycStatus } from "@/lib/anchors/types";
+import type { PollOutcome } from "../../types/ramp";
 
 interface KycBannerProps {
   status: KycStatus | undefined;
   onStartKyc: () => void;
   isLoading?: boolean;
+  pollOutcome?: PollOutcome;
+  onRetryPoll?: () => void;
 }
 
 export const KycBanner: React.FC<KycBannerProps> = ({
   status,
   onStartKyc,
   isLoading,
+  pollOutcome = "pending",
+  onRetryPoll,
 }) => {
+  if (pollOutcome === "unreachable") {
+    return (
+      <div className="flex items-center justify-between gap-3 bg-orange-400/10 border border-orange-400/20 rounded-xl px-4 py-3">
+        <div className="flex items-center gap-3">
+          <WifiOff className="h-5 w-5 text-orange-400 shrink-0" />
+          <div>
+            <p className="text-orange-400 text-sm font-medium">
+              Could not check KYC status
+            </p>
+            <p className="text-white/40 text-xs">
+              The status check failed. Your verification may still be in
+              progress.
+            </p>
+          </div>
+        </div>
+        {onRetryPoll && (
+          <button
+            onClick={onRetryPoll}
+            className="shrink-0 px-4 py-2 rounded-lg bg-orange-400 hover:bg-orange-500 text-white text-sm font-medium transition-colors"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
   if (status === "approved") {
     return (
       <div className="flex items-center gap-3 bg-green-400/10 border border-green-400/20 rounded-xl px-4 py-3">
@@ -35,7 +67,6 @@ export const KycBanner: React.FC<KycBannerProps> = ({
     );
   }
 
-  // While loading and no cached status, render nothing to avoid flash.
   if (isLoading && !status) return null;
 
   if (

--- a/apps/web-app/src/features/on-off-ramps/components/ui/TransactionStatus.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/ui/TransactionStatus.tsx
@@ -2,13 +2,16 @@
 
 import React from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { CheckCircle, XCircle, Loader2, WifiOff, Clock } from "lucide-react";
 import type { TransactionStatus } from "@/lib/anchors/types";
+import type { PollOutcome } from "../../types/ramp";
 
 interface TransactionStatusProps {
   status: TransactionStatus;
   type: "onramp" | "offramp";
   transactionId: string;
+  pollOutcome?: PollOutcome;
+  onRetry?: () => void;
   onDone: () => void;
 }
 
@@ -26,42 +29,79 @@ export const TransactionStatusDisplay: React.FC<TransactionStatusProps> = ({
   status,
   type,
   transactionId,
+  pollOutcome = "pending",
+  onRetry,
   onDone,
 }) => {
   const router = useRouter();
   const isComplete = status === "completed";
   const isError = ["failed", "expired", "cancelled"].includes(status);
-  const isPending = !isComplete && !isError;
+  const isTimedOut = pollOutcome === "timed-out";
+  const isUnreachable = pollOutcome === "unreachable";
+  const isPollFailure = isTimedOut || isUnreachable;
+  const isPending = !isComplete && !isError && !isPollFailure;
 
   return (
     <div className="bg-[#1C1C1C] rounded-[20px] p-6 flex flex-col items-center gap-4 text-center">
       {isComplete && <CheckCircle className="h-12 w-12 text-green-400" />}
       {isError && <XCircle className="h-12 w-12 text-red-400" />}
+      {isTimedOut && <Clock className="h-12 w-12 text-orange-400" />}
+      {isUnreachable && <WifiOff className="h-12 w-12 text-orange-400" />}
       {isPending && (
         <Loader2 className="h-12 w-12 text-[#229EDF] animate-spin" />
       )}
 
       <div className="flex flex-col gap-1">
-        <p className="text-white font-semibold">{STATUS_LABELS[status]}</p>
-        {isPending && (
-          <p className="text-white/40 text-sm">
-            {type === "onramp"
-              ? "We're waiting for your SPEI transfer to be confirmed."
-              : "Your transaction is being processed on Stellar."}
-          </p>
+        {isTimedOut && (
+          <>
+            <p className="text-white font-semibold">Status check timed out</p>
+            <p className="text-white/40 text-sm">
+              We could not confirm the final status in time. Your transaction
+              may still be processing.
+            </p>
+          </>
         )}
-        {isComplete && (
-          <p className="text-white/40 text-sm">
-            {type === "onramp"
-              ? "Your crypto has been sent to your Stellar wallet."
-              : "Funds will arrive in your bank account shortly."}
-          </p>
+        {isUnreachable && (
+          <>
+            <p className="text-white font-semibold">Unable to reach server</p>
+            <p className="text-white/40 text-sm">
+              Status checks failed repeatedly. Check your connection and retry.
+            </p>
+          </>
+        )}
+        {!isPollFailure && (
+          <>
+            <p className="text-white font-semibold">{STATUS_LABELS[status]}</p>
+            {isPending && (
+              <p className="text-white/40 text-sm">
+                {type === "onramp"
+                  ? "We're waiting for your SPEI transfer to be confirmed."
+                  : "Your transaction is being processed on Stellar."}
+              </p>
+            )}
+            {isComplete && (
+              <p className="text-white/40 text-sm">
+                {type === "onramp"
+                  ? "Your crypto has been sent to your Stellar wallet."
+                  : "Funds will arrive in your bank account shortly."}
+              </p>
+            )}
+          </>
         )}
       </div>
 
       <p className="text-white/20 text-xs font-mono">
         ID: {transactionId.slice(0, 8)}...
       </p>
+
+      {isPollFailure && onRetry && (
+        <button
+          onClick={onRetry}
+          className="w-full py-3 rounded-xl bg-[#229EDF] hover:bg-[#1a8bc7] text-white font-semibold transition-colors"
+        >
+          Retry Status Check
+        </button>
+      )}
 
       {(isComplete || isError) && (
         <button

--- a/apps/web-app/src/features/on-off-ramps/constants/ramp.config.ts
+++ b/apps/web-app/src/features/on-off-ramps/constants/ramp.config.ts
@@ -45,7 +45,10 @@ export const RAMP_PROVIDERS: Record<AnchorProvider, ProviderConfig> = {
 
 export const DEFAULT_PROVIDER: AnchorProvider = "etherfuse";
 export const POLL_INTERVAL_MS = 5_000;
+export const POLL_MAX_INTERVAL_MS = 30_000;
+export const POLL_UNREACHABLE_AFTER = 3;
 export const MAX_POLL_DURATION_MS = 5 * 60 * 1_000; // 5 minutes
+export const RAMP_API_TIMEOUT_MS = 20_000;
 export const CUSTOMER_ID_STORAGE_KEY = "neko_anchor_customer_ids";
 export const BANK_ACCOUNT_ID_STORAGE_KEY = "neko_anchor_bank_account_ids";
 export const ONBOARDING_URL_STORAGE_KEY = "neko_anchor_onboarding_urls";

--- a/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useAnchorPolling.test.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useAnchorPolling.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAnchorPolling } from "../useAnchorPolling";
+import { RampApiError } from "../../utils/rampApi";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestWrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  }
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+}
+
+describe("useAnchorPolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reaches terminal outcome when isTerminal returns true", async () => {
+    const queryFn = vi.fn().mockResolvedValue({ status: "completed" });
+
+    const { result } = renderHook(
+      () =>
+        useAnchorPolling({
+          enabled: true,
+          queryFn,
+          isTerminal: (data) => data.status === "completed",
+          intervalMs: 100,
+          deadlineMs: 5_000,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.outcome).toBe("terminal");
+    expect(queryFn).toHaveBeenCalled();
+  });
+
+  it("reaches timed-out when the deadline elapses", async () => {
+    const queryFn = vi.fn().mockResolvedValue({ status: "pending" });
+
+    const { result } = renderHook(
+      () =>
+        useAnchorPolling({
+          enabled: true,
+          queryFn,
+          isTerminal: (data) => data.status === "completed",
+          intervalMs: 100,
+          deadlineMs: 250,
+          unreachableAfter: 99,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(result.current.outcome).toBe("timed-out");
+  });
+
+  it("widens the interval after consecutive failures", async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValue(new RampApiError("fail", "UNREACHABLE", 503));
+
+    renderHook(
+      () =>
+        useAnchorPolling({
+          enabled: true,
+          queryFn,
+          isTerminal: () => false,
+          intervalMs: 100,
+          deadlineMs: 10_000,
+          unreachableAfter: 5,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(queryFn.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not update outcome after unmount abort", async () => {
+    let resolveFetch!: () => void;
+    const queryFn = vi.fn(
+      () =>
+        new Promise<{ status: string }>((resolve) => {
+          resolveFetch = () => resolve({ status: "completed" });
+        })
+    );
+
+    const { result, unmount } = renderHook(
+      () =>
+        useAnchorPolling({
+          enabled: true,
+          queryFn,
+          isTerminal: (data) => data.status === "completed",
+          intervalMs: 100,
+          deadlineMs: 5_000,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveFetch();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.outcome).toBe("pending");
+  });
+
+  it("retry keeps the same queryFn identity window", async () => {
+    const queryFn = vi.fn().mockResolvedValue({ status: "pending" });
+
+    const { result } = renderHook(
+      () =>
+        useAnchorPolling({
+          enabled: true,
+          queryFn,
+          isTerminal: (data) => data.status === "completed",
+          intervalMs: 50,
+          deadlineMs: 120,
+          unreachableAfter: 99,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(result.current.outcome).toBe("timed-out");
+
+    queryFn.mockResolvedValue({ status: "completed" });
+
+    await act(async () => {
+      result.current.retry();
+    });
+    expect(result.current.outcome).toBe("pending");
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.outcome).toBe("terminal");
+    expect(queryFn.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useOffRamp.test.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useOffRamp.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useOffRamp } from "../useOffRamp";
+
+const getOffRampTransactionMock = vi.hoisted(() => vi.fn());
+const createOffRampMock = vi.hoisted(() => vi.fn());
+const submitSignedXdrMock = vi.hoisted(() => vi.fn());
+const signTransactionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils/rampApi", () => ({
+  createOffRamp: createOffRampMock,
+  getOffRampTransaction: getOffRampTransactionMock,
+  submitSignedXdr: submitSignedXdrMock,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestWrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  }
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+}
+
+describe("useOffRamp", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createOffRampMock.mockReset();
+    getOffRampTransactionMock.mockReset();
+    submitSignedXdrMock.mockReset();
+    signTransactionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not mark done when completion polling times out", async () => {
+    createOffRampMock.mockResolvedValue({
+      id: "tx-1",
+      status: "processing",
+      signableTransaction: "xdr-1",
+    });
+    signTransactionMock.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+    submitSignedXdrMock.mockResolvedValue({ success: true, hash: "hash-1" });
+    getOffRampTransactionMock.mockResolvedValue({
+      id: "tx-1",
+      status: "processing",
+    });
+
+    const { result } = renderHook(
+      () => useOffRamp("etherfuse", signTransactionMock),
+      { wrapper: createWrapper() }
+    );
+
+    await act(async () => {
+      await result.current.startOffRamp({
+        customerId: "cust-1",
+        quoteId: "quote-1",
+        stellarAddress: "GTEST",
+        fromCurrency: "CETES",
+        toCurrency: "MXN",
+        amount: "100",
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.phase).toBe("polling");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000 + 100);
+    });
+
+    expect(result.current.isDone).toBe(false);
+    expect(result.current.pollOutcome).toBe("timed-out");
+  });
+
+  it("does not call signTransaction twice for the same transaction id", async () => {
+    createOffRampMock.mockResolvedValue({
+      id: "tx-1",
+      status: "processing",
+      signableTransaction: "xdr-1",
+    });
+    signTransactionMock.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+    submitSignedXdrMock.mockResolvedValue({ success: true, hash: "hash-1" });
+    getOffRampTransactionMock.mockResolvedValue({
+      id: "tx-1",
+      status: "processing",
+    });
+
+    const { result, rerender } = renderHook(
+      ({ signTransaction }) => useOffRamp("etherfuse", signTransaction),
+      {
+        initialProps: { signTransaction: signTransactionMock },
+        wrapper: createWrapper(),
+      }
+    );
+
+    await act(async () => {
+      await result.current.startOffRamp({
+        customerId: "cust-1",
+        quoteId: "quote-1",
+        stellarAddress: "GTEST",
+        fromCurrency: "CETES",
+        toCurrency: "MXN",
+        amount: "100",
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(signTransactionMock).toHaveBeenCalledTimes(1);
+
+    rerender({ signTransaction: signTransactionMock });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(signTransactionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useOnRamp.test.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useOnRamp.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useOnRamp } from "../useOnRamp";
+
+const getOnRampTransactionMock = vi.hoisted(() => vi.fn());
+const createOnRampMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils/rampApi", () => ({
+  createOnRamp: createOnRampMock,
+  getOnRampTransaction: getOnRampTransactionMock,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestWrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  }
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+}
+
+describe("useOnRamp", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createOnRampMock.mockReset();
+    getOnRampTransactionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sets timed-out outcome when the poll deadline elapses", async () => {
+    createOnRampMock.mockResolvedValue({
+      id: "tx-1",
+      status: "pending",
+    });
+    getOnRampTransactionMock.mockResolvedValue({
+      id: "tx-1",
+      status: "pending",
+    });
+
+    const { result } = renderHook(() => useOnRamp("etherfuse"), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.startOnRamp({
+        customerId: "cust-1",
+        quoteId: "quote-1",
+        stellarAddress: "GTEST",
+        fromCurrency: "MXN",
+        toCurrency: "CETES",
+        amount: "100",
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000 + 100);
+    });
+
+    expect(result.current.pollOutcome).toBe("timed-out");
+    expect(result.current.isPolling).toBe(false);
+  });
+
+  it("retry resumes polling for the same transaction id", async () => {
+    createOnRampMock.mockResolvedValue({
+      id: "tx-1",
+      status: "pending",
+    });
+    getOnRampTransactionMock.mockResolvedValue({
+      id: "tx-1",
+      status: "pending",
+    });
+
+    const { result } = renderHook(() => useOnRamp("etherfuse"), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.startOnRamp({
+        customerId: "cust-1",
+        quoteId: "quote-1",
+        stellarAddress: "GTEST",
+        fromCurrency: "MXN",
+        toCurrency: "CETES",
+        amount: "100",
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000 + 100);
+    });
+
+    getOnRampTransactionMock.mockResolvedValue({
+      id: "tx-1",
+      status: "completed",
+    });
+
+    await act(async () => {
+      result.current.retryPoll();
+    });
+    expect(result.current.pollOutcome).toBe("pending");
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.pollOutcome).toBe("terminal");
+    expect(getOnRampTransactionMock).toHaveBeenCalledWith(
+      "etherfuse",
+      "tx-1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+});

--- a/apps/web-app/src/features/on-off-ramps/hooks/useAnchorKyc.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/useAnchorKyc.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { getKycStatus, getKycUrl } from "../utils/rampApi";
 import type { AnchorProvider, KycStatus } from "@/lib/anchors/types";
+import type { PollOutcome } from "../types/ramp";
+import { useAnchorPolling } from "./useAnchorPolling";
 
 export function useAnchorKyc(
   provider: AnchorProvider,
@@ -12,22 +14,24 @@ export function useAnchorKyc(
   /** Presigned URL from initial registration (localStorage). */
   storedOnboardingUrl?: string | null
 ) {
-  const {
-    data: kycStatus,
-    isLoading: isCheckingKyc,
-    refetch: refetchKycStatus,
-  } = useQuery<KycStatus>({
-    queryKey: ["kyc-status", provider, customerId, publicKey],
-    queryFn: () => getKycStatus(provider, customerId!, publicKey),
+  const [kycStatus, setKycStatus] = useState<KycStatus | undefined>();
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  const { outcome: pollOutcome, retry: retryKycPoll } = useAnchorPolling({
     enabled: !!customerId,
-    staleTime: 30_000,
-    // Poll every 30 s while the user hasn't finished KYC so the banner
-    // updates automatically when they complete the Hosted UI.
-    refetchInterval: (query) => {
-      const status = query.state.data;
-      return status === "approved" || status === "pending" ? false : 15_000;
+    queryFn: async (signal) => {
+      const status = await getKycStatus(provider, customerId!, publicKey, {
+        signal,
+      });
+      setKycStatus(status);
+      setIsInitialLoad(false);
+      return status;
     },
+    isTerminal: (status) => status === "approved" || status === "pending",
   });
+
+  const isCheckingKyc =
+    !!customerId && isInitialLoad && pollOutcome === "pending";
 
   const isKycRequired =
     kycStatus === "not_started" ||
@@ -35,6 +39,10 @@ export function useAnchorKyc(
     kycStatus === "update_required";
   const isKycApproved = kycStatus === "approved";
   const isKycPending = kycStatus === "pending";
+
+  const refetchKycStatus = () => {
+    retryKycPoll();
+  };
 
   /**
    * Open the Etherfuse Hosted UI in a new tab.
@@ -49,13 +57,11 @@ export function useAnchorKyc(
   const openKycFlow = async () => {
     if (!customerId) return;
 
-    // Path 1: stored URL — open directly, no async needed.
     if (storedOnboardingUrl) {
       window.open(storedOnboardingUrl, "_blank", "noopener,noreferrer");
       return;
     }
 
-    // Path 2: no stored URL — claim gesture now, fetch URL, then navigate.
     const win = window.open("about:blank", "_blank");
     if (!win) return;
 
@@ -72,13 +78,17 @@ export function useAnchorKyc(
     }
   };
 
+  const kycPollOutcome: PollOutcome = customerId ? pollOutcome : "pending";
+
   return {
     kycStatus,
     isCheckingKyc,
     isKycRequired,
     isKycApproved,
     isKycPending,
+    kycPollOutcome,
     refetchKycStatus,
+    retryKycPoll,
     openKycFlow,
   };
 }

--- a/apps/web-app/src/features/on-off-ramps/hooks/useAnchorPolling.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/useAnchorPolling.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  POLL_INTERVAL_MS,
+  MAX_POLL_DURATION_MS,
+  POLL_MAX_INTERVAL_MS,
+  POLL_UNREACHABLE_AFTER,
+} from "../constants/ramp.config";
+import type { PollOutcome } from "../types/ramp";
+
+interface UseAnchorPollingOptions<T> {
+  enabled: boolean;
+  queryFn: (signal: AbortSignal) => Promise<T | null>;
+  isTerminal: (data: T) => boolean;
+  intervalMs?: number;
+  deadlineMs?: number;
+  unreachableAfter?: number;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+export function useAnchorPolling<T>({
+  enabled,
+  queryFn,
+  isTerminal,
+  intervalMs = POLL_INTERVAL_MS,
+  deadlineMs = MAX_POLL_DURATION_MS,
+  unreachableAfter = POLL_UNREACHABLE_AFTER,
+}: UseAnchorPollingOptions<T>) {
+  const [outcome, setOutcome] = useState<PollOutcome>("pending");
+  const [pollSession, setPollSession] = useState(0);
+
+  const queryFnRef = useRef(queryFn);
+  const isTerminalRef = useRef(isTerminal);
+
+  useEffect(() => {
+    queryFnRef.current = queryFn;
+    isTerminalRef.current = isTerminal;
+  });
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const retry = useCallback(() => {
+    setPollSession((session) => session + 1);
+    setOutcome("pending");
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      abortControllerRef.current?.abort();
+      return;
+    }
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let consecutiveFailures = 0;
+    let currentInterval = intervalMs;
+    const deadlineAt = Date.now() + deadlineMs;
+
+    const scheduleNext = (delay: number) => {
+      if (cancelled) return;
+      timeoutId = setTimeout(() => {
+        void poll();
+      }, delay);
+    };
+
+    const poll = async () => {
+      if (cancelled) return;
+
+      if (Date.now() >= deadlineAt) {
+        setOutcome("timed-out");
+        return;
+      }
+
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      try {
+        const result = await queryFnRef.current(controller.signal);
+        if (cancelled || controller.signal.aborted) return;
+
+        consecutiveFailures = 0;
+        currentInterval = intervalMs;
+
+        if (result !== null && isTerminalRef.current(result)) {
+          setOutcome("terminal");
+          return;
+        }
+      } catch (error) {
+        if (cancelled || isAbortError(error)) return;
+
+        consecutiveFailures += 1;
+        currentInterval = Math.min(
+          intervalMs * 2 ** (consecutiveFailures - 1),
+          POLL_MAX_INTERVAL_MS
+        );
+
+        if (consecutiveFailures >= unreachableAfter) {
+          setOutcome("unreachable");
+          return;
+        }
+      }
+
+      if (Date.now() >= deadlineAt) {
+        setOutcome("timed-out");
+        return;
+      }
+
+      scheduleNext(currentInterval);
+    };
+
+    scheduleNext(0);
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      abortControllerRef.current?.abort();
+    };
+  }, [enabled, pollSession, intervalMs, deadlineMs, unreachableAfter]);
+
+  useEffect(() => {
+    if (!enabled) {
+      abortControllerRef.current?.abort();
+    }
+  }, [enabled]);
+
+  return { outcome, retry };
+}

--- a/apps/web-app/src/features/on-off-ramps/hooks/useOffRamp.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/useOffRamp.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMutation } from "@tanstack/react-query";
 import {
   createOffRamp,
@@ -8,11 +8,9 @@ import {
   submitSignedXdr,
 } from "../utils/rampApi";
 import type { AnchorProvider, OffRampTransaction } from "@/lib/anchors/types";
-import {
-  POLL_INTERVAL_MS,
-  MAX_POLL_DURATION_MS,
-} from "../constants/ramp.config";
 import { TERMINAL_STATUSES } from "../types/ramp";
+import type { PollOutcome } from "../types/ramp";
+import { useAnchorPolling } from "./useAnchorPolling";
 
 type OffRampPhase =
   | "idle"
@@ -33,6 +31,7 @@ export function useOffRamp(
   );
   const [phase, setPhase] = useState<OffRampPhase>("idle");
   const [error, setError] = useState<string | null>(null);
+  const signedForTxIdRef = useRef<string | null>(null);
 
   const { mutateAsync: startOffRamp, isPending: isCreating } = useMutation({
     mutationFn: (data: {
@@ -51,7 +50,6 @@ export function useOffRamp(
       if (TERMINAL_STATUSES.has(tx.status)) {
         setPhase("done");
       } else if (tx.signableTransaction) {
-        // XDR already available (rare for Etherfuse, may happen for Alfred Pay)
         setPhase("signing");
       } else {
         setPhase("waiting-xdr");
@@ -63,47 +61,32 @@ export function useOffRamp(
     },
   });
 
-  // Phase 1: Poll for signableTransaction (Etherfuse deferred signing)
-  useEffect(() => {
-    if (phase !== "waiting-xdr" || !transaction?.id) return;
-
-    const startTime = Date.now();
-    let timeoutId: NodeJS.Timeout;
-
-    const poll = async () => {
-      if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
-        setPhase("error");
-        setError("Timed out waiting for transaction to sign");
-        return;
-      }
-
-      try {
-        const updated = await getOffRampTransaction(provider, transaction.id);
-        if (updated) {
-          setTransaction(updated);
-          if (TERMINAL_STATUSES.has(updated.status)) {
-            setPhase("done");
-            return;
-          }
-          if (updated.signableTransaction) {
-            setPhase("signing");
-            return;
-          }
+  const { outcome: xdrPollOutcome, retry: retryXdrPoll } = useAnchorPolling({
+    enabled: phase === "waiting-xdr" && !!transaction?.id,
+    queryFn: async (signal) => {
+      if (!transaction?.id) return null;
+      const updated = await getOffRampTransaction(provider, transaction.id, {
+        signal,
+      });
+      if (updated) {
+        setTransaction(updated);
+        if (TERMINAL_STATUSES.has(updated.status)) {
+          setPhase("done");
+        } else if (updated.signableTransaction) {
+          setPhase("signing");
         }
-      } catch {
-        // retry
       }
+      return updated;
+    },
+    isTerminal: (tx) =>
+      TERMINAL_STATUSES.has(tx.status) || !!tx.signableTransaction,
+  });
 
-      timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    };
-
-    timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    return () => clearTimeout(timeoutId);
-  }, [phase, transaction?.id, provider]);
-
-  // Phase 2: Auto-sign when XDR is ready
   useEffect(() => {
     if (phase !== "signing" || !transaction?.signableTransaction) return;
+    if (signedForTxIdRef.current === transaction.id) return;
+
+    signedForTxIdRef.current = transaction.id;
 
     const sign = async () => {
       try {
@@ -115,7 +98,7 @@ export function useOffRamp(
         setPhase("polling");
       } catch (err) {
         if (err instanceof Error && err.message === "USER_REJECTED") {
-          // User rejected: go back to waiting so they can retry
+          signedForTxIdRef.current = null;
           setPhase("waiting-xdr");
         } else {
           setError(err instanceof Error ? err.message : String(err));
@@ -124,59 +107,73 @@ export function useOffRamp(
       }
     };
 
-    sign();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase]);
+    void sign();
+  }, [
+    phase,
+    transaction?.id,
+    transaction?.signableTransaction,
+    signTransaction,
+    provider,
+  ]);
 
-  // Phase 3: Poll for completion after signing
-  useEffect(() => {
-    if (phase !== "polling" || !transaction?.id) return;
-
-    const startTime = Date.now();
-    let timeoutId: NodeJS.Timeout;
-
-    const poll = async () => {
-      if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
-        setPhase("done"); // best effort
-        return;
-      }
-
-      try {
-        const updated = await getOffRampTransaction(provider, transaction.id);
+  const { outcome: completionPollOutcome, retry: retryCompletionPoll } =
+    useAnchorPolling({
+      enabled: phase === "polling" && !!transaction?.id,
+      queryFn: async (signal) => {
+        if (!transaction?.id) return null;
+        const updated = await getOffRampTransaction(provider, transaction.id, {
+          signal,
+        });
         if (updated) {
           setTransaction(updated);
           if (TERMINAL_STATUSES.has(updated.status)) {
             setPhase("done");
-            return;
           }
         }
-      } catch {
-        // retry
-      }
+        return updated;
+      },
+      isTerminal: (tx) => TERMINAL_STATUSES.has(tx.status),
+    });
 
-      timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    };
+  const pollOutcome: PollOutcome =
+    phase === "polling"
+      ? completionPollOutcome
+      : phase === "waiting-xdr"
+        ? xdrPollOutcome
+        : "pending";
 
-    timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    return () => clearTimeout(timeoutId);
-  }, [phase, transaction?.id, provider]);
+  const retryPoll = () => {
+    if (phase === "polling") {
+      retryCompletionPoll();
+    } else if (phase === "waiting-xdr") {
+      retryXdrPoll();
+    }
+  };
 
   const reset = () => {
     setTransaction(null);
     setPhase("idle");
     setError(null);
+    signedForTxIdRef.current = null;
   };
+
+  const hasPollFailure =
+    pollOutcome === "timed-out" || pollOutcome === "unreachable";
 
   return {
     transaction,
     phase,
     error,
     isCreating,
-    isWaitingForXdr: phase === "waiting-xdr",
+    isWaitingForXdr: phase === "waiting-xdr" && !hasPollFailure,
     isSigning: phase === "signing" || phase === "submitting",
-    isPolling: phase === "polling",
+    isPolling:
+      (phase === "polling" || phase === "waiting-xdr") &&
+      pollOutcome === "pending",
     isDone: phase === "done",
     isError: phase === "error",
+    pollOutcome,
+    retryPoll,
     startOffRamp,
     reset,
   };

--- a/apps/web-app/src/features/on-off-ramps/hooks/useOnRamp.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/useOnRamp.ts
@@ -1,20 +1,35 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { createOnRamp, getOnRampTransaction } from "../utils/rampApi";
 import type { AnchorProvider, OnRampTransaction } from "@/lib/anchors/types";
-import {
-  POLL_INTERVAL_MS,
-  MAX_POLL_DURATION_MS,
-} from "../constants/ramp.config";
 import { TERMINAL_STATUSES } from "../types/ramp";
+import type { PollOutcome } from "../types/ramp";
+import { useAnchorPolling } from "./useAnchorPolling";
 
 export function useOnRamp(provider: AnchorProvider) {
   const [transaction, setTransaction] = useState<OnRampTransaction | null>(
     null
   );
-  const [isPolling, setIsPolling] = useState(false);
+
+  const shouldPoll =
+    !!transaction && !TERMINAL_STATUSES.has(transaction.status);
+
+  const { outcome: pollOutcome, retry: retryPoll } = useAnchorPolling({
+    enabled: shouldPoll,
+    queryFn: async (signal) => {
+      if (!transaction?.id) return null;
+      const updated = await getOnRampTransaction(provider, transaction.id, {
+        signal,
+      });
+      if (updated) {
+        setTransaction(updated);
+      }
+      return updated;
+    },
+    isTerminal: (tx) => TERMINAL_STATUSES.has(tx.status),
+  });
 
   const { mutateAsync: startOnRamp, isPending: isCreating } = useMutation({
     mutationFn: (data: {
@@ -29,54 +44,21 @@ export function useOnRamp(provider: AnchorProvider) {
     }) => createOnRamp(provider, data),
     onSuccess: (tx) => {
       setTransaction(tx);
-      if (!TERMINAL_STATUSES.has(tx.status)) {
-        setIsPolling(true);
-      }
     },
   });
 
-  // Polling loop
-  useEffect(() => {
-    if (!isPolling || !transaction?.id) return;
-
-    const startTime = Date.now();
-    let timeoutId: NodeJS.Timeout;
-
-    const poll = async () => {
-      if (Date.now() - startTime > MAX_POLL_DURATION_MS) {
-        setIsPolling(false);
-        return;
-      }
-
-      try {
-        const updated = await getOnRampTransaction(provider, transaction.id);
-        if (updated) {
-          setTransaction(updated);
-          if (TERMINAL_STATUSES.has(updated.status)) {
-            setIsPolling(false);
-            return;
-          }
-        }
-      } catch {
-        // Retry on next interval
-      }
-
-      timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    };
-
-    timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
-    return () => clearTimeout(timeoutId);
-  }, [isPolling, transaction?.id, provider]);
-
   const reset = () => {
     setTransaction(null);
-    setIsPolling(false);
   };
+
+  const isPolling = shouldPoll && pollOutcome === "pending";
 
   return {
     transaction,
     isCreating,
     isPolling,
+    pollOutcome: transaction ? pollOutcome : ("pending" as PollOutcome),
+    retryPoll,
     startOnRamp,
     reset,
   };

--- a/apps/web-app/src/features/on-off-ramps/types/ramp.ts
+++ b/apps/web-app/src/features/on-off-ramps/types/ramp.ts
@@ -56,3 +56,5 @@ export const TERMINAL_STATUSES = new Set([
   "cancelled",
   "refunded",
 ]);
+
+export type PollOutcome = "pending" | "terminal" | "unreachable" | "timed-out";

--- a/apps/web-app/src/features/on-off-ramps/utils/__tests__/rampApi.test.ts
+++ b/apps/web-app/src/features/on-off-ramps/utils/__tests__/rampApi.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RampApiError } from "../rampApi";
+
+describe("rampApi apiFetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("throws TIMEOUT when the client deadline fires", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    });
+
+    const { getOnRampTransaction } = await import("../rampApi");
+    const assertion = expect(
+      getOnRampTransaction("etherfuse", "tx-1", { timeoutMs: 50 })
+    ).rejects.toMatchObject({
+      code: "TIMEOUT",
+      status: 504,
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+  });
+
+  it("rethrows AbortError when the caller aborts", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        })
+    );
+
+    const { getOnRampTransaction } = await import("../rampApi");
+    const controller = new AbortController();
+    const promise = getOnRampTransaction("etherfuse", "tx-1", {
+      signal: controller.signal,
+      timeoutMs: 5_000,
+    });
+
+    controller.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("does not resolve with a body after abort", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      return new Promise<Response>((resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+        setTimeout(() => {
+          resolve(
+            new Response(JSON.stringify({ id: "tx-1", status: "completed" }), {
+              status: 200,
+            })
+          );
+        }, 1_000);
+      });
+    });
+
+    const { getOnRampTransaction } = await import("../rampApi");
+    const controller = new AbortController();
+    const promise = getOnRampTransaction("etherfuse", "tx-1", {
+      signal: controller.signal,
+      timeoutMs: 5_000,
+    });
+
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("maps server TIMEOUT responses to RampApiError", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "timed out", code: "TIMEOUT" }), {
+        status: 504,
+      })
+    );
+
+    const { getOnRampTransaction } = await import("../rampApi");
+
+    await expect(
+      getOnRampTransaction("etherfuse", "tx-1")
+    ).rejects.toBeInstanceOf(RampApiError);
+  });
+});

--- a/apps/web-app/src/features/on-off-ramps/utils/rampApi.ts
+++ b/apps/web-app/src/features/on-off-ramps/utils/rampApi.ts
@@ -10,6 +10,7 @@ import type {
   KycSubmissionResult,
   AnchorProvider,
 } from "@/lib/anchors/types";
+import { RAMP_API_TIMEOUT_MS } from "../constants/ramp.config";
 
 export class RampApiError extends Error {
   code: string;
@@ -23,22 +24,112 @@ export class RampApiError extends Error {
   }
 }
 
-async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(url, options);
-  if (!res.ok) {
-    let body: { error?: string; code?: string } = {};
-    try {
-      body = await res.json();
-    } catch {
-      // ignore
+export interface RampApiRequestInit extends RequestInit {
+  timeoutMs?: number;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function combineSignals(
+  timeoutMs: number,
+  callerSignal?: AbortSignal
+): { signal: AbortSignal; cleanup: () => void } {
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    timeoutController.abort("timeout");
+  }, timeoutMs);
+
+  const onCallerAbort = () => {
+    timeoutController.abort(callerSignal?.reason);
+  };
+
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      clearTimeout(timeoutId);
+      timeoutController.abort(callerSignal.reason);
+    } else {
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
     }
-    throw new RampApiError(
-      body.error || `API error ${res.status}`,
-      body.code || "UNKNOWN_ERROR",
-      res.status
-    );
   }
-  return res.json() as Promise<T>;
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    if (callerSignal) {
+      callerSignal.removeEventListener("abort", onCallerAbort);
+    }
+  };
+
+  return { signal: timeoutController.signal, cleanup };
+}
+
+function isTimeoutAbort(signal: AbortSignal): boolean {
+  return signal.aborted && signal.reason === "timeout";
+}
+
+async function apiFetch<T>(
+  url: string,
+  options: RampApiRequestInit = {}
+): Promise<T> {
+  const {
+    timeoutMs = RAMP_API_TIMEOUT_MS,
+    signal: callerSignal,
+    ...init
+  } = options;
+  const { signal, cleanup } = combineSignals(
+    timeoutMs,
+    callerSignal ?? undefined
+  );
+
+  try {
+    if (signal.aborted) {
+      if (isTimeoutAbort(signal)) {
+        throw new RampApiError("Request timed out", "TIMEOUT", 504);
+      }
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    const res = await fetch(url, { ...init, signal });
+
+    if (!res.ok) {
+      let body: { error?: string; code?: string } = {};
+      try {
+        body = await res.json();
+      } catch {
+        // ignore
+      }
+      throw new RampApiError(
+        body.error || `API error ${res.status}`,
+        body.code || "UNKNOWN_ERROR",
+        res.status
+      );
+    }
+
+    return res.json() as Promise<T>;
+  } catch (error) {
+    if (isAbortError(error)) {
+      if (isTimeoutAbort(signal)) {
+        throw new RampApiError("Request timed out", "TIMEOUT", 504);
+      }
+      throw error;
+    }
+
+    if (error instanceof RampApiError) {
+      throw error;
+    }
+
+    throw new RampApiError(
+      error instanceof Error ? error.message : "Network request failed",
+      "UNREACHABLE",
+      503
+    );
+  } finally {
+    cleanup();
+  }
 }
 
 const BASE = "/api/anchor";
@@ -46,25 +137,31 @@ const BASE = "/api/anchor";
 // Customers
 export async function createCustomer(
   provider: AnchorProvider,
-  data: { email?: string; country?: string; publicKey?: string }
+  data: { email?: string; country?: string; publicKey?: string },
+  options?: RampApiRequestInit
 ): Promise<Customer> {
   return apiFetch<Customer>(`${BASE}/${provider}/customers`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
+    ...options,
   });
 }
 
 export async function getCustomer(
   provider: AnchorProvider,
-  params: { email?: string; customerId?: string; country?: string }
+  params: { email?: string; customerId?: string; country?: string },
+  options?: RampApiRequestInit
 ): Promise<Customer | null> {
   const query = new URLSearchParams();
   if (params.email) query.set("email", params.email);
   if (params.customerId) query.set("customerId", params.customerId);
   if (params.country) query.set("country", params.country);
   try {
-    return await apiFetch<Customer>(`${BASE}/${provider}/customers?${query}`);
+    return await apiFetch<Customer>(
+      `${BASE}/${provider}/customers?${query}`,
+      options
+    );
   } catch (err) {
     if (err instanceof RampApiError && err.status === 404) return null;
     throw err;
@@ -82,12 +179,14 @@ export async function getQuote(
     customerId?: string;
     stellarAddress?: string;
     resourceId?: string;
-  }
+  },
+  options?: RampApiRequestInit
 ): Promise<Quote> {
   return apiFetch<Quote>(`${BASE}/${provider}/quotes`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
+    ...options,
   });
 }
 
@@ -103,22 +202,26 @@ export async function createOnRamp(
     amount: string;
     memo?: string;
     bankAccountId?: string;
-  }
+  },
+  options?: RampApiRequestInit
 ): Promise<OnRampTransaction> {
   return apiFetch<OnRampTransaction>(`${BASE}/${provider}/onramp`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
+    ...options,
   });
 }
 
 export async function getOnRampTransaction(
   provider: AnchorProvider,
-  transactionId: string
+  transactionId: string,
+  options?: RampApiRequestInit
 ): Promise<OnRampTransaction | null> {
   try {
     return await apiFetch<OnRampTransaction>(
-      `${BASE}/${provider}/onramp?transactionId=${transactionId}`
+      `${BASE}/${provider}/onramp?transactionId=${transactionId}`,
+      options
     );
   } catch (err) {
     if (err instanceof RampApiError && err.status === 404) return null;
@@ -139,22 +242,26 @@ export async function createOffRamp(
     fiatAccountId?: string;
     bankAccount?: { clabe: string; beneficiary: string; bankName?: string };
     memo?: string;
-  }
+  },
+  options?: RampApiRequestInit
 ): Promise<OffRampTransaction> {
   return apiFetch<OffRampTransaction>(`${BASE}/${provider}/offramp`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
+    ...options,
   });
 }
 
 export async function getOffRampTransaction(
   provider: AnchorProvider,
-  transactionId: string
+  transactionId: string,
+  options?: RampApiRequestInit
 ): Promise<OffRampTransaction | null> {
   try {
     return await apiFetch<OffRampTransaction>(
-      `${BASE}/${provider}/offramp?transactionId=${transactionId}`
+      `${BASE}/${provider}/offramp?transactionId=${transactionId}`,
+      options
     );
   } catch (err) {
     if (err instanceof RampApiError && err.status === 404) return null;
@@ -165,7 +272,8 @@ export async function getOffRampTransaction(
 export async function submitSignedXdr(
   provider: AnchorProvider,
   signedXdr: string,
-  transactionId: string
+  transactionId: string,
+  options?: RampApiRequestInit
 ): Promise<{ success: boolean; hash: string }> {
   return apiFetch<{ success: boolean; hash: string }>(
     `${BASE}/${provider}/offramp/sign`,
@@ -173,6 +281,7 @@ export async function submitSignedXdr(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ signedXdr, transactionId }),
+      ...options,
     }
   );
 }
@@ -181,12 +290,14 @@ export async function submitSignedXdr(
 export async function getKycStatus(
   provider: AnchorProvider,
   customerId: string,
-  publicKey?: string
+  publicKey?: string,
+  options?: RampApiRequestInit
 ): Promise<KycStatus> {
   const query = new URLSearchParams({ customerId });
   if (publicKey) query.set("publicKey", publicKey);
   const res = await apiFetch<{ status: KycStatus }>(
-    `${BASE}/${provider}/kyc?${query}`
+    `${BASE}/${provider}/kyc?${query}`,
+    options
   );
   return res.status;
 }
@@ -195,23 +306,27 @@ export async function getKycUrl(
   provider: AnchorProvider,
   customerId: string,
   publicKey?: string,
-  bankAccountId?: string
+  bankAccountId?: string,
+  options?: RampApiRequestInit
 ): Promise<string> {
   const query = new URLSearchParams({ customerId, type: "iframe" });
   if (publicKey) query.set("publicKey", publicKey);
   if (bankAccountId) query.set("bankAccountId", bankAccountId);
   const res = await apiFetch<{ url: string }>(
-    `${BASE}/${provider}/kyc?${query}`
+    `${BASE}/${provider}/kyc?${query}`,
+    options
   );
   return res.url;
 }
 
 export async function getKycRequirements(
   provider: AnchorProvider,
-  country: string = "MX"
+  country: string = "MX",
+  options?: RampApiRequestInit
 ): Promise<KycRequirements> {
   return apiFetch<KycRequirements>(
-    `${BASE}/${provider}/kyc?type=requirements&country=${country}`
+    `${BASE}/${provider}/kyc?type=requirements&country=${country}`,
+    options
   );
 }
 
@@ -221,7 +336,8 @@ export async function submitKyc(
   data: {
     fields: Record<string, string>;
     documents: Record<string, File | string>;
-  }
+  },
+  options?: RampApiRequestInit
 ): Promise<KycSubmissionResult> {
   return apiFetch<KycSubmissionResult>(
     `${BASE}/${provider}/kyc?type=submit-kyc`,
@@ -229,6 +345,7 @@ export async function submitKyc(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ customerId, data }),
+      ...options,
     }
   );
 }
@@ -236,10 +353,12 @@ export async function submitKyc(
 // Fiat Accounts
 export async function getFiatAccounts(
   provider: AnchorProvider,
-  customerId: string
+  customerId: string,
+  options?: RampApiRequestInit
 ): Promise<SavedFiatAccount[]> {
   return apiFetch<SavedFiatAccount[]>(
-    `${BASE}/${provider}/fiat-accounts?customerId=${customerId}`
+    `${BASE}/${provider}/fiat-accounts?customerId=${customerId}`,
+    options
   );
 }
 
@@ -251,35 +370,41 @@ export async function registerFiatAccount(
     beneficiary: string;
     bankName?: string;
     publicKey?: string;
-  }
+  },
+  options?: RampApiRequestInit
 ): Promise<RegisteredFiatAccount> {
   return apiFetch<RegisteredFiatAccount>(`${BASE}/${provider}/fiat-accounts`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
+    ...options,
   });
 }
 
 // Assets (Etherfuse — trustline check)
 export async function getEtherfuseAssets(
   provider: AnchorProvider,
-  wallet: string
+  wallet: string,
+  options?: RampApiRequestInit
 ): Promise<{
   assets: { symbol: string; identifier: string; balance: string | null }[];
 }> {
   return apiFetch(
-    `${BASE}/${provider}/assets?wallet=${encodeURIComponent(wallet)}`
+    `${BASE}/${provider}/assets?wallet=${encodeURIComponent(wallet)}`,
+    options
   );
 }
 
 // Sandbox
 export async function simulateFiatReceived(
   provider: AnchorProvider,
-  orderId: string
+  orderId: string,
+  options?: RampApiRequestInit
 ): Promise<{ success: boolean }> {
   return apiFetch<{ success: boolean }>(`${BASE}/${provider}/sandbox`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ action: "simulateFiatReceived", orderId }),
+    ...options,
   });
 }

--- a/apps/web-app/src/lib/anchors/__tests__/alfredpay.client.test.ts
+++ b/apps/web-app/src/lib/anchors/__tests__/alfredpay.client.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AlfredPayClient } from "../alfredpay/client";
+import { AnchorTimeoutError } from "../types";
+
+const anchorRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../http", () => ({
+  anchorRequest: anchorRequestMock,
+  ANCHOR_REQUEST_TIMEOUT_MS: 15_000,
+}));
+
+describe("AlfredPayClient", () => {
+  const client = new AlfredPayClient({
+    baseUrl: "https://api.alfredpay.io",
+    apiKey: "key",
+    apiSecret: "secret",
+  });
+
+  beforeEach(() => {
+    anchorRequestMock.mockReset();
+  });
+
+  it("routes request() through anchorRequest", async () => {
+    anchorRequestMock.mockResolvedValue(
+      new Response(JSON.stringify({ status: "APPROVED" }), { status: 200 })
+    );
+
+    await client.getKycStatus("cust-1");
+
+    expect(anchorRequestMock).toHaveBeenCalledTimes(1);
+    expect(anchorRequestMock.mock.calls[0]?.[0]).toContain(
+      "https://api.alfredpay.io"
+    );
+  });
+
+  it("routes submitKycFile through anchorRequest", async () => {
+    anchorRequestMock.mockResolvedValue(
+      new Response(JSON.stringify({ fileId: "file-1" }), { status: 200 })
+    );
+
+    const file = new File(["content"], "id.pdf", { type: "application/pdf" });
+    await client.submitKycFile(
+      "cust-1",
+      "sub-1",
+      "NATIONAL_ID_FRONT",
+      file,
+      "id.pdf"
+    );
+
+    expect(anchorRequestMock).toHaveBeenCalledWith(
+      expect.stringContaining("/customers/cust-1/kyc/sub-1/files"),
+      expect.objectContaining({ method: "POST" }),
+      expect.any(Object)
+    );
+  });
+
+  it("surfaces AnchorTimeoutError from anchorRequest", async () => {
+    anchorRequestMock.mockRejectedValue(new AnchorTimeoutError());
+
+    await expect(client.getKycStatus("cust-1")).rejects.toBeInstanceOf(
+      AnchorTimeoutError
+    );
+  });
+});

--- a/apps/web-app/src/lib/anchors/__tests__/etherfuse.client.test.ts
+++ b/apps/web-app/src/lib/anchors/__tests__/etherfuse.client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EtherfuseClient } from "../etherfuse/client";
+import { AnchorTimeoutError } from "../types";
+
+const anchorRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../http", () => ({
+  anchorRequest: anchorRequestMock,
+  ANCHOR_REQUEST_TIMEOUT_MS: 15_000,
+}));
+
+describe("EtherfuseClient", () => {
+  const client = new EtherfuseClient({
+    baseUrl: "https://sand.etherfuse.com/api",
+    apiKey: "test-key",
+    defaultBlockchain: "stellar",
+  });
+
+  beforeEach(() => {
+    anchorRequestMock.mockReset();
+  });
+
+  it("routes request() through anchorRequest", async () => {
+    anchorRequestMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "cust-1",
+          email: "a@b.com",
+          kycStatus: "approved",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        }),
+        { status: 200 }
+      )
+    );
+
+    await client.getCustomer({ customerId: "cust-1" });
+
+    expect(anchorRequestMock).toHaveBeenCalledTimes(1);
+    expect(anchorRequestMock.mock.calls[0]?.[0]).toContain(
+      "https://sand.etherfuse.com/api"
+    );
+  });
+
+  it("routes simulateFiatReceived through anchorRequest", async () => {
+    anchorRequestMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    const status = await client.simulateFiatReceived("order-1");
+
+    expect(status).toBe(200);
+    expect(anchorRequestMock).toHaveBeenCalledWith(
+      "https://sand.etherfuse.com/api/ramp/order/fiat_received",
+      expect.objectContaining({ method: "POST" }),
+      expect.any(Object)
+    );
+  });
+
+  it("surfaces AnchorTimeoutError from anchorRequest", async () => {
+    anchorRequestMock.mockRejectedValue(new AnchorTimeoutError());
+
+    await expect(
+      client.getCustomer({ customerId: "cust-1" })
+    ).rejects.toBeInstanceOf(AnchorTimeoutError);
+  });
+});

--- a/apps/web-app/src/lib/anchors/__tests__/http.test.ts
+++ b/apps/web-app/src/lib/anchors/__tests__/http.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  anchorRequest,
+  ANCHOR_REQUEST_TIMEOUT_MS,
+  anchorErrorResponse,
+} from "../http";
+import {
+  AnchorTimeoutError,
+  AnchorUnreachableError,
+  AnchorError,
+} from "../types";
+
+describe("anchorRequest", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("throws AnchorTimeoutError when the deadline fires", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    });
+
+    const assertion = expect(
+      anchorRequest("https://anchor.test/api", {}, { timeoutMs: 50 })
+    ).rejects.toBeInstanceOf(AnchorTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+  });
+
+  it("rethrows AbortError when the caller aborts", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        })
+    );
+
+    const controller = new AbortController();
+    const promise = anchorRequest(
+      "https://anchor.test/api",
+      {},
+      { timeoutMs: ANCHOR_REQUEST_TIMEOUT_MS, signal: controller.signal }
+    );
+
+    controller.abort();
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("cleans up timers after completion", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
+
+    await anchorRequest("https://anchor.test/api", {}, { timeoutMs: 100 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("throws AnchorUnreachableError on network failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("fetch failed")
+    );
+
+    await expect(
+      anchorRequest("https://anchor.test/api", {}, { timeoutMs: 100 })
+    ).rejects.toBeInstanceOf(AnchorUnreachableError);
+  });
+});
+
+describe("anchorErrorResponse", () => {
+  it("maps timeout to 504", async () => {
+    const response = anchorErrorResponse(new AnchorTimeoutError());
+    expect(response?.status).toBe(504);
+    const body = await response!.json();
+    expect(body.code).toBe("TIMEOUT");
+  });
+
+  it("maps unreachable to 503", async () => {
+    const response = anchorErrorResponse(new AnchorUnreachableError());
+    expect(response?.status).toBe(503);
+    const body = await response!.json();
+    expect(body.code).toBe("UNREACHABLE");
+  });
+
+  it("returns null for client abort", () => {
+    const response = anchorErrorResponse(
+      new DOMException("Aborted", "AbortError")
+    );
+    expect(response).toBeNull();
+  });
+
+  it("preserves other AnchorError status codes", async () => {
+    const response = anchorErrorResponse(
+      new AnchorError("Not found", "NOT_FOUND", 404)
+    );
+    expect(response?.status).toBe(404);
+  });
+});

--- a/apps/web-app/src/lib/anchors/alfredpay/client.ts
+++ b/apps/web-app/src/lib/anchors/alfredpay/client.ts
@@ -25,6 +25,7 @@ import type {
   KycSubmissionData,
   KycSubmissionResult,
 } from "../types";
+import { anchorRequest } from "../http";
 import { AnchorError } from "../types";
 import type {
   AlfredPayConfig,
@@ -75,18 +76,23 @@ export class AlfredPayClient implements Anchor {
   private async request<T>(
     method: "GET" | "POST" | "PUT" | "DELETE",
     endpoint: string,
-    body?: unknown
+    body?: unknown,
+    signal?: AbortSignal
   ): Promise<T> {
     const url = `${this.config.baseUrl}${endpoint}`;
-    const response = await fetch(url, {
-      method,
-      headers: {
-        "Content-Type": "application/json",
-        "api-key": this.config.apiKey,
-        "api-secret": this.config.apiSecret,
+    const response = await anchorRequest(
+      url,
+      {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": this.config.apiKey,
+          "api-secret": this.config.apiSecret,
+        },
+        body: body ? JSON.stringify(body) : undefined,
       },
-      body: body ? JSON.stringify(body) : undefined,
-    });
+      { signal }
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -243,7 +249,10 @@ export class AlfredPayClient implements Anchor {
     };
   }
 
-  async createCustomer(input: CreateCustomerInput): Promise<Customer> {
+  async createCustomer(
+    input: CreateCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer> {
     if (!input.email) {
       throw new AnchorError(
         "email is required for AlfredPay",
@@ -258,7 +267,8 @@ export class AlfredPayClient implements Anchor {
         email: input.email,
         type: "INDIVIDUAL",
         country: input.country || "MX",
-      }
+      },
+      signal
     );
     return {
       id: response.customerId,
@@ -269,7 +279,10 @@ export class AlfredPayClient implements Anchor {
     };
   }
 
-  async getCustomer(input: GetCustomerInput): Promise<Customer | null> {
+  async getCustomer(
+    input: GetCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer | null> {
     if (!input.email) {
       throw new AnchorError(
         "email is required for AlfredPay customer lookup",
@@ -281,7 +294,9 @@ export class AlfredPayClient implements Anchor {
     try {
       const response = await this.request<{ customerId: string }>(
         "GET",
-        `/customers/find/${encodeURIComponent(input.email)}/${country}`
+        `/customers/find/${encodeURIComponent(input.email)}/${country}`,
+        undefined,
+        signal
       );
       return {
         id: response.customerId,
@@ -296,7 +311,7 @@ export class AlfredPayClient implements Anchor {
     }
   }
 
-  async getQuote(input: GetQuoteInput): Promise<Quote> {
+  async getQuote(input: GetQuoteInput, signal?: AbortSignal): Promise<Quote> {
     const body: Record<string, unknown> = {
       fromCurrency: input.fromCurrency,
       toCurrency: input.toCurrency,
@@ -312,12 +327,16 @@ export class AlfredPayClient implements Anchor {
     const response = await this.request<AlfredPayQuoteResponse>(
       "POST",
       "/quotes",
-      body
+      body,
+      signal
     );
     return this.mapQuote(response);
   }
 
-  async createOnRamp(input: CreateOnRampInput): Promise<OnRampTransaction> {
+  async createOnRamp(
+    input: CreateOnRampInput,
+    signal?: AbortSignal
+  ): Promise<OnRampTransaction> {
     const response = await this.request<AlfredPayOnRampResponse>(
       "POST",
       "/onramp",
@@ -332,18 +351,22 @@ export class AlfredPayClient implements Anchor {
         depositAddress: input.stellarAddress,
         memo: input.memo || "",
         onrampTransactionRequiredFieldsJson: {},
-      }
+      },
+      signal
     );
     return this.mapOnRampTransaction(response);
   }
 
   async getOnRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OnRampTransaction | null> {
     try {
       const response = await this.request<AlfredPayOnRampFlatResponse>(
         "GET",
-        `/onramp/${transactionId}`
+        `/onramp/${transactionId}`,
+        undefined,
+        signal
       );
       return this.mapOnRampFlatTransaction(response);
     } catch (error) {
@@ -353,7 +376,8 @@ export class AlfredPayClient implements Anchor {
   }
 
   async registerFiatAccount(
-    input: RegisterFiatAccountInput
+    input: RegisterFiatAccountInput,
+    signal?: AbortSignal
   ): Promise<RegisteredFiatAccount> {
     const response = await this.request<AlfredPayFiatAccountResponse>(
       "POST",
@@ -371,7 +395,8 @@ export class AlfredPayClient implements Anchor {
           metadata: { accountHolderName: input.account.beneficiary },
         },
         isExternal: true,
-      }
+      },
+      signal
     );
     return {
       id: response.fiatAccountId,
@@ -382,11 +407,16 @@ export class AlfredPayClient implements Anchor {
     };
   }
 
-  async getFiatAccounts(customerId: string): Promise<SavedFiatAccount[]> {
+  async getFiatAccounts(
+    customerId: string,
+    signal?: AbortSignal
+  ): Promise<SavedFiatAccount[]> {
     try {
       const response = await this.request<AlfredPayFiatAccountListItem[]>(
         "GET",
-        `/fiatAccounts?customerId=${customerId}`
+        `/fiatAccounts?customerId=${customerId}`,
+        undefined,
+        signal
       );
       return response.map((account) => ({
         id: account.fiatAccountId,
@@ -405,7 +435,10 @@ export class AlfredPayClient implements Anchor {
     }
   }
 
-  async createOffRamp(input: CreateOffRampInput): Promise<OffRampTransaction> {
+  async createOffRamp(
+    input: CreateOffRampInput,
+    signal?: AbortSignal
+  ): Promise<OffRampTransaction> {
     const response = await this.request<AlfredPayOffRampResponse>(
       "POST",
       "/offramp",
@@ -419,18 +452,22 @@ export class AlfredPayClient implements Anchor {
         chain: "XLM",
         memo: input.memo || "",
         originAddress: input.stellarAddress,
-      }
+      },
+      signal
     );
     return this.mapOffRampTransaction(response);
   }
 
   async getOffRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OffRampTransaction | null> {
     try {
       const response = await this.request<AlfredPayOffRampResponse>(
         "GET",
-        `/offramp/${transactionId}`
+        `/offramp/${transactionId}`,
+        undefined,
+        signal
       );
       return this.mapOffRampTransaction(response);
     } catch (error) {
@@ -439,18 +476,31 @@ export class AlfredPayClient implements Anchor {
     }
   }
 
-  async getKycUrl(customerId: string, country: string = "MX"): Promise<string> {
+  async getKycUrl(
+    customerId: string,
+    country: string = "MX",
+    _publicKey?: string,
+    signal?: AbortSignal
+  ): Promise<string> {
     const response = await this.request<AlfredPayKycIframeResponse>(
       "GET",
-      `/customers/${customerId}/kyc/${country}/url`
+      `/customers/${customerId}/kyc/${country}/url`,
+      undefined,
+      signal
     );
     return response.verification_url;
   }
 
-  async getKycStatus(customerId: string): Promise<KycStatus> {
+  async getKycStatus(
+    customerId: string,
+    _publicKey?: string,
+    signal?: AbortSignal
+  ): Promise<KycStatus> {
     const response = await this.request<AlfredPayCustomerResponse>(
       "GET",
-      `/customers/${customerId}`
+      `/customers/${customerId}`,
+      undefined,
+      signal
     );
     const raw = response.statusKyc?.toUpperCase();
     const statusMap: Record<string, KycStatus> = {
@@ -465,12 +515,15 @@ export class AlfredPayClient implements Anchor {
   }
 
   async getKycSubmission(
-    customerId: string
+    customerId: string,
+    signal?: AbortSignal
   ): Promise<AlfredPayKycSubmissionResponse | null> {
     try {
       return await this.request<AlfredPayKycSubmissionResponse>(
         "GET",
-        `/customers/kyc/${customerId}`
+        `/customers/kyc/${customerId}`,
+        undefined,
+        signal
       );
     } catch (error) {
       if (error instanceof AnchorError && error.statusCode === 404) return null;
@@ -480,11 +533,14 @@ export class AlfredPayClient implements Anchor {
 
   async getKycSubmissionStatus(
     customerId: string,
-    submissionId: string
+    submissionId: string,
+    signal?: AbortSignal
   ): Promise<AlfredPayKycSubmissionStatusResponse> {
     return this.request<AlfredPayKycSubmissionStatusResponse>(
       "GET",
-      `/customers/${customerId}/kyc/${submissionId}/status`
+      `/customers/${customerId}/kyc/${submissionId}/status`,
+      undefined,
+      signal
     );
   }
 
@@ -497,7 +553,10 @@ export class AlfredPayClient implements Anchor {
     );
   }
 
-  async getKycRequirements(_country?: string): Promise<KycRequirements> {
+  async getKycRequirements(
+    _country?: string,
+    _signal?: AbortSignal
+  ): Promise<KycRequirements> {
     return {
       fields: [
         { key: "firstName", label: "First Name", type: "text", required: true },
@@ -560,7 +619,8 @@ export class AlfredPayClient implements Anchor {
 
   async submitKyc(
     customerId: string,
-    data: KycSubmissionData
+    data: KycSubmissionData,
+    signal?: AbortSignal
   ): Promise<KycSubmissionResult> {
     const kycData = {
       firstName: data.fields.firstName || "",
@@ -576,7 +636,7 @@ export class AlfredPayClient implements Anchor {
       dni: data.fields.dni || "",
     };
 
-    const submission = await this.submitKycData(customerId, kycData);
+    const submission = await this.submitKycData(customerId, kycData, signal);
     const submissionId = submission.submissionId;
 
     const fileTypeMap: Record<string, AlfredPayKycFileType> = {
@@ -594,17 +654,19 @@ export class AlfredPayClient implements Anchor {
           submissionId,
           fileType,
           doc,
-          filename
+          filename,
+          signal
         );
       }
     }
 
     const statusResponse = await this.getKycSubmissionStatus(
       customerId,
-      submissionId
+      submissionId,
+      signal
     );
     if (statusResponse.status === "CREATED") {
-      await this.finalizeKycSubmission(customerId, submissionId);
+      await this.finalizeKycSubmission(customerId, submissionId, signal);
     }
 
     return { customerId, kycStatus: "pending", submissionId };
@@ -612,22 +674,27 @@ export class AlfredPayClient implements Anchor {
 
   async submitKycData(
     customerId: string,
-    data: AlfredPayKycSubmissionRequest["kycSubmission"]
+    data: AlfredPayKycSubmissionRequest["kycSubmission"],
+    signal?: AbortSignal
   ): Promise<AlfredPayKycSubmissionResponse> {
     return this.request<AlfredPayKycSubmissionResponse>(
       "POST",
       `/customers/${customerId}/kyc`,
-      { kycSubmission: data }
+      { kycSubmission: data },
+      signal
     );
   }
 
   async finalizeKycSubmission(
     customerId: string,
-    submissionId: string
+    submissionId: string,
+    signal?: AbortSignal
   ): Promise<void> {
     await this.request<{ message: string }>(
       "POST",
-      `/customers/${customerId}/kyc/${submissionId}/submit`
+      `/customers/${customerId}/kyc/${submissionId}/submit`,
+      undefined,
+      signal
     );
   }
 
@@ -636,21 +703,26 @@ export class AlfredPayClient implements Anchor {
     submissionId: string,
     fileType: AlfredPayKycFileType,
     file: Blob,
-    filename: string
+    filename: string,
+    signal?: AbortSignal
   ): Promise<AlfredPayKycFileResponse> {
     const url = `${this.config.baseUrl}/customers/${customerId}/kyc/${submissionId}/files`;
     const formData = new FormData();
     formData.append("fileBody", file, filename);
     formData.append("fileType", fileType);
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "api-key": this.config.apiKey,
-        "api-secret": this.config.apiSecret,
+    const response = await anchorRequest(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "api-key": this.config.apiKey,
+          "api-secret": this.config.apiSecret,
+        },
+        body: formData,
       },
-      body: formData,
-    });
+      { signal }
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -675,17 +747,29 @@ export class AlfredPayClient implements Anchor {
   }
 
   async sendSandboxWebhook(
-    webhook: AlfredPaySandboxWebhookRequest
+    webhook: AlfredPaySandboxWebhookRequest,
+    signal?: AbortSignal
   ): Promise<void> {
-    await this.request<{ message: string }>("POST", "/webhooks", webhook);
+    await this.request<{ message: string }>(
+      "POST",
+      "/webhooks",
+      webhook,
+      signal
+    );
   }
 
-  async completeKycSandbox(submissionId: string): Promise<void> {
-    await this.sendSandboxWebhook({
-      referenceId: submissionId,
-      eventType: "KYC",
-      status: "COMPLETED",
-      metadata: null,
-    });
+  async completeKycSandbox(
+    submissionId: string,
+    signal?: AbortSignal
+  ): Promise<void> {
+    await this.sendSandboxWebhook(
+      {
+        referenceId: submissionId,
+        eventType: "KYC",
+        status: "COMPLETED",
+        metadata: null,
+      },
+      signal
+    );
   }
 }

--- a/apps/web-app/src/lib/anchors/etherfuse/client.ts
+++ b/apps/web-app/src/lib/anchors/etherfuse/client.ts
@@ -22,6 +22,7 @@ import type {
   KycStatus,
   TransactionStatus,
 } from "../types";
+import { anchorRequest } from "../http";
 import { AnchorError } from "../types";
 import type {
   EtherfuseConfig,
@@ -82,12 +83,18 @@ export class EtherfuseClient implements Anchor {
   private async resolveAssetPair(
     fromCurrency: string,
     toCurrency: string,
-    wallet: string
+    wallet: string,
+    signal?: AbortSignal
   ): Promise<[string, string]> {
     if (fromCurrency.includes(":") && toCurrency.includes(":")) {
       return [fromCurrency, toCurrency];
     }
-    const response = await this.getAssets(this.blockchain, "mxn", wallet);
+    const response = await this.getAssets(
+      this.blockchain,
+      "mxn",
+      wallet,
+      signal
+    );
     const identifiers = new Map(
       response.assets.map((a) => [a.symbol, a.identifier])
     );
@@ -100,17 +107,22 @@ export class EtherfuseClient implements Anchor {
   private async request<T>(
     method: "GET" | "POST" | "PUT" | "DELETE",
     endpoint: string,
-    body?: unknown
+    body?: unknown,
+    signal?: AbortSignal
   ): Promise<T> {
     const url = `${this.config.baseUrl}${endpoint}`;
-    const response = await fetch(url, {
-      method,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: this.config.apiKey,
+    const response = await anchorRequest(
+      url,
+      {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: this.config.apiKey,
+        },
+        body: body ? JSON.stringify(body) : undefined,
       },
-      body: body ? JSON.stringify(body) : undefined,
-    });
+      { signal }
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -215,7 +227,10 @@ export class EtherfuseClient implements Anchor {
     };
   }
 
-  async createCustomer(input: CreateCustomerInput): Promise<Customer> {
+  async createCustomer(
+    input: CreateCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer> {
     if (!input.publicKey) {
       throw new AnchorError(
         "publicKey is required to create an Etherfuse customer",
@@ -239,7 +254,8 @@ export class EtherfuseClient implements Anchor {
           bankAccountId,
           publicKey: input.publicKey,
           blockchain: this.blockchain,
-        }
+        },
+        signal
       );
 
       const now = new Date().toISOString();
@@ -262,7 +278,10 @@ export class EtherfuseClient implements Anchor {
           // Etherfuse binds it on first use, so any valid UUID works.
           let resolvedBankAccountId: string = bankAccountId;
           try {
-            const accounts = await this.getFiatAccounts(existingCustomerId);
+            const accounts = await this.getFiatAccounts(
+              existingCustomerId,
+              signal
+            );
             if (accounts.length > 0) resolvedBankAccountId = accounts[0].id;
           } catch {
             // ignore — keep the generated bankAccountId as fallback
@@ -275,7 +294,8 @@ export class EtherfuseClient implements Anchor {
             onboardingUrl = await this.getKycUrl(
               existingCustomerId,
               input.publicKey,
-              resolvedBankAccountId
+              resolvedBankAccountId,
+              signal
             );
           } catch {
             // If the URL can't be refreshed, the client will use the stored one.
@@ -297,7 +317,10 @@ export class EtherfuseClient implements Anchor {
     }
   }
 
-  async getCustomer(input: GetCustomerInput): Promise<Customer | null> {
+  async getCustomer(
+    input: GetCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer | null> {
     if (!input.customerId) {
       throw new AnchorError(
         "customerId is required for Etherfuse customer lookup",
@@ -308,7 +331,9 @@ export class EtherfuseClient implements Anchor {
     try {
       const response = await this.request<EtherfuseCustomerResponse>(
         "GET",
-        `/ramp/customer/${input.customerId}`
+        `/ramp/customer/${input.customerId}`,
+        undefined,
+        signal
       );
       return {
         id: response.customerId,
@@ -323,12 +348,13 @@ export class EtherfuseClient implements Anchor {
     }
   }
 
-  async getQuote(input: GetQuoteInput): Promise<Quote> {
+  async getQuote(input: GetQuoteInput, signal?: AbortSignal): Promise<Quote> {
     const quoteId = crypto.randomUUID();
     const [sourceAsset, targetAsset] = await this.resolveAssetPair(
       input.fromCurrency,
       input.toCurrency,
-      input.stellarAddress || ""
+      input.stellarAddress || "",
+      signal
     );
     const type = sourceAsset.includes(":") ? "offramp" : "onramp";
 
@@ -342,7 +368,8 @@ export class EtherfuseClient implements Anchor {
         blockchain: this.blockchain,
         quoteAssets: { type, sourceAsset, targetAsset },
         sourceAmount: String(input.fromAmount || input.toAmount || ""),
-      }
+      },
+      signal
     );
 
     return {
@@ -359,11 +386,14 @@ export class EtherfuseClient implements Anchor {
     };
   }
 
-  async createOnRamp(input: CreateOnRampInput): Promise<OnRampTransaction> {
+  async createOnRamp(
+    input: CreateOnRampInput,
+    signal?: AbortSignal
+  ): Promise<OnRampTransaction> {
     const orderId = crypto.randomUUID();
     let bankAccountId = input.bankAccountId;
     if (!bankAccountId && input.customerId) {
-      const accounts = await this.getFiatAccounts(input.customerId);
+      const accounts = await this.getFiatAccounts(input.customerId, signal);
       if (accounts.length > 0) bankAccountId = accounts[0].id;
     }
 
@@ -376,7 +406,8 @@ export class EtherfuseClient implements Anchor {
         publicKey: input.stellarAddress,
         quoteId: input.quoteId,
         memo: input.memo || undefined,
-      }
+      },
+      signal
     );
 
     const { onramp } = response;
@@ -403,12 +434,15 @@ export class EtherfuseClient implements Anchor {
   }
 
   async getOnRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OnRampTransaction | null> {
     try {
       const response = await this.request<EtherfuseOrderResponse>(
         "GET",
-        `/ramp/order/${transactionId}`
+        `/ramp/order/${transactionId}`,
+        undefined,
+        signal
       );
       return this.mapOnRampTransaction(response);
     } catch (error) {
@@ -418,7 +452,8 @@ export class EtherfuseClient implements Anchor {
   }
 
   async registerFiatAccount(
-    input: RegisterFiatAccountInput
+    input: RegisterFiatAccountInput,
+    signal?: AbortSignal
   ): Promise<RegisteredFiatAccount> {
     if (!input.publicKey) {
       throw new AnchorError(
@@ -429,7 +464,9 @@ export class EtherfuseClient implements Anchor {
     }
     const presignedUrl = await this.getKycUrl(
       input.customerId,
-      input.publicKey
+      input.publicKey,
+      undefined,
+      signal
     );
     const response = await this.request<EtherfuseBankAccountResponse>(
       "POST",
@@ -441,7 +478,8 @@ export class EtherfuseClient implements Anchor {
           beneficiary: input.account.beneficiary,
           bankName: input.account.bankName || undefined,
         },
-      }
+      },
+      signal
     );
     return {
       id: response.bankAccountId,
@@ -452,12 +490,16 @@ export class EtherfuseClient implements Anchor {
     };
   }
 
-  async getFiatAccounts(customerId: string): Promise<SavedFiatAccount[]> {
+  async getFiatAccounts(
+    customerId: string,
+    signal?: AbortSignal
+  ): Promise<SavedFiatAccount[]> {
     try {
       const response = await this.request<EtherfuseBankAccountListResponse>(
         "POST",
         `/ramp/customer/${customerId}/bank-accounts`,
-        { pageSize: 100, pageNumber: 0 }
+        { pageSize: 100, pageNumber: 0 },
+        signal
       );
       return response.items.map((account) => ({
         id: account.bankAccountId,
@@ -473,11 +515,14 @@ export class EtherfuseClient implements Anchor {
     }
   }
 
-  async createOffRamp(input: CreateOffRampInput): Promise<OffRampTransaction> {
+  async createOffRamp(
+    input: CreateOffRampInput,
+    signal?: AbortSignal
+  ): Promise<OffRampTransaction> {
     const orderId = crypto.randomUUID();
     let bankAccountId = input.fiatAccountId;
     if (!bankAccountId && input.customerId) {
-      const accounts = await this.getFiatAccounts(input.customerId);
+      const accounts = await this.getFiatAccounts(input.customerId, signal);
       if (accounts.length > 0) bankAccountId = accounts[0].id;
     }
 
@@ -490,7 +535,8 @@ export class EtherfuseClient implements Anchor {
         publicKey: input.stellarAddress,
         quoteId: input.quoteId,
         memo: input.memo || undefined,
-      }
+      },
+      signal
     );
 
     return {
@@ -513,12 +559,15 @@ export class EtherfuseClient implements Anchor {
   }
 
   async getOffRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OffRampTransaction | null> {
     try {
       const response = await this.request<EtherfuseOrderResponse>(
         "GET",
-        `/ramp/order/${transactionId}`
+        `/ramp/order/${transactionId}`,
+        undefined,
+        signal
       );
       return this.mapOffRampTransaction(response);
     } catch (error) {
@@ -530,7 +579,8 @@ export class EtherfuseClient implements Anchor {
   async getKycUrl(
     customerId: string,
     publicKey?: string,
-    bankAccountId?: string
+    bankAccountId?: string,
+    signal?: AbortSignal
   ): Promise<string> {
     if (!publicKey) {
       throw new AnchorError(
@@ -550,14 +600,16 @@ export class EtherfuseClient implements Anchor {
         bankAccountId: resolvedBankAccountId,
         publicKey,
         blockchain: this.blockchain,
-      }
+      },
+      signal
     );
     return response.presigned_url;
   }
 
   async getKycStatus(
     customerId: string,
-    publicKey?: string
+    publicKey?: string,
+    signal?: AbortSignal
   ): Promise<KycStatus> {
     if (!publicKey) {
       throw new AnchorError(
@@ -568,7 +620,9 @@ export class EtherfuseClient implements Anchor {
     }
     const response = await this.request<EtherfuseKycStatusResponse>(
       "GET",
-      `/ramp/customer/${customerId}/kyc/${publicKey}`
+      `/ramp/customer/${customerId}/kyc/${publicKey}`,
+      undefined,
+      signal
     );
     return this.mapKycStatus(response.status);
   }
@@ -578,12 +632,15 @@ export class EtherfuseClient implements Anchor {
   async getAssets(
     blockchain: string,
     currency: string,
-    wallet: string
+    wallet: string,
+    signal?: AbortSignal
   ): Promise<EtherfuseAssetsResponse> {
     const params = new URLSearchParams({ blockchain, currency, wallet });
     return this.request<EtherfuseAssetsResponse>(
       "GET",
-      `/ramp/assets?${params.toString()}`
+      `/ramp/assets?${params.toString()}`,
+      undefined,
+      signal
     );
   }
 
@@ -643,16 +700,23 @@ export class EtherfuseClient implements Anchor {
     return this.acceptCustomerAgreement(presignedUrl);
   }
 
-  async simulateFiatReceived(orderId: string): Promise<number> {
+  async simulateFiatReceived(
+    orderId: string,
+    signal?: AbortSignal
+  ): Promise<number> {
     const url = `${this.config.baseUrl}/ramp/order/fiat_received`;
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: this.config.apiKey,
+    const response = await anchorRequest(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: this.config.apiKey,
+        },
+        body: JSON.stringify({ orderId }),
       },
-      body: JSON.stringify({ orderId }),
-    });
+      { signal }
+    );
     return response.status;
   }
 }

--- a/apps/web-app/src/lib/anchors/http.ts
+++ b/apps/web-app/src/lib/anchors/http.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from "next/server";
+import {
+  AnchorError,
+  AnchorTimeoutError,
+  AnchorUnreachableError,
+} from "./types";
+
+export const ANCHOR_REQUEST_TIMEOUT_MS = 15_000;
+
+export interface AnchorRequestOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function isTimeoutAbort(signal: AbortSignal): boolean {
+  return signal.aborted && signal.reason === "timeout";
+}
+
+function combineSignals(
+  timeoutMs: number,
+  callerSignal?: AbortSignal
+): { signal: AbortSignal; cleanup: () => void } {
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    timeoutController.abort("timeout");
+  }, timeoutMs);
+
+  const onCallerAbort = () => {
+    timeoutController.abort(callerSignal?.reason);
+  };
+
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      clearTimeout(timeoutId);
+      timeoutController.abort(callerSignal.reason);
+    } else {
+      callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+  }
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    if (callerSignal) {
+      callerSignal.removeEventListener("abort", onCallerAbort);
+    }
+  };
+
+  return { signal: timeoutController.signal, cleanup };
+}
+
+export async function anchorRequest(
+  url: string,
+  init: RequestInit = {},
+  options: AnchorRequestOptions = {}
+): Promise<Response> {
+  const timeoutMs = options.timeoutMs ?? ANCHOR_REQUEST_TIMEOUT_MS;
+  const { signal, cleanup } = combineSignals(timeoutMs, options.signal);
+
+  try {
+    if (signal.aborted) {
+      if (isTimeoutAbort(signal)) {
+        throw new AnchorTimeoutError();
+      }
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    const response = await fetch(url, { ...init, signal });
+    return response;
+  } catch (error) {
+    if (isAbortError(error)) {
+      if (isTimeoutAbort(signal)) {
+        throw new AnchorTimeoutError();
+      }
+      throw error;
+    }
+
+    if (error instanceof AnchorError) {
+      throw error;
+    }
+
+    throw new AnchorUnreachableError(
+      error instanceof Error ? error.message : "Anchor is unreachable"
+    );
+  } finally {
+    cleanup();
+  }
+}
+
+export function anchorErrorResponse(error: unknown): NextResponse | null {
+  if (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  ) {
+    return null;
+  }
+
+  if (error instanceof AnchorTimeoutError) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: error.statusCode }
+    );
+  }
+
+  if (error instanceof AnchorUnreachableError) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: error.statusCode }
+    );
+  }
+
+  if (error instanceof AnchorError) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: error.statusCode }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      error: "Internal server error",
+      details: error instanceof Error ? error.message : String(error),
+    },
+    { status: 500 }
+  );
+}
+
+export function raceWithSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise
+      .then((value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      })
+      .catch((error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      });
+  });
+}
+
+export function disconnectedResponse(): NextResponse {
+  return new NextResponse(null, { status: 499 });
+}
+
+export function handleRouteError(error: unknown): NextResponse {
+  const response = anchorErrorResponse(error);
+  return response ?? disconnectedResponse();
+}

--- a/apps/web-app/src/lib/anchors/index.ts
+++ b/apps/web-app/src/lib/anchors/index.ts
@@ -5,6 +5,7 @@ import { AlfredPayClient } from "./alfredpay";
 import { serverEnv } from "@/lib/env.server";
 
 export * from "./types";
+export * from "./http";
 export { EtherfuseClient } from "./etherfuse";
 export { AlfredPayClient } from "./alfredpay";
 

--- a/apps/web-app/src/lib/anchors/types.ts
+++ b/apps/web-app/src/lib/anchors/types.ts
@@ -461,31 +461,58 @@ export interface Anchor {
   readonly supportedCurrencies: readonly string[];
   readonly supportedRails: readonly string[];
 
-  createCustomer(input: CreateCustomerInput): Promise<Customer>;
-  getCustomer(input: GetCustomerInput): Promise<Customer | null>;
-  getQuote(input: GetQuoteInput): Promise<Quote>;
-  createOnRamp(input: CreateOnRampInput): Promise<OnRampTransaction>;
+  createCustomer(
+    input: CreateCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer>;
+  getCustomer(
+    input: GetCustomerInput,
+    signal?: AbortSignal
+  ): Promise<Customer | null>;
+  getQuote(input: GetQuoteInput, signal?: AbortSignal): Promise<Quote>;
+  createOnRamp(
+    input: CreateOnRampInput,
+    signal?: AbortSignal
+  ): Promise<OnRampTransaction>;
   getOnRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OnRampTransaction | null>;
   registerFiatAccount(
-    input: RegisterFiatAccountInput
+    input: RegisterFiatAccountInput,
+    signal?: AbortSignal
   ): Promise<RegisteredFiatAccount>;
-  getFiatAccounts(customerId: string): Promise<SavedFiatAccount[]>;
-  createOffRamp(input: CreateOffRampInput): Promise<OffRampTransaction>;
+  getFiatAccounts(
+    customerId: string,
+    signal?: AbortSignal
+  ): Promise<SavedFiatAccount[]>;
+  createOffRamp(
+    input: CreateOffRampInput,
+    signal?: AbortSignal
+  ): Promise<OffRampTransaction>;
   getOffRampTransaction(
-    transactionId: string
+    transactionId: string,
+    signal?: AbortSignal
   ): Promise<OffRampTransaction | null>;
   getKycUrl?(
     customerId: string,
     publicKey?: string,
-    bankAccountId?: string
+    bankAccountId?: string,
+    signal?: AbortSignal
   ): Promise<string>;
-  getKycStatus(customerId: string, publicKey?: string): Promise<KycStatus>;
-  getKycRequirements?(country?: string): Promise<KycRequirements>;
+  getKycStatus(
+    customerId: string,
+    publicKey?: string,
+    signal?: AbortSignal
+  ): Promise<KycStatus>;
+  getKycRequirements?(
+    country?: string,
+    signal?: AbortSignal
+  ): Promise<KycRequirements>;
   submitKyc?(
     customerId: string,
-    data: KycSubmissionData
+    data: KycSubmissionData,
+    signal?: AbortSignal
   ): Promise<KycSubmissionResult>;
 }
 
@@ -504,5 +531,21 @@ export class AnchorError extends Error {
     this.name = "AnchorError";
     this.code = code;
     this.statusCode = statusCode;
+  }
+}
+
+/** Thrown when an anchor HTTP request exceeds its deadline. */
+export class AnchorTimeoutError extends AnchorError {
+  constructor(message = "Anchor request timed out") {
+    super(message, "TIMEOUT", 504);
+    this.name = "AnchorTimeoutError";
+  }
+}
+
+/** Thrown when an anchor cannot be reached (network failure). */
+export class AnchorUnreachableError extends AnchorError {
+  constructor(message = "Anchor is unreachable") {
+    super(message, "UNREACHABLE", 503);
+    this.name = "AnchorUnreachableError";
   }
 }


### PR DESCRIPTION
## Summary

- **Server HTTP layer:** Added `anchorRequest` with 15s deadlines, manual `AbortSignal` combining, `AnchorTimeoutError` (504) / `AnchorUnreachableError` (503), and migrated Etherfuse + AlfredPay clients (including `simulateFiatReceived` and `submitKycFile`) off raw `fetch`.
- **Route cancellation:** All nine `/api/anchor/[provider]/*` handlers pass `request.signal` upstream; off-ramp sign races Soroban/Horizon submission against client disconnect.
- **Client polling:** New `useAnchorPolling` hook (pending / terminal / timed-out / unreachable) with exponential backoff; `rampApi` uses 20s browser deadlines; on/off-ramp hooks and UI show retryable timeout/unreachable states without claiming success.

## Verification

| Layer | How verified |
|-------|----------------|
| `anchorRequest` | Vitest: deadline → `AnchorTimeoutError`, caller abort, cleanup, network → `AnchorUnreachableError` |
| SDK clients | Vitest: `request`, `simulateFiatReceived`, `submitKycFile` route through `anchorRequest` |
| `rampApi` | Vitest: client timeout/abort; 504/503 mapped to `RampApiError` codes |
| `useAnchorPolling` | Vitest: four outcomes, backoff, unmount abort, `retry()` same identity |
| `useOnRamp` / `useOffRamp` | Vitest: deadline → timed-out (not success); off-ramp completion timeout ≠ `done`; no duplicate sign |
| Lint (changed files) | `eslint` on touched anchor/ramp paths — no new errors |

Closes #294