### PR TITLE
feat(stellar): unify Soroban transaction execution and fix backstop

### DIFF
--- a/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
+++ b/apps/web-app/src/app/api/anchor/[provider]/offramp/sign/route.ts
@@ -9,8 +9,9 @@ import {
   OffRampSignBodySchema,
   ProviderSchema,
 } from "@/lib/validation/schemas";
-import { rpc, Horizon, TransactionBuilder } from "@stellar/stellar-sdk";
+import { Horizon, TransactionBuilder } from "@stellar/stellar-sdk";
 import { clientEnv } from "@/lib/env.client";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 
 export const dynamic = "force-dynamic";
 
@@ -41,7 +42,7 @@ export async function POST(
 
     const { rpcUrl, networkPassphrase, horizonUrl } = clientEnv;
 
-    const sorobanServer = new rpc.Server(rpcUrl);
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
 
     try {

--- a/apps/web-app/src/app/api/automation/execute/route.ts
+++ b/apps/web-app/src/app/api/automation/execute/route.ts
@@ -14,15 +14,6 @@ import {
   MissingWalletAddressError,
   requireWalletAddress,
 } from "@/lib/jobs/walletAuth";
-import { raiseEvent } from "@/lib/event-platform/outbox";
-
-// In-memory plan store for demo
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationPlans: Map<string, RebalancePlan> | undefined;
-}
-globalThis.__automationPlans ??= new Map<string, RebalancePlan>();
-const planStore = globalThis.__automationPlans;
 
 export const dynamic = "force-dynamic";
 
@@ -44,29 +35,6 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
-}
-
-// Raises a durable event whenever a plan lands in "failed" — inert today
-// (neither `confirm` nor `cancel` below produce that status; this stub has
-// no real step-execution yet, per the "kick off step execution via a queue
-// worker" TODO above), but it fires automatically the moment that worker
-// exists, with no further change needed here. `walletAddress` is optional
-// because RebalancePlan has no owner field at all in this stub — the client
-// may supply it in the request body; without it, a failure has no wallet to
-// notify and is skipped (see the PR description's known limitations).
-async function raiseFailureEventIfNeeded(
-  plan: RebalancePlan,
-  walletAddress: string | undefined
-): Promise<void> {
-  if (plan.status !== "failed" || !walletAddress) return;
-  await raiseEvent({
-    source: "automation",
-    walletAddress,
-    dedupeKey: `plan-failed:${plan.id}`,
-    eventType: "plan-failed",
-    severity: "critical",
-    payload: { planId: plan.id, strategyId: plan.strategyId },
-  });
 }
 
 export async function POST(req: NextRequest) {
@@ -110,19 +78,6 @@ export async function POST(req: NextRequest) {
       const updated = await cancelPlan(planId, walletAddress);
       return NextResponse.json(updated);
     }
-  // Checked against the plan as fetched, before confirm/cancel below
-  // overwrite its status — this is what makes the hook observable at all: a
-  // plan already marked "failed" by some other process (the future
-  // step-execution worker) before this request arrived still gets reported,
-  // even though confirm/cancel always assign their own terminal status next.
-  await raiseFailureEventIfNeeded(plan, walletAddress);
-
-  if (action === "confirm") {
-    plan = { ...plan, status: "executing" };
-    planStore.set(plan.id, plan);
-    // In production: kick off step execution via a queue worker
-    return NextResponse.json(plan);
-  }
 
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   } catch (err) {

--- a/apps/web-app/src/app/api/faucet/route.ts
+++ b/apps/web-app/src/app/api/faucet/route.ts
@@ -17,6 +17,7 @@ import { parseJsonBody } from "@/lib/validation/parse";
 import { FaucetBodySchema } from "@/lib/validation/schemas";
 import { clientEnv } from "@/lib/env.client";
 import { serverEnv } from "@/lib/env.server";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 
 export const dynamic = "force-dynamic";
 
@@ -176,9 +177,7 @@ export async function POST(request: NextRequest) {
     const { rpcUrl, horizonUrl, networkPassphrase: passphrase } = clientEnv;
 
     const adminKeypair = Keypair.fromSecret(secretKey);
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: network === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
 
     const faucetContractId = serverEnv.FAUCET_CONTRACT_ID;

--- a/apps/web-app/src/app/api/vault/apy/route.ts
+++ b/apps/web-app/src/app/api/vault/apy/route.ts
@@ -11,6 +11,7 @@ import {
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
 import { clientEnv } from "@/lib/env.client";
 import { serverEnv } from "@/lib/env.server";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -155,7 +156,7 @@ export async function GET() {
 
     const { rpcUrl, networkPassphrase } = getRpcConfig();
     const keypair = Keypair.fromSecret(secretKey);
-    const server = new rpc.Server(rpcUrl);
+    const server = getSorobanServer(rpcUrl);
 
     const client = new DefindexVaultClient({
       contractId: VAULT_CONTRACT_ID,

--- a/apps/web-app/src/app/api/vault/invest/route.ts
+++ b/apps/web-app/src/app/api/vault/invest/route.ts
@@ -12,6 +12,7 @@ import {
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
 import { clientEnv } from "@/lib/env.client";
 import { requireServerEnv } from "@/lib/env.server";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -286,7 +287,7 @@ export async function POST(request: NextRequest) {
 
     const { secretKey, rpcUrl, networkPassphrase } = getEnv();
     const keypair = Keypair.fromSecret(secretKey);
-    const server = new rpc.Server(rpcUrl);
+    const server = getSorobanServer(rpcUrl);
     const client = new DefindexVaultClient({
       contractId: VAULT_CONTRACT_ID,
       rpcUrl,

--- a/apps/web-app/src/components/navigation/MobileHeader.tsx
+++ b/apps/web-app/src/components/navigation/MobileHeader.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 import { NAV_ITEMS } from "./sidebarConfig";
 import { useWalletType } from "@/hooks/useWalletType";
 import { useStellarWallet } from "@/hooks/useStellarWallet";
-import { useStellarWallet } from "@/hooks/useStellarWallet";
 import { truncateAddress } from "@/lib/utils";
 import { useActivityFeed } from "@/features/activity/hooks/useActivityFeed";
 import { clientEnv } from "@/lib/env.client";

--- a/apps/web-app/src/components/navigation/sidebarConfig.ts
+++ b/apps/web-app/src/components/navigation/sidebarConfig.ts
@@ -11,6 +11,7 @@ import {
   PieChart,
   Zap,
   Bell,
+  Workflow,
 } from "lucide-react";
 
 export const NAV_ITEMS = [

--- a/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
+++ b/apps/web-app/src/features/backstop/components/ui/BackstopActionPanel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { AmountInput } from "@/components/AmountInput";
 import { BackstopInfoAlert } from "./BackstopInfoAlert";
 import { QueueCountdown } from "./QueueCountdown";
+import { BackstopAmountInput } from "./BackstopAmountInput";
+import { BACKSTOP_WITHDRAWAL_QUEUE_DAYS } from "../../const/backstop";
 
 type ActionTab = "deposit" | "withdraw";
 
@@ -18,9 +19,9 @@ interface BackstopActionPanelProps {
   inWithdrawalQueue: boolean;
   queueExpired: boolean;
   queueExpiresAt: Date | null;
-  onDeposit: (amount: string) => Promise<void>;
-  onInitiateWithdrawal: (amount: string) => Promise<void>;
-  onWithdraw: (amount: string) => Promise<void>;
+  onDeposit: (amount: string) => Promise<boolean>;
+  onInitiateWithdrawal: (amount: string) => Promise<boolean>;
+  onWithdraw: (amount: string) => Promise<boolean>;
 }
 
 export function BackstopActionPanel({
@@ -68,7 +69,6 @@ export function BackstopActionPanel({
         Actions
       </p>
 
-      {/* Tabs */}
       <div className="flex items-center gap-1 rounded-xl bg-[#242424] p-1">
         <button
           onClick={() => setActiveTab("deposit")}
@@ -93,31 +93,15 @@ export function BackstopActionPanel({
         </button>
       </div>
 
-      {/* Deposit */}
       {activeTab === "deposit" && (
         <div className="flex flex-col gap-4">
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-white/50 text-sm font-medium">Amount</span>
-              {parseFloat(walletBalance) > 0 && (
-                <button
-                  onClick={() => setDepositAmount(walletBalance)}
-                  disabled={isLoading}
-                  className="text-[#229EDF] text-xs font-semibold hover:text-[#229EDF]/70 transition-colors disabled:opacity-40 shrink-0 ml-2"
-                >
-                  Max: {parseFloat(walletBalance).toFixed(4)}
-                </button>
-              )}
-            </div>
-            <div className="bg-[#2A2A2A] rounded-xl px-4 h-14 flex items-center">
-              <AmountInput
-                value={depositAmount}
-                onChange={setDepositAmount}
-                disabled={isLoading || !backstopTokenConfigured}
-                className="bg-transparent text-white text-2xl font-bold w-full outline-none placeholder:text-white/30 disabled:opacity-50"
-              />
-            </div>
-          </div>
+          <BackstopAmountInput
+            label="Amount"
+            value={depositAmount}
+            onChange={setDepositAmount}
+            disabled={isLoading || !backstopTokenConfigured}
+            max={walletBalance}
+          />
 
           <div className="bg-[#252525] rounded-xl p-3.5">
             <p className="text-white/40 text-xs">Available in wallet</p>
@@ -134,7 +118,9 @@ export function BackstopActionPanel({
 
           <button
             onClick={() =>
-              void onDeposit(depositAmount).then(() => setDepositAmount(""))
+              void onDeposit(depositAmount).then((ok) => {
+                if (ok) setDepositAmount("");
+              })
             }
             disabled={!canDeposit}
             className="w-full rounded-xl bg-[#229EDF] py-3 text-white font-semibold text-sm hover:bg-[#1a8bc7] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -148,7 +134,6 @@ export function BackstopActionPanel({
         </div>
       )}
 
-      {/* Withdraw */}
       {activeTab === "withdraw" && (
         <div className="flex flex-col gap-4">
           {hasActiveDeposit && (
@@ -158,35 +143,20 @@ export function BackstopActionPanel({
                 {inWithdrawalQueue && queueExpiresAt ? (
                   <QueueCountdown expiresAt={queueExpiresAt} />
                 ) : (
-                  <span className="font-semibold text-amber-400">17 days</span>
+                  <span className="font-semibold text-amber-400">
+                    {BACKSTOP_WITHDRAWAL_QUEUE_DAYS} days
+                  </span>
                 )}
                 .
               </BackstopInfoAlert>
 
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-white/50 text-sm font-medium">
-                    Amount to queue
-                  </span>
-                  {parseFloat(activeDepositAmount) > 0 && (
-                    <button
-                      onClick={() => setWithdrawAmount(activeDepositAmount)}
-                      disabled={isLoading}
-                      className="text-[#229EDF] text-xs font-semibold hover:text-[#229EDF]/70 transition-colors disabled:opacity-40"
-                    >
-                      Max: {parseFloat(activeDepositAmount).toFixed(4)}
-                    </button>
-                  )}
-                </div>
-                <div className="bg-[#2A2A2A] rounded-xl px-4 h-14 flex items-center">
-                  <AmountInput
-                    value={withdrawAmount}
-                    onChange={setWithdrawAmount}
-                    disabled={isLoading}
-                    className="bg-transparent text-white text-2xl font-bold w-full outline-none placeholder:text-white/30 disabled:opacity-50"
-                  />
-                </div>
-              </div>
+              <BackstopAmountInput
+                label="Amount to queue"
+                value={withdrawAmount}
+                onChange={setWithdrawAmount}
+                disabled={isLoading}
+                max={activeDepositAmount}
+              />
 
               <div className="bg-[#252525] rounded-xl p-3.5">
                 <p className="text-white/40 text-xs">Available to queue</p>
@@ -197,14 +167,16 @@ export function BackstopActionPanel({
 
               <button
                 onClick={() =>
-                  void onInitiateWithdrawal(withdrawAmount).then(() =>
-                    setWithdrawAmount("")
-                  )
+                  void onInitiateWithdrawal(withdrawAmount).then((ok) => {
+                    if (ok) setWithdrawAmount("");
+                  })
                 }
                 disabled={!canQueue}
                 className="w-full rounded-xl border border-amber-500/40 py-3 text-amber-400 font-semibold text-sm hover:bg-amber-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isLoading ? "Processing…" : "Queue Withdrawal (17-day wait)"}
+                {isLoading
+                  ? "Processing…"
+                  : `Queue Withdrawal (${BACKSTOP_WITHDRAWAL_QUEUE_DAYS}-day wait)`}
               </button>
             </>
           )}
@@ -224,9 +196,9 @@ export function BackstopActionPanel({
 
               <button
                 onClick={() =>
-                  void onWithdraw(queuedDepositAmount).then(() =>
-                    setWithdrawAmount("")
-                  )
+                  void onWithdraw(queuedDepositAmount).then((ok) => {
+                    if (ok) setWithdrawAmount("");
+                  })
                 }
                 disabled={!canWithdraw}
                 className="w-full rounded-xl bg-[#229EDF] py-3 text-white font-semibold text-sm hover:bg-[#1a8bc7] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/apps/web-app/src/features/backstop/const/backstop.ts
+++ b/apps/web-app/src/features/backstop/const/backstop.ts
@@ -1,0 +1,2 @@
+export const BACKSTOP_WITHDRAWAL_QUEUE_DAYS = 17;
+export const BACKSTOP_TOKEN_DECIMALS = 7;

--- a/apps/web-app/src/features/backstop/hooks/__tests__/useBackstop.test.ts
+++ b/apps/web-app/src/features/backstop/hooks/__tests__/useBackstop.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const {
+  addNotification,
+  signTransaction,
+  executeTransactionMock,
+  depositToBackstopMock,
+  initiateBackstopWithdrawalMock,
+  withdrawFromBackstopMock,
+  getBackstopTokenMock,
+  getBackstopDepositMock,
+  getTokenBalanceMock,
+  walletState,
+} = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  signTransaction: vi.fn(),
+  executeTransactionMock: vi.fn(),
+  depositToBackstopMock: vi.fn(),
+  initiateBackstopWithdrawalMock: vi.fn(),
+  withdrawFromBackstopMock: vi.fn(),
+  getBackstopTokenMock: vi.fn(),
+  getBackstopDepositMock: vi.fn(),
+  getTokenBalanceMock: vi.fn(),
+  walletState: {
+    address: "GTEST" as string | undefined,
+    signTransaction: vi.fn(),
+    networkPassphrase: "Test SDF Network ; September 2015",
+  },
+}));
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ addNotification }),
+}));
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => walletState,
+}));
+vi.mock("@/lib/helpers/stellar/lending", () => ({
+  depositToBackstop: depositToBackstopMock,
+  initiateBackstopWithdrawal: initiateBackstopWithdrawalMock,
+  withdrawFromBackstop: withdrawFromBackstopMock,
+  getBackstopToken: getBackstopTokenMock,
+  getBackstopDeposit: getBackstopDepositMock,
+  getTokenBalance: getTokenBalanceMock,
+}));
+vi.mock("@/lib/helpers/stellar/executeTransaction", () => ({
+  executeTransaction: executeTransactionMock,
+}));
+vi.mock("@/lib/helpers/tokenUtils", () => ({
+  fromSmallestUnit: (raw: string, decimals: number) => {
+    const value = BigInt(raw);
+    const scale = 10 ** decimals;
+    return (Number(value) / scale).toString();
+  },
+}));
+
+let mockCountdownExpired = false;
+vi.mock("@/hooks/useCountdown", () => ({
+  useCountdown: () => ({
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: mockCountdownExpired ? 0 : 30,
+    expired: mockCountdownExpired,
+  }),
+}));
+
+import { useBackstop } from "../useBackstop";
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  Wrapper.displayName = "QueryWrapper";
+  return Wrapper;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  mockCountdownExpired = false;
+  walletState.address = "GTEST";
+  walletState.signTransaction = signTransaction;
+  getBackstopTokenMock.mockResolvedValue("CTOKEN");
+  getTokenBalanceMock.mockResolvedValue(100_0000000n);
+  getBackstopDepositMock.mockResolvedValue({
+    amount: 50_0000000n,
+    activeAmount: 50_0000000n,
+    queuedAmount: 0n,
+    inWithdrawalQueue: false,
+    queuedAt: null,
+  });
+  depositToBackstopMock.mockResolvedValue("DEPOSIT_XDR");
+  initiateBackstopWithdrawalMock.mockResolvedValue("QUEUE_XDR");
+  withdrawFromBackstopMock.mockResolvedValue("WITHDRAW_XDR");
+  executeTransactionMock.mockResolvedValue({ status: "success", hash: "HASH" });
+  signTransaction.mockResolvedValue({ signedTxXdr: "SIGNED" });
+});
+
+describe("useBackstop – amount validation", () => {
+  it("shows an error and returns false for empty deposit amounts", async () => {
+    const { result } = renderHook(() => useBackstop("CPOOL"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.walletBalance).toBe("100"));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.handleDeposit("");
+    });
+
+    expect(ok).toBe(false);
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Enter an amount greater than zero.",
+      })
+    );
+    expect(executeTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects deposit above wallet balance", async () => {
+    const { result } = renderHook(() => useBackstop("CPOOL"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.walletBalance).toBe("100"));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.handleDeposit("150");
+    });
+
+    expect(ok).toBe(false);
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: "Amount exceeds wallet balance (100).",
+      })
+    );
+  });
+});
+
+describe("useBackstop – reactive queue expiry", () => {
+  it("marks queueExpired true when the queue date is already past", async () => {
+    mockCountdownExpired = true;
+    getBackstopDepositMock.mockResolvedValue({
+      amount: 10_0000000n,
+      activeAmount: 0n,
+      queuedAmount: 10_0000000n,
+      inWithdrawalQueue: true,
+      queuedAt: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    const { result } = renderHook(() => useBackstop("CPOOL"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.queueExpired).toBe(true));
+  });
+
+  it("flips queueExpired when the countdown elapses", async () => {
+    const expiresAtSec = Math.floor((Date.now() + 3000) / 1000);
+    getBackstopDepositMock.mockResolvedValue({
+      amount: 10_0000000n,
+      activeAmount: 0n,
+      queuedAmount: 10_0000000n,
+      inWithdrawalQueue: true,
+      queuedAt: expiresAtSec,
+    });
+
+    const { result, rerender } = renderHook(() => useBackstop("CPOOL"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.inWithdrawalQueue).toBe(true));
+    expect(result.current.queueExpired).toBe(false);
+
+    mockCountdownExpired = true;
+    await act(async () => {
+      rerender();
+    });
+
+    expect(result.current.queueExpired).toBe(true);
+  });
+});
+
+describe("useBackstop – contract errors", () => {
+  it("maps queue-not-expired contract errors consistently", async () => {
+    getBackstopDepositMock.mockResolvedValue({
+      amount: 10_0000000n,
+      activeAmount: 0n,
+      queuedAmount: 10_0000000n,
+      inWithdrawalQueue: true,
+      queuedAt: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    executeTransactionMock.mockResolvedValue({
+      status: "contract_error",
+      error: {
+        kind: "withdrawal_queue_not_expired",
+        message: "Withdrawal queue has not expired yet",
+      },
+    });
+
+    const { result } = renderHook(() => useBackstop("CPOOL"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.inWithdrawalQueue).toBe(true));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.handleWithdraw("10");
+    });
+
+    expect(ok).toBe(false);
+    expect(addNotification).toHaveBeenCalledWith(
+      "Something went wrong",
+      "error",
+      expect.objectContaining({
+        description: expect.stringContaining("withdrawal queue period"),
+      })
+    );
+  });
+});

--- a/apps/web-app/src/features/backstop/hooks/useBackstop.ts
+++ b/apps/web-app/src/features/backstop/hooks/useBackstop.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
-import { rpc } from "@stellar/stellar-sdk";
+import { Networks } from "@stellar/stellar-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useWallet } from "@/hooks/useWallet";
 import { useToast } from "@/hooks/useToast";
+import { useCountdown } from "@/hooks/useCountdown";
 import { TOAST_CONFIG } from "@/lib/constants/toast.config";
 import {
   depositToBackstop,
@@ -15,12 +15,13 @@ import {
   getBackstopDeposit,
   getTokenBalance,
 } from "@/lib/helpers/stellar/lending";
-import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
-import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+import { executeTransaction } from "@/lib/helpers/stellar/executeTransaction";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
-import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
-
-const WITHDRAWAL_QUEUE_DAYS = 17;
+import {
+  BACKSTOP_TOKEN_DECIMALS,
+  BACKSTOP_WITHDRAWAL_QUEUE_DAYS,
+} from "../const/backstop";
+import { validateBackstopAmount } from "../utils/validateBackstopAmount";
 
 export function useBackstop(contractId: string) {
   const [isLoading, setIsLoading] = useState(false);
@@ -46,7 +47,6 @@ export function useBackstop(contractId: string) {
     [addNotification]
   );
 
-  // Fetch the backstop token address from the contract
   const { data: backstopTokenAddress } = useQuery({
     queryKey: ["backstopToken", contractId],
     queryFn: () => getBackstopToken(contractId),
@@ -55,7 +55,6 @@ export function useBackstop(contractId: string) {
     refetchOnWindowFocus: false,
   });
 
-  // Fetch the user's wallet balance of the backstop token
   const {
     data: walletBalance,
     isLoading: isLoadingWalletBalance,
@@ -65,7 +64,7 @@ export function useBackstop(contractId: string) {
     queryFn: async () => {
       if (!address || !backstopTokenAddress) return "0";
       const raw = await getTokenBalance(backstopTokenAddress, address);
-      return fromSmallestUnit(raw.toString(), 7);
+      return fromSmallestUnit(raw.toString(), BACKSTOP_TOKEN_DECIMALS);
     },
     enabled: !!address && !!backstopTokenAddress,
     staleTime: 30_000,
@@ -74,7 +73,6 @@ export function useBackstop(contractId: string) {
     placeholderData: (prev) => prev,
   });
 
-  // Fetch the user's deposited backstop balance and queue status
   const {
     data: depositInfo,
     isLoading: isLoadingDeposit,
@@ -96,171 +94,150 @@ export function useBackstop(contractId: string) {
     await Promise.all([refetchWalletBalance(), refetchDepositInfo()]);
   }, [refetchWalletBalance, refetchDepositInfo]);
 
-  // Deposit to backstop — Soroban auth propagation bundles token transfer
-  // authorization into the prepared tx, so no separate approve is needed.
-  const handleDeposit = useCallback(
-    async (amount: string) => {
-      if (!address || !amount || parseFloat(amount) <= 0) return;
-      setIsLoading(true);
-      try {
-        const passphrase = networkPassphrase || Networks.TESTNET;
-        const sorobanServer = new rpc.Server(rpcUrl, {
-          allowHttp: stellarNetwork === "LOCAL",
-        });
+  const walletBalanceValue = walletBalance ?? "0";
+  const depositedAmount = depositInfo
+    ? fromSmallestUnit(depositInfo.amount.toString(), BACKSTOP_TOKEN_DECIMALS)
+    : "0";
+  const activeDepositAmount = depositInfo
+    ? fromSmallestUnit(
+        depositInfo.activeAmount.toString(),
+        BACKSTOP_TOKEN_DECIMALS
+      )
+    : "0";
+  const queuedDepositAmount = depositInfo
+    ? fromSmallestUnit(
+        depositInfo.queuedAmount.toString(),
+        BACKSTOP_TOKEN_DECIMALS
+      )
+    : "0";
 
-        const depositXdr = await depositToBackstop(amount, address, contractId);
-        const signedDeposit = await signTransaction(depositXdr, {
-          networkPassphrase: passphrase,
-          address,
-        });
-        const sendResult = await sorobanServer.sendTransaction(
-          TransactionBuilder.fromXDR(signedDeposit.signedTxXdr, passphrase)
-        );
-
-        await waitForTransaction(sendResult.hash, sorobanServer);
-        await refetchAll();
-        showSuccess(`Successfully deposited ${amount} tokens to backstop`);
-      } catch (err) {
-        const msg = extractContractErrorOrNull(err);
-        showError(
-          typeof msg === "string" ? msg : "An unexpected error occurred."
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [
-      address,
-      networkPassphrase,
-      signTransaction,
-      refetchAll,
-      showError,
-      showSuccess,
-    ]
-  );
-
-  // Enter the 17-day withdrawal queue
-  const handleInitiateWithdrawal = useCallback(
-    async (amount: string) => {
-      if (!address || !amount || parseFloat(amount) <= 0) return;
-      setIsLoading(true);
-      try {
-        const passphrase = networkPassphrase || Networks.TESTNET;
-        const sorobanServer = new rpc.Server(rpcUrl, {
-          allowHttp: stellarNetwork === "LOCAL",
-        });
-
-        const xdr = await initiateBackstopWithdrawal(
-          amount,
-          address,
-          contractId
-        );
-        const signed = await signTransaction(xdr, {
-          networkPassphrase: passphrase,
-          address,
-        });
-        const sendResult = await sorobanServer.sendTransaction(
-          TransactionBuilder.fromXDR(signed.signedTxXdr, passphrase)
-        );
-
-        await waitForTransaction(sendResult.hash, sorobanServer);
-        await refetchAll();
-        showSuccess(
-          `Withdrawal queued. You can withdraw after ${WITHDRAWAL_QUEUE_DAYS} days.`
-        );
-      } catch (err) {
-        const msg = extractContractErrorOrNull(err);
-        showError(
-          typeof msg === "string" ? msg : "An unexpected error occurred."
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [
-      address,
-      networkPassphrase,
-      signTransaction,
-      refetchAll,
-      showError,
-      showSuccess,
-    ]
-  );
-
-  // Execute withdrawal after queue period
-  const handleWithdraw = useCallback(
-    async (amount: string) => {
-      if (!address || !amount || parseFloat(amount) <= 0) return;
-      setIsLoading(true);
-      try {
-        const passphrase = networkPassphrase || Networks.TESTNET;
-        const sorobanServer = new rpc.Server(rpcUrl, {
-          allowHttp: stellarNetwork === "LOCAL",
-        });
-
-        const xdr = await withdrawFromBackstop(amount, address, contractId);
-        const signed = await signTransaction(xdr, {
-          networkPassphrase: passphrase,
-          address,
-        });
-        const sendResult = await sorobanServer.sendTransaction(
-          TransactionBuilder.fromXDR(signed.signedTxXdr, passphrase)
-        );
-
-        await waitForTransaction(sendResult.hash, sorobanServer);
-        await refetchAll();
-        showSuccess(`Successfully withdrew ${amount} tokens from backstop`);
-      } catch (err) {
-        const errStr = String(err);
-        if (
-          errStr.includes("WithdrawalQueueNotExpired") ||
-          errStr.includes("#72")
-        ) {
-          showError(
-            `Your withdrawal queue period has not yet expired. Please wait ${WITHDRAWAL_QUEUE_DAYS} days after queuing before withdrawing.`
-          );
-          return;
-        }
-        const msg = extractContractErrorOrNull(err);
-        showError(
-          typeof msg === "string" ? msg : "An unexpected error occurred."
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [
-      address,
-      networkPassphrase,
-      signTransaction,
-      refetchAll,
-      showError,
-      showSuccess,
-    ]
-  );
-
-  // Derive queue expiry info — queuedAt now holds the expiration timestamp
-  // directly from the backstop contract's Q4W.exp field.
   const queueExpiresAt: Date | null =
     depositInfo?.inWithdrawalQueue && depositInfo.queuedAt
       ? new Date(Number(depositInfo.queuedAt) * 1000)
       : null;
 
-  const queueExpired = queueExpiresAt !== null && new Date() >= queueExpiresAt;
+  const { expired: countdownExpired } = useCountdown(queueExpiresAt);
+  const queueExpired = queueExpiresAt !== null && countdownExpired;
 
-  const depositedAmount = depositInfo
-    ? fromSmallestUnit(depositInfo.amount.toString(), 7)
-    : "0";
-  const activeDepositAmount = depositInfo
-    ? fromSmallestUnit(depositInfo.activeAmount.toString(), 7)
-    : "0";
-  const queuedDepositAmount = depositInfo
-    ? fromSmallestUnit(depositInfo.queuedAmount.toString(), 7)
-    : "0";
+  const resolveTxErrorMessage = useCallback(
+    (
+      result: Exclude<
+        Awaited<ReturnType<typeof executeTransaction>>,
+        { status: "success" }
+      >
+    ) => {
+      if (result.status === "user_rejected") return null;
+      if (result.status === "contract_error") {
+        if (result.error.kind === "withdrawal_queue_not_expired") {
+          return `Your withdrawal queue period has not yet expired. Please wait ${BACKSTOP_WITHDRAWAL_QUEUE_DAYS} days after queuing before withdrawing.`;
+        }
+        return result.error.message;
+      }
+      return result.message;
+    },
+    []
+  );
+
+  const runBackstopTransaction = useCallback(
+    async (
+      amount: string,
+      action: "deposit" | "queue" | "withdraw",
+      buildXdr: () => Promise<string>,
+      successMessage: string
+    ): Promise<boolean> => {
+      if (!address) return false;
+
+      const validation = validateBackstopAmount({
+        action,
+        amount,
+        walletBalance: walletBalanceValue,
+        activeDepositAmount,
+        queuedDepositAmount,
+      });
+      if (!validation.valid) {
+        showError(validation.message);
+        return false;
+      }
+
+      setIsLoading(true);
+      try {
+        const passphrase = networkPassphrase || Networks.TESTNET;
+        const xdr = await buildXdr();
+        const result = await executeTransaction({
+          xdr,
+          signTransaction,
+          networkPassphrase: passphrase,
+          address,
+          contractName: "rwa-lending",
+          confirmation: "wait",
+        });
+
+        if (result.status !== "success") {
+          const msg = resolveTxErrorMessage(result);
+          if (msg) showError(msg);
+          return false;
+        }
+
+        await refetchAll();
+        showSuccess(successMessage);
+        return true;
+      } catch (err) {
+        showError("An unexpected error occurred.");
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      address,
+      walletBalanceValue,
+      activeDepositAmount,
+      queuedDepositAmount,
+      networkPassphrase,
+      signTransaction,
+      refetchAll,
+      showError,
+      showSuccess,
+      resolveTxErrorMessage,
+    ]
+  );
+
+  const handleDeposit = useCallback(
+    (amount: string) =>
+      runBackstopTransaction(
+        amount,
+        "deposit",
+        () => depositToBackstop(amount, address!, contractId),
+        `Successfully deposited ${amount} tokens to backstop`
+      ),
+    [runBackstopTransaction, address, contractId]
+  );
+
+  const handleInitiateWithdrawal = useCallback(
+    (amount: string) =>
+      runBackstopTransaction(
+        amount,
+        "queue",
+        () => initiateBackstopWithdrawal(amount, address!, contractId),
+        `Withdrawal queued. You can withdraw after ${BACKSTOP_WITHDRAWAL_QUEUE_DAYS} days.`
+      ),
+    [runBackstopTransaction, address, contractId]
+  );
+
+  const handleWithdraw = useCallback(
+    (amount: string) =>
+      runBackstopTransaction(
+        amount,
+        "withdraw",
+        () => withdrawFromBackstop(amount, address!, contractId),
+        `Successfully withdrew ${amount} tokens from backstop`
+      ),
+    [runBackstopTransaction, address, contractId]
+  );
 
   return {
     isLoading,
-    walletBalance: walletBalance ?? "0",
+    walletBalance: walletBalanceValue,
     isLoadingWalletBalance,
     depositedAmount,
     activeDepositAmount,

--- a/apps/web-app/src/features/backstop/utils/__tests__/validateBackstopAmount.test.ts
+++ b/apps/web-app/src/features/backstop/utils/__tests__/validateBackstopAmount.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { validateBackstopAmount } from "../validateBackstopAmount";
+
+const base = {
+  walletBalance: "100",
+  activeDepositAmount: "50",
+  queuedDepositAmount: "25",
+};
+
+describe("validateBackstopAmount", () => {
+  it("rejects empty or non-positive amounts", () => {
+    expect(
+      validateBackstopAmount({ ...base, action: "deposit", amount: "" })
+    ).toEqual({
+      valid: false,
+      message: "Enter an amount greater than zero.",
+    });
+    expect(
+      validateBackstopAmount({ ...base, action: "deposit", amount: "0" })
+    ).toEqual({
+      valid: false,
+      message: "Enter an amount greater than zero.",
+    });
+  });
+
+  it("rejects deposit above wallet balance", () => {
+    const result = validateBackstopAmount({
+      ...base,
+      action: "deposit",
+      amount: "150",
+    });
+    expect(result).toEqual({
+      valid: false,
+      message: "Amount exceeds wallet balance (100).",
+    });
+  });
+
+  it("rejects queue above active deposit", () => {
+    const result = validateBackstopAmount({
+      ...base,
+      action: "queue",
+      amount: "75",
+    });
+    expect(result).toEqual({
+      valid: false,
+      message: "Amount exceeds active deposit (50).",
+    });
+  });
+
+  it("rejects withdraw above queued deposit", () => {
+    const result = validateBackstopAmount({
+      ...base,
+      action: "withdraw",
+      amount: "30",
+    });
+    expect(result).toEqual({
+      valid: false,
+      message: "Amount exceeds queued deposit (25).",
+    });
+  });
+
+  it("accepts valid amounts within limits", () => {
+    expect(
+      validateBackstopAmount({ ...base, action: "deposit", amount: "10" })
+    ).toEqual({ valid: true });
+    expect(
+      validateBackstopAmount({ ...base, action: "queue", amount: "10" })
+    ).toEqual({ valid: true });
+    expect(
+      validateBackstopAmount({ ...base, action: "withdraw", amount: "10" })
+    ).toEqual({ valid: true });
+  });
+});

--- a/apps/web-app/src/features/backstop/utils/validateBackstopAmount.ts
+++ b/apps/web-app/src/features/backstop/utils/validateBackstopAmount.ts
@@ -1,0 +1,72 @@
+export type BackstopAmountAction = "deposit" | "queue" | "withdraw";
+
+export interface ValidateBackstopAmountInput {
+  action: BackstopAmountAction;
+  amount: string;
+  walletBalance: string;
+  activeDepositAmount: string;
+  queuedDepositAmount: string;
+}
+
+export type ValidateBackstopAmountResult =
+  | { valid: true }
+  | { valid: false; message: string };
+
+function parsePositiveAmount(amount: string): number | null {
+  const trimmed = amount.trim();
+  if (!trimmed) return null;
+  const value = parseFloat(trimmed);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+export function validateBackstopAmount(
+  input: ValidateBackstopAmountInput
+): ValidateBackstopAmountResult {
+  const {
+    action,
+    amount,
+    walletBalance,
+    activeDepositAmount,
+    queuedDepositAmount,
+  } = input;
+  const parsed = parsePositiveAmount(amount);
+
+  if (parsed == null) {
+    return {
+      valid: false,
+      message: "Enter an amount greater than zero.",
+    };
+  }
+
+  if (action === "deposit") {
+    const limit = parseFloat(walletBalance);
+    if (parsed > limit) {
+      return {
+        valid: false,
+        message: `Amount exceeds wallet balance (${walletBalance}).`,
+      };
+    }
+    return { valid: true };
+  }
+
+  if (action === "queue") {
+    const limit = parseFloat(activeDepositAmount);
+    if (parsed > limit) {
+      return {
+        valid: false,
+        message: `Amount exceeds active deposit (${activeDepositAmount}).`,
+      };
+    }
+    return { valid: true };
+  }
+
+  const limit = parseFloat(queuedDepositAmount);
+  if (parsed > limit) {
+    return {
+      valid: false,
+      message: `Amount exceeds queued deposit (${queuedDepositAmount}).`,
+    };
+  }
+  return { valid: true };
+}

--- a/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
+++ b/apps/web-app/src/features/lending/hooks/__tests__/useLend.test.ts
@@ -75,17 +75,11 @@ vi.mock("@/lib/helpers/stellar/lending", () => ({
 vi.mock("@/lib/helpers/stellar/soroswap", () => ({
   getAvailableTokens: () => ({ USDC: { contract: "CUSDC", decimals: 7 } }),
 }));
-vi.mock("@/lib/helpers/stellar/waitForTransaction", () => ({
-  waitForTransaction: vi.fn(),
+vi.mock("@/lib/helpers/stellar/executeTransaction", () => ({
+  executeTransaction: vi.fn(),
 }));
 vi.mock("@stellar/stellar-sdk", () => ({
   Networks: { TESTNET: "Test SDF Network ; September 2015" },
-  TransactionBuilder: { fromXDR: vi.fn(() => ({})) },
-  rpc: {
-    Server: class {
-      sendTransaction = vi.fn().mockResolvedValue({ hash: "HASH" });
-    },
-  },
 }));
 
 import { useLend } from "../useLend";
@@ -94,12 +88,12 @@ import {
   withdrawFromPool,
   getBTokenBalance,
 } from "@/lib/helpers/stellar/lending";
-import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+import { executeTransaction } from "@/lib/helpers/stellar/executeTransaction";
 
 const depositToPoolMock = vi.mocked(depositToPool);
 const withdrawFromPoolMock = vi.mocked(withdrawFromPool);
 const getBTokenBalanceMock = vi.mocked(getBTokenBalance);
-const waitForTransactionMock = vi.mocked(waitForTransaction);
+const executeTransactionMock = vi.mocked(executeTransaction);
 
 const nekoPool: PoolData = {
   id: "pool-0",
@@ -131,7 +125,10 @@ beforeEach(() => {
   depositToPoolMock.mockResolvedValue("DEPOSIT_XDR");
   withdrawFromPoolMock.mockResolvedValue("WITHDRAW_XDR");
   getBTokenBalanceMock.mockResolvedValue("0");
-  waitForTransactionMock.mockResolvedValue(undefined as never);
+  executeTransactionMock.mockResolvedValue({
+    status: "success",
+    hash: "HASH",
+  });
   signTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
   executePoolActionMock.mockResolvedValue(undefined);
   refetchPoolsMock.mockResolvedValue(undefined);
@@ -241,13 +238,12 @@ describe("useLend – Neko deposit path", () => {
       "GTEST_ADDRESS",
       "CPOOL"
     );
-    expect(signTransaction).toHaveBeenCalledWith(
-      "DEPOSIT_XDR",
-      expect.objectContaining({ address: "GTEST_ADDRESS" })
-    );
-    expect(waitForTransactionMock).toHaveBeenCalledWith(
-      "HASH",
-      expect.anything()
+    expect(executeTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        xdr: "DEPOSIT_XDR",
+        confirmation: "wait",
+        contractName: "rwa-lending",
+      })
     );
     expect(addNotification).toHaveBeenCalledWith(
       "Success",
@@ -277,9 +273,12 @@ describe("useLend – Neko withdraw path", () => {
       "GTEST_ADDRESS",
       "CPOOL"
     );
-    expect(waitForTransactionMock).toHaveBeenCalledWith(
-      "HASH",
-      expect.anything()
+    expect(executeTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        xdr: "WITHDRAW_XDR",
+        confirmation: "wait",
+        contractName: "rwa-lending",
+      })
     );
     expect(addNotification).toHaveBeenCalledWith(
       "Success",

--- a/apps/web-app/src/features/lending/hooks/useLend.ts
+++ b/apps/web-app/src/features/lending/hooks/useLend.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
-import { rpc } from "@stellar/stellar-sdk";
+import { Networks } from "@stellar/stellar-sdk";
 import { useWallet } from "@/hooks/useWallet";
 import { useToast } from "@/hooks/useToast";
 import { TOAST_CONFIG } from "@/lib/constants/toast.config";
@@ -13,9 +12,8 @@ import {
   getBTokenBalance,
 } from "@/lib/helpers/stellar/lending";
 import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
-import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
-import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+import { executeTransaction } from "@/lib/helpers/stellar/executeTransaction";
 import { usePools, usePoolAction } from "@/lib/orchestrator";
 import type { PoolInfo } from "@/lib/orchestrator";
 import { fromSmallestUnit, toSmallestUnit } from "@/lib/helpers/tokenUtils";
@@ -207,10 +205,6 @@ export function useLend() {
 
         const decimals = token.decimals || 7;
         const passphrase = networkPassphrase || Networks.TESTNET;
-        const sorobanServer = new rpc.Server(rpcUrl, {
-          allowHttp: stellarNetwork === "LOCAL",
-        });
-
         const lendingContractId = selectedPool.contractId;
 
         if (isDeposit) {
@@ -222,14 +216,23 @@ export function useLend() {
             lendingContractId
           );
 
-          const signedDeposit = await signTransaction(depositXdr, {
+          const result = await executeTransaction({
+            xdr: depositXdr,
+            signTransaction,
             networkPassphrase: passphrase,
             address,
+            contractName: "rwa-lending",
+            confirmation: "wait",
           });
-          const sendResult = await sorobanServer.sendTransaction(
-            TransactionBuilder.fromXDR(signedDeposit.signedTxXdr, passphrase)
-          );
-          await waitForTransaction(sendResult.hash, sorobanServer);
+          if (result.status !== "success") {
+            throw new Error(
+              result.status === "contract_error"
+                ? result.error.message
+                : result.status === "network_error"
+                  ? result.message
+                  : "Transaction cancelled"
+            );
+          }
         } else {
           if (!selectedPool.bTokenRate)
             throw new Error("Unable to calculate bTokens. Please try again.");
@@ -242,14 +245,23 @@ export function useLend() {
             lendingContractId
           );
 
-          const signedWithdraw = await signTransaction(withdrawXdr, {
+          const result = await executeTransaction({
+            xdr: withdrawXdr,
+            signTransaction,
             networkPassphrase: passphrase,
             address,
+            contractName: "rwa-lending",
+            confirmation: "wait",
           });
-          const sendResult = await sorobanServer.sendTransaction(
-            TransactionBuilder.fromXDR(signedWithdraw.signedTxXdr, passphrase)
-          );
-          await waitForTransaction(sendResult.hash, sorobanServer);
+          if (result.status !== "success") {
+            throw new Error(
+              result.status === "contract_error"
+                ? result.error.message
+                : result.status === "network_error"
+                  ? result.message
+                  : "Transaction cancelled"
+            );
+          }
         }
 
         await loadBTokenBalance();

--- a/apps/web-app/src/features/vault/hooks/useVaultAction.ts
+++ b/apps/web-app/src/features/vault/hooks/useVaultAction.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
-import { rpc } from "@stellar/stellar-sdk";
+import { Networks } from "@stellar/stellar-sdk";
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
 import { useWallet } from "@/hooks/useWallet";
 import { useToast } from "@/hooks/useToast";
@@ -12,11 +11,8 @@ import {
   networkPassphrase,
   allowHttpForSoroban,
 } from "@/lib/constants/network";
-import {
-  rpcUrl as configRpcUrl,
-  stellarNetwork,
-} from "@/lib/config/stellar.config";
 import { extractContractErrorOrNull } from "@/lib/helpers/stellar/contractErrors";
+import { executeTransaction } from "@/lib/helpers/stellar/executeTransaction";
 import { toSmallestUnit } from "@/lib/helpers/tokenUtils";
 import { useVaultBalance } from "./useVaultBalance";
 import { useVaultData } from "./useVaultData";
@@ -26,32 +22,6 @@ const VAULT_CONTRACT_ID =
   "CBHGX6TCHHVYJ7P3UZS7WI5TRAAA7GQA2L2Y7P2LCPIXWWD5FKDF2Z5S";
 
 const SLIPPAGE = 0.01;
-
-/**
- * Signs and submits a simulated AssembledTransaction by:
- * 1. Getting the XDR (already includes simulation auth entries)
- * 2. Signing with the user's wallet (Freighter handles Soroban auth in the XDR)
- * 3. Submitting via rpc.Server
- *
- * Bypasses SDK's signAndSend() which crashes on .switch() in some v14 builds.
- */
-async function signAndSubmit(
-  xdr: string,
-  passphrase: string,
-  signFn: (
-    xdr: string,
-    opts: { networkPassphrase: string; address?: string }
-  ) => Promise<{ signedTxXdr: string }>,
-  address: string
-) {
-  const server = new rpc.Server(configRpcUrl, {
-    allowHttp: stellarNetwork === "LOCAL",
-  });
-  const signed = await signFn(xdr, { networkPassphrase: passphrase, address });
-  return server.sendTransaction(
-    TransactionBuilder.fromXDR(signed.signedTxXdr, passphrase)
-  );
-}
 
 export function useVaultAction() {
   const [isLoading, setIsLoading] = useState(false);
@@ -82,6 +52,29 @@ export function useVaultAction() {
     [addNotification]
   );
 
+  const submitVaultTransaction = useCallback(
+    async (xdr: string, passphrase: string): Promise<boolean> => {
+      const result = await executeTransaction({
+        xdr,
+        signTransaction,
+        networkPassphrase: passphrase,
+        address: address!,
+        confirmation: "none",
+      });
+
+      if (result.status === "success") return true;
+      if (result.status === "user_rejected") return false;
+
+      const msg =
+        result.status === "contract_error"
+          ? result.error.message
+          : result.message;
+      showError(msg);
+      return false;
+    },
+    [address, signTransaction, showError]
+  );
+
   const handleDeposit = useCallback(
     async (amount: string) => {
       if (!address || !amount || parseFloat(amount) <= 0) return;
@@ -90,7 +83,6 @@ export function useVaultAction() {
       try {
         const passphrase = walletPassphrase || Networks.TESTNET;
 
-        // Client needs publicKey so simulation uses the real user account
         const client = new DefindexVaultClient({
           contractId: VAULT_CONTRACT_ID,
           rpcUrl,
@@ -100,14 +92,11 @@ export function useVaultAction() {
         });
 
         const amountBigInt = toSmallestUnit(amount, 7);
-        // SLIPPAGE is a decimal fraction (0.01 = 1%). Scale it string-safely (7 decimals)
-        // so there is no float multiplication.
         const SLIPPAGE_SCALE = 10_000_000n;
-        const slippageScaled = toSmallestUnit(String(SLIPPAGE), 7); // 0.01 -> 100000n
+        const slippageScaled = toSmallestUnit(String(SLIPPAGE), 7);
         const minAmount =
           amountBigInt - (amountBigInt * slippageScaled) / SLIPPAGE_SCALE;
 
-        // Simulate — the resulting XDR already includes Soroban auth entries
         const depositTx = await client.deposit({
           amounts_desired: [amountBigInt],
           amounts_min: [minAmount],
@@ -115,13 +104,11 @@ export function useVaultAction() {
           invest: false,
         });
 
-        // Sign + submit the simulated XDR directly (Freighter handles auth entries)
-        await signAndSubmit(
+        const submitted = await submitVaultTransaction(
           depositTx.toXDR(),
-          passphrase,
-          signTransaction,
-          address
+          passphrase
         );
+        if (!submitted) return;
 
         await new Promise((r) => setTimeout(r, 3000));
         await Promise.all([refetchBalance(), refetchVaultData()]);
@@ -145,7 +132,7 @@ export function useVaultAction() {
     [
       address,
       walletPassphrase,
-      signTransaction,
+      submitVaultTransaction,
       refetchBalance,
       refetchVaultData,
       showError,
@@ -177,12 +164,11 @@ export function useVaultAction() {
           from: address,
         });
 
-        await signAndSubmit(
+        const submitted = await submitVaultTransaction(
           withdrawTx.toXDR(),
-          passphrase,
-          signTransaction,
-          address
+          passphrase
         );
+        if (!submitted) return;
 
         await new Promise((r) => setTimeout(r, 3000));
         await Promise.all([refetchBalance(), refetchVaultData()]);
@@ -206,7 +192,7 @@ export function useVaultAction() {
     [
       address,
       walletPassphrase,
-      signTransaction,
+      submitVaultTransaction,
       refetchBalance,
       refetchVaultData,
       showError,

--- a/apps/web-app/src/lib/constants/faucet.ts
+++ b/apps/web-app/src/lib/constants/faucet.ts
@@ -4,10 +4,10 @@ import {
   nativeToScVal,
   Contract,
   TransactionBuilder,
-  rpc,
   Horizon,
 } from "@stellar/stellar-sdk";
 import { clientEnv } from "@/lib/env.client";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 export interface FaucetToken {
   symbol: string;
   contractId: string;
@@ -138,7 +138,7 @@ export async function buildFaucetTransaction(
     .setTimeout(300)
     .build();
 
-  const sorobanServer = new rpc.Server(sorobanRpcUrl, { allowHttp: true });
+  const sorobanServer = getSorobanServer(sorobanRpcUrl);
   const prepared = await sorobanServer.prepareTransaction(tx);
 
   return prepared.toXDR();

--- a/apps/web-app/src/lib/env.server.ts
+++ b/apps/web-app/src/lib/env.server.ts
@@ -30,7 +30,7 @@ const serverSchema = z.object({
   // authorizes a repay/withdraw itself, only wraps an already user-signed
   // unwind-tranche transaction with a fresh fee. See lib/coordinator/execute.ts.
   LEVERAGE_COORDINATOR_SECRET_KEY: z.string().optional(),
-  // Job ledger persistence (server-only) — see lib/jobs
+  // Job ledger + event platform persistence (server-only) — see lib/jobs, lib/event-platform
   SUPABASE_URL: z.string().url().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 
@@ -48,8 +48,6 @@ const serverSchema = z.object({
   ALFREDPAY_BASE_URL: z.string().url().optional(),
 
   // Event platform (outbox/queue/delivery) — server-only
-  SUPABASE_URL: z.string().url().optional(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 const parsed = serverSchema.safeParse({
@@ -64,8 +62,6 @@ const parsed = serverSchema.safeParse({
   ALFREDPAY_API_KEY: process.env.ALFREDPAY_API_KEY,
   ALFREDPAY_API_SECRET: process.env.ALFREDPAY_API_SECRET,
   ALFREDPAY_BASE_URL: process.env.ALFREDPAY_BASE_URL,
-  SUPABASE_URL: process.env.SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
 });
 
 if (!parsed.success) {

--- a/apps/web-app/src/lib/helpers/stellar/__tests__/contractErrors.test.ts
+++ b/apps/web-app/src/lib/helpers/stellar/__tests__/contractErrors.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mapContractError } from "../contractErrors";
+
+describe("mapContractError", () => {
+  it("maps #72 to withdrawal_queue_not_expired", () => {
+    const err = new Error("HostError: Error(Contract, #72)");
+    const mapped = mapContractError(err, "rwa-lending");
+    expect(mapped).toEqual({
+      kind: "withdrawal_queue_not_expired",
+      message: "Withdrawal queue has not expired yet",
+    });
+  });
+
+  it("maps InsufficientBalance (#1) to insufficient_balance", () => {
+    const err = new Error("Error(Contract, #1)");
+    const mapped = mapContractError(err, "rwa-token");
+    expect(mapped?.kind).toBe("insufficient_balance");
+    expect(mapped?.message).toBe("Insufficient token balance");
+  });
+
+  it("maps Unauthorized to unauthorized", () => {
+    const err = new Error("HostError: Unauthorized access");
+    const mapped = mapContractError(err);
+    expect(mapped?.kind).toBe("unauthorized");
+  });
+
+  it("returns null for user cancellation", () => {
+    const err = new Error("User rejected the request");
+    expect(mapContractError(err)).toBeNull();
+  });
+
+  it("falls back to other for unmapped contract codes", () => {
+    const err = new Error("Error(Contract, #99)");
+    const mapped = mapContractError(err);
+    expect(mapped?.kind).toBe("other");
+    expect(mapped?.code).toBe(99);
+  });
+});

--- a/apps/web-app/src/lib/helpers/stellar/__tests__/executeTransaction.test.ts
+++ b/apps/web-app/src/lib/helpers/stellar/__tests__/executeTransaction.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  signTransactionMock,
+  sendTransactionMock,
+  pollTransactionMock,
+  waitForTransactionMock,
+  getSorobanServerMock,
+} = vi.hoisted(() => ({
+  signTransactionMock: vi.fn(),
+  sendTransactionMock: vi.fn(),
+  pollTransactionMock: vi.fn(),
+  waitForTransactionMock: vi.fn(),
+  getSorobanServerMock: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  TransactionBuilder: {
+    fromXDR: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock("../sorobanServer", () => ({
+  getSorobanServer: getSorobanServerMock,
+}));
+
+vi.mock("../waitForTransaction", () => ({
+  waitForTransaction: waitForTransactionMock,
+}));
+
+import { executeTransaction } from "../executeTransaction";
+
+const server = {
+  sendTransaction: sendTransactionMock,
+  pollTransaction: pollTransactionMock,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSorobanServerMock.mockReturnValue(server);
+  signTransactionMock.mockResolvedValue({ signedTxXdr: "SIGNED" });
+  sendTransactionMock.mockResolvedValue({ hash: "HASH123", status: "PENDING" });
+  waitForTransactionMock.mockResolvedValue({ status: "SUCCESS" });
+  pollTransactionMock.mockResolvedValue({ status: "SUCCESS" });
+});
+
+describe("executeTransaction", () => {
+  const baseOptions = {
+    xdr: "XDR",
+    signTransaction: signTransactionMock,
+    networkPassphrase: "Test SDF Network ; September 2015",
+    address: "GTEST",
+  };
+
+  it("returns success after wait confirmation", async () => {
+    const result = await executeTransaction(baseOptions);
+    expect(result).toEqual({
+      status: "success",
+      hash: "HASH123",
+      confirmation: { status: "SUCCESS" },
+    });
+    expect(waitForTransactionMock).toHaveBeenCalledWith(
+      "HASH123",
+      server,
+      undefined
+    );
+  });
+
+  it("returns success without confirmation when confirmation is none", async () => {
+    const result = await executeTransaction({
+      ...baseOptions,
+      confirmation: "none",
+    });
+    expect(result).toEqual({ status: "success", hash: "HASH123" });
+    expect(waitForTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns contract_error for on-chain contract failures", async () => {
+    waitForTransactionMock.mockRejectedValue(
+      new Error("HostError: Error(Contract, #72)")
+    );
+
+    const result = await executeTransaction({
+      ...baseOptions,
+      contractName: "rwa-lending",
+    });
+
+    expect(result.status).toBe("contract_error");
+    if (result.status === "contract_error") {
+      expect(result.error.kind).toBe("withdrawal_queue_not_expired");
+    }
+  });
+
+  it("returns network_error for submission ERROR status without contract mapping", async () => {
+    sendTransactionMock.mockResolvedValue({ hash: "HASH123", status: "ERROR" });
+
+    const result = await executeTransaction(baseOptions);
+    expect(result.status).toBe("network_error");
+  });
+
+  it("returns user_rejected when the wallet rejects signing", async () => {
+    signTransactionMock.mockRejectedValue(
+      new Error("User rejected the request")
+    );
+
+    const result = await executeTransaction(baseOptions);
+    expect(result).toEqual({ status: "user_rejected" });
+  });
+
+  it("uses poll confirmation when configured", async () => {
+    const result = await executeTransaction({
+      ...baseOptions,
+      confirmation: "poll",
+      pollOptions: { attempts: 30 },
+    });
+
+    expect(result.status).toBe("success");
+    expect(pollTransactionMock).toHaveBeenCalledWith("HASH123", {
+      attempts: 30,
+    });
+    expect(waitForTransactionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-app/src/lib/helpers/stellar/__tests__/sorobanServer.test.ts
+++ b/apps/web-app/src/lib/helpers/stellar/__tests__/sorobanServer.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { ServerMock, stellarNetworkMock } = vi.hoisted(() => {
+  const instances: Array<{ url: string; options: { allowHttp?: boolean } }> =
+    [];
+  class ServerMock {
+    url: string;
+    options: { allowHttp?: boolean };
+    constructor(url: string, options: { allowHttp?: boolean } = {}) {
+      this.url = url;
+      this.options = options;
+      instances.push({ url, options });
+    }
+  }
+  return {
+    ServerMock,
+    instances,
+    stellarNetworkMock: vi.fn(() => "TESTNET"),
+  };
+});
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  rpc: { Server: ServerMock },
+}));
+
+vi.mock("@/lib/config/stellar.config", () => ({
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  get stellarNetwork() {
+    return stellarNetworkMock();
+  },
+}));
+
+import { getSorobanServer, resetSorobanServerCache } from "../sorobanServer";
+
+beforeEach(() => {
+  resetSorobanServerCache();
+  stellarNetworkMock.mockReturnValue("TESTNET");
+});
+
+describe("getSorobanServer", () => {
+  it("returns a memoized singleton for the same URL", () => {
+    const a = getSorobanServer();
+    const b = getSorobanServer();
+    expect(a).toBe(b);
+  });
+
+  it("creates separate instances for different URLs", () => {
+    const defaultServer = getSorobanServer();
+    const customServer = getSorobanServer("https://custom-rpc.example");
+    expect(defaultServer).not.toBe(customServer);
+  });
+
+  it("sets allowHttp when stellarNetwork is LOCAL", () => {
+    stellarNetworkMock.mockReturnValue("LOCAL");
+    resetSorobanServerCache();
+    const server = getSorobanServer("http://localhost:8000/rpc");
+    expect(
+      (server as { options: { allowHttp?: boolean } }).options.allowHttp
+    ).toBe(true);
+  });
+
+  it("does not set allowHttp for non-LOCAL networks", () => {
+    const server = getSorobanServer();
+    expect(
+      (server as { options: { allowHttp?: boolean } }).options.allowHttp
+    ).toBe(false);
+  });
+});

--- a/apps/web-app/src/lib/helpers/stellar/contractErrors.ts
+++ b/apps/web-app/src/lib/helpers/stellar/contractErrors.ts
@@ -230,3 +230,102 @@ export function extractContractErrorOrNull(
 
   return extractContractError(error, contractName);
 }
+
+export type MappedContractError =
+  | { kind: "withdrawal_queue_not_expired"; message: string }
+  | { kind: "insufficient_balance"; message: string }
+  | { kind: "unauthorized"; message: string }
+  | { kind: "other"; message: string; code?: number };
+
+const WITHDRAWAL_QUEUE_NOT_EXPIRED_CODE = 72;
+
+const INSUFFICIENT_BALANCE_CODE_NAMES = new Set([
+  "InsufficientBalance",
+  "InsufficientPoolBalance",
+  "InsufficientLiquidity",
+  "InsufficientBTokenBalance",
+  "InsufficientDepositAmount",
+  "InsufficientWithdrawalBalance",
+  "InsufficientCollateral",
+  "InsufficientBorrowLimit",
+  "InsufficientDTokenBalance",
+  "InsufficientDebtToRepay",
+  "InsufficientBackstopDeposit",
+  "InsufficientAllowance",
+]);
+
+function extractNumericErrorCode(error: unknown): number | null {
+  if (!error) return null;
+  const errorString = String(error);
+  const match = errorString.match(/Error\(Contract,\s*#(\d+)\)/);
+  if (!match) return null;
+  return parseInt(match[1], 10);
+}
+
+/**
+ * Classifies a contract error into a typed discriminant for UI handling.
+ */
+export function mapContractError(
+  error: unknown,
+  contractName?: string
+): MappedContractError | null {
+  if (!error || isUserCancellationError(error)) return null;
+
+  const numericCode = extractNumericErrorCode(error);
+  const message = extractContractError(error, contractName);
+
+  if (numericCode === WITHDRAWAL_QUEUE_NOT_EXPIRED_CODE) {
+    return { kind: "withdrawal_queue_not_expired", message };
+  }
+
+  const inferredContract =
+    contractName || extractContractNameFromError(String(error));
+  if (numericCode != null && inferredContract) {
+    const contractError = getContractError(inferredContract, numericCode);
+    if (contractError) {
+      if (contractError.code === "WithdrawalQueueNotExpired") {
+        return { kind: "withdrawal_queue_not_expired", message };
+      }
+      if (
+        contractError.code === "Unauthorized" ||
+        contractError.code === "NotAuthorized"
+      ) {
+        return { kind: "unauthorized", message: contractError.message };
+      }
+      if (INSUFFICIENT_BALANCE_CODE_NAMES.has(contractError.code)) {
+        return { kind: "insufficient_balance", message };
+      }
+    }
+  }
+
+  if (numericCode != null && isValidErrorCode(numericCode)) {
+    const info = CONTRACT_ERRORS[numericCode];
+    if (info.code === "WithdrawalQueueNotExpired") {
+      return { kind: "withdrawal_queue_not_expired", message };
+    }
+    if (info.code === "Unauthorized") {
+      return { kind: "unauthorized", message };
+    }
+    if (INSUFFICIENT_BALANCE_CODE_NAMES.has(info.code)) {
+      return { kind: "insufficient_balance", message };
+    }
+    return { kind: "other", message, code: numericCode };
+  }
+
+  const errorString = String(error);
+  if (errorString.includes("WithdrawalQueueNotExpired")) {
+    return { kind: "withdrawal_queue_not_expired", message };
+  }
+  if (/\b(Unauthorized|NotAuthorized)\b/.test(errorString)) {
+    return { kind: "unauthorized", message };
+  }
+  if (/\bInsufficient\w*\b/.test(errorString)) {
+    return { kind: "insufficient_balance", message };
+  }
+
+  if (numericCode != null) {
+    return { kind: "other", message, code: numericCode };
+  }
+
+  return { kind: "other", message };
+}

--- a/apps/web-app/src/lib/helpers/stellar/executeTransaction.ts
+++ b/apps/web-app/src/lib/helpers/stellar/executeTransaction.ts
@@ -127,7 +127,7 @@ export async function executeTransaction(
       return { status: "contract_error", error: mapped };
     }
 
-    if (mapped?.kind !== "other") {
+    if (mapped && mapped.kind !== "other") {
       return { status: "contract_error", error: mapped };
     }
 

--- a/apps/web-app/src/lib/helpers/stellar/executeTransaction.ts
+++ b/apps/web-app/src/lib/helpers/stellar/executeTransaction.ts
@@ -1,0 +1,173 @@
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { getSorobanServer } from "./sorobanServer";
+import {
+  isUserCancellationError,
+  mapContractError,
+  type MappedContractError,
+} from "./contractErrors";
+import {
+  waitForTransaction,
+  type WaitForTransactionOptions,
+} from "./waitForTransaction";
+import type { SignTransactionFn } from "./transaction";
+
+export type ExecuteTransactionResult =
+  | { status: "success"; hash: string; confirmation?: unknown }
+  | { status: "contract_error"; error: MappedContractError }
+  | { status: "network_error"; message: string; cause?: unknown }
+  | { status: "user_rejected" };
+
+export interface ExecuteTransactionOptions {
+  xdr: string;
+  signTransaction: SignTransactionFn;
+  networkPassphrase: string;
+  address?: string;
+  contractName?: string;
+  rpcUrl?: string;
+  confirmation?: "wait" | "poll" | "none";
+  waitOptions?: WaitForTransactionOptions;
+  pollOptions?: { attempts?: number };
+}
+
+function isContractFailure(error: unknown): boolean {
+  if (!error) return false;
+  const str = String(error);
+  return (
+    str.includes("Error(Contract,") ||
+    str.includes("HostError:") ||
+    str.includes("simulation failed")
+  );
+}
+
+/**
+ * Signs, submits, and optionally confirms a Soroban transaction.
+ * Returns a typed result instead of throwing for expected failure modes.
+ */
+export async function executeTransaction(
+  options: ExecuteTransactionOptions
+): Promise<ExecuteTransactionResult> {
+  const {
+    xdr,
+    signTransaction,
+    networkPassphrase,
+    address,
+    contractName,
+    rpcUrl,
+    confirmation = "wait",
+    waitOptions,
+    pollOptions,
+  } = options;
+
+  try {
+    const signed = await signTransaction(xdr, {
+      networkPassphrase,
+      address,
+    });
+
+    const tx = TransactionBuilder.fromXDR(
+      signed.signedTxXdr,
+      networkPassphrase
+    );
+    const server = getSorobanServer(rpcUrl);
+    const sendResult = await server.sendTransaction(tx);
+
+    if (sendResult.status === "ERROR") {
+      return {
+        status: "network_error",
+        message: `Transaction submission failed with status ${sendResult.status}`,
+      };
+    }
+
+    const hash = sendResult.hash;
+
+    if (confirmation === "none") {
+      return { status: "success", hash };
+    }
+
+    if (confirmation === "poll") {
+      const confirmed = await server.pollTransaction(hash, {
+        attempts: pollOptions?.attempts ?? 30,
+      });
+      if (confirmed.status !== "SUCCESS") {
+        const mapped = mapContractError(
+          new Error(
+            confirmed.status === "FAILED"
+              ? "Transaction failed on-chain"
+              : "Transaction confirmation timeout"
+          ),
+          contractName
+        );
+        if (mapped) {
+          return { status: "contract_error", error: mapped };
+        }
+        return {
+          status: "network_error",
+          message:
+            confirmed.status === "FAILED"
+              ? "Transaction failed on-chain"
+              : "Transaction confirmation timeout",
+        };
+      }
+      return { status: "success", hash, confirmation: confirmed };
+    }
+
+    const confirmationResult = await waitForTransaction(
+      hash,
+      server,
+      waitOptions
+    );
+    return { status: "success", hash, confirmation: confirmationResult };
+  } catch (error) {
+    if (isUserCancellationError(error)) {
+      return { status: "user_rejected" };
+    }
+
+    const mapped = mapContractError(error, contractName);
+    if (mapped && isContractFailure(error)) {
+      return { status: "contract_error", error: mapped };
+    }
+
+    if (mapped?.kind !== "other") {
+      return { status: "contract_error", error: mapped };
+    }
+
+    const message =
+      error instanceof Error ? error.message : "An unexpected error occurred";
+
+    if (
+      message.toLowerCase().includes("network") ||
+      message.toLowerCase().includes("timeout") ||
+      error instanceof TypeError
+    ) {
+      return { status: "network_error", message, cause: error };
+    }
+
+    if (mapped) {
+      return { status: "contract_error", error: mapped };
+    }
+
+    return { status: "network_error", message, cause: error };
+  }
+}
+
+/** Submit a signed XDR without confirmation (for multi-phase transports). */
+export async function submitSignedTransaction(
+  signedXdr: string,
+  networkPassphrase: string,
+  rpcUrl?: string
+): Promise<{ hash: string }> {
+  const server = getSorobanServer(rpcUrl);
+  const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+  const result = await server.sendTransaction(tx);
+  return { hash: result.hash };
+}
+
+/** Confirm a previously submitted transaction hash. */
+export async function confirmTransactionHash(
+  hash: string,
+  rpcUrl?: string,
+  waitOptions?: WaitForTransactionOptions
+): Promise<unknown> {
+  const server = getSorobanServer(rpcUrl);
+  return waitForTransaction(hash, server, waitOptions);
+}

--- a/apps/web-app/src/lib/helpers/stellar/lending.ts
+++ b/apps/web-app/src/lib/helpers/stellar/lending.ts
@@ -16,11 +16,11 @@ import {
   rpcUrl,
   networkPassphrase,
   horizonUrl,
-  stellarNetwork,
   allowHttpForSoroban,
 } from "@/lib/constants/network";
 import { toSmallestUnit } from "../tokenUtils";
 import { extractContractError } from "./contractErrors";
+import { getSorobanServer } from "./sorobanServer";
 
 export const depositToPool = async (
   assetCode: string,
@@ -30,9 +30,7 @@ export const depositToPool = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -99,9 +97,7 @@ export const withdrawFromPool = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -166,9 +162,7 @@ export const addCollateral = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -231,9 +225,7 @@ export const removeCollateral = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -296,9 +288,7 @@ export const borrowFromPool = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -365,9 +355,7 @@ export const repayPool = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -431,9 +419,7 @@ export const getTokenBalance = async (
   walletAddress: string
 ): Promise<bigint> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const tokenContract = new Contract(tokenContractAddress);
 
@@ -660,9 +646,7 @@ export const depositToBackstop = async (
   backstopContractId: string = backstopNetworks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
@@ -722,9 +706,7 @@ export const initiateBackstopWithdrawal = async (
   backstopContractId: string = backstopNetworks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
@@ -784,9 +766,7 @@ export const withdrawFromBackstop = async (
   backstopContractId: string = backstopNetworks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const backstopContract = new Contract(backstopContractId);
 
@@ -926,9 +906,7 @@ export const createBadDebtAuction = async (
   contractId: string = networks.testnet.contractId
 ): Promise<string> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -999,9 +977,7 @@ export const buildFillBadDebtAuctionXdr = async (
   contractId: string = networks.testnet.contractId
 ): Promise<FillBadDebtAuctionResult> => {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, {
-      allowHttp: stellarNetwork === "LOCAL",
-    });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const lendingContract = new Contract(contractId);
 
@@ -1082,9 +1058,7 @@ export interface ActiveBadDebtAuction {
 export async function getActiveBadDebtAuctions(
   contractId: string
 ): Promise<ActiveBadDebtAuction[]> {
-  const sorobanServer = new rpc.Server(rpcUrl, {
-    allowHttp: stellarNetwork === "LOCAL",
-  });
+  const sorobanServer = getSorobanServer(rpcUrl);
 
   const { sequence: currentLedger } = await sorobanServer.getLatestLedger();
   // Look back enough to cover the full auction duration plus some buffer

--- a/apps/web-app/src/lib/helpers/stellar/sorobanBalance.ts
+++ b/apps/web-app/src/lib/helpers/stellar/sorobanBalance.ts
@@ -8,6 +8,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { rpcUrl, networkPassphrase, horizonUrl } from "@/lib/constants/network";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
+import { getSorobanServer } from "./sorobanServer";
 
 export async function getTokenBalanceFromContract(
   contractAddress: string,
@@ -15,7 +16,7 @@ export async function getTokenBalanceFromContract(
   decimals: number = 7
 ): Promise<string> {
   try {
-    const sorobanServer = new rpc.Server(rpcUrl, { allowHttp: true });
+    const sorobanServer = getSorobanServer(rpcUrl);
     const horizonServer = new Horizon.Server(horizonUrl);
     const contract = new Contract(contractAddress);
 

--- a/apps/web-app/src/lib/helpers/stellar/sorobanBalances.ts
+++ b/apps/web-app/src/lib/helpers/stellar/sorobanBalances.ts
@@ -8,6 +8,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { getFaucetTokens } from "@/lib/constants/faucet";
 import { fromSmallestUnit } from "@/lib/helpers/tokenUtils";
+import { getSorobanServer } from "./sorobanServer";
 
 export interface SorobanTokenBalance {
   contractId: string;
@@ -64,7 +65,7 @@ export async function fetchSorobanTokenBalances(
   passphrase: string
 ): Promise<SorobanTokenBalance[]> {
   const tokens = getFaucetTokens();
-  const sorobanServer = new rpc.Server(sorobanRpcUrl, { allowHttp: true });
+  const sorobanServer = getSorobanServer(sorobanRpcUrl);
   const horizonServer = new Horizon.Server(stellarHorizonUrl);
 
   const results = await Promise.allSettled(

--- a/apps/web-app/src/lib/helpers/stellar/sorobanServer.ts
+++ b/apps/web-app/src/lib/helpers/stellar/sorobanServer.ts
@@ -1,0 +1,26 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { rpcUrl, stellarNetwork } from "@/lib/config/stellar.config";
+
+const serverCache = new Map<string, rpc.Server>();
+
+function resolveAllowHttp(): boolean {
+  return stellarNetwork === "LOCAL";
+}
+
+/**
+ * Returns a memoized Soroban RPC client for the given URL (defaults to app config).
+ * Only this module constructs `new rpc.Server`.
+ */
+export function getSorobanServer(url: string = rpcUrl): rpc.Server {
+  const cached = serverCache.get(url);
+  if (cached) return cached;
+
+  const server = new rpc.Server(url, { allowHttp: resolveAllowHttp() });
+  serverCache.set(url, server);
+  return server;
+}
+
+/** Clears the memoized server cache (for tests). */
+export function resetSorobanServerCache(): void {
+  serverCache.clear();
+}

--- a/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
+++ b/apps/web-app/src/lib/helpers/stellar/soroswap/quotes.ts
@@ -36,6 +36,7 @@ import type {
   PoolInfo,
   GetPoolRequest,
 } from "../../../types/soroswapTypes";
+import { getSorobanServer } from "../sorobanServer";
 
 const SOROSWAP_API_URL = "https://api.soroswap.finance";
 
@@ -81,7 +82,7 @@ const getDirectPoolQuote = async (
     throw new Error("Soroswap router or factory not found for this network");
   }
 
-  const server = new rpc.Server(rpcUrl);
+  const server = getSorobanServer(rpcUrl);
   const dummyAccount = new Account(Keypair.random().publicKey(), "0");
 
   const factory = new Contract(factoryAddress);
@@ -443,7 +444,7 @@ export const buildTransaction = async (
         );
       }
 
-      const server = new rpc.Server(rpcUrl);
+      const server = getSorobanServer(rpcUrl);
       const account = await server.getAccount(request.from);
       const router = new Contract(routerAddress);
       const deadline = BigInt(Math.floor(Date.now() / 1000) + 300);

--- a/apps/web-app/src/lib/helpers/stellar/transaction.ts
+++ b/apps/web-app/src/lib/helpers/stellar/transaction.ts
@@ -1,5 +1,5 @@
-import { TransactionBuilder, rpc } from "@stellar/stellar-sdk";
-import { stellarNetwork } from "@/lib/constants/network";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { getSorobanServer } from "./sorobanServer";
 
 const PENDING_WAIT_MS = 5000;
 
@@ -26,9 +26,7 @@ export async function signAndSendTransaction(
     signed.signedTxXdr,
     options.networkPassphrase
   );
-  const sorobanServer = new rpc.Server(options.rpcUrl, {
-    allowHttp: stellarNetwork === "LOCAL",
-  });
+  const sorobanServer = getSorobanServer(options.rpcUrl);
   const result = await sorobanServer.sendTransaction(tx);
 
   if (options.waitForPending !== false && result.status === "PENDING") {

--- a/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
@@ -5,7 +5,7 @@ import {
   TokenMetadata,
   type Request,
 } from "@blend-capital/blend-sdk";
-import { TransactionBuilder, rpc, xdr, Horizon } from "@stellar/stellar-sdk";
+import { TransactionBuilder, xdr, Horizon } from "@stellar/stellar-sdk";
 
 import { rpcUrl, networkPassphrase, horizonUrl } from "@/lib/constants/network";
 import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";

--- a/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
+++ b/apps/web-app/src/lib/orchestrator/adapters/BlendPoolAdapter.ts
@@ -8,6 +8,7 @@ import {
 import { TransactionBuilder, rpc, xdr, Horizon } from "@stellar/stellar-sdk";
 
 import { rpcUrl, networkPassphrase, horizonUrl } from "@/lib/constants/network";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 
 import type { BasePoolAdapter } from "../types/adapter.types";
 import type {
@@ -381,7 +382,7 @@ export class BlendPoolAdapter implements BasePoolAdapter {
       .setTimeout(300)
       .build();
 
-    const server = new rpc.Server(rpcUrl, { allowHttp: true });
+    const server = getSorobanServer(rpcUrl);
     const prepared = await server.prepareTransaction(tx);
 
     return {

--- a/apps/web-app/src/lib/orchestrator/hooks/usePoolAction.ts
+++ b/apps/web-app/src/lib/orchestrator/hooks/usePoolAction.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { rpc, TransactionBuilder } from "@stellar/stellar-sdk";
 import { useWallet } from "@/hooks/useWallet";
 import { useToast } from "@/hooks/useToast";
-import { rpcUrl } from "@/lib/constants/network";
 import { isUserCancellationError } from "@/lib/helpers/stellar/contractErrors";
+import { executeTransaction } from "@/lib/helpers/stellar/executeTransaction";
 import { orchestrator } from "../core/Orchestrator";
 import { POOLS_QUERY_KEY } from "./usePools";
 import type { PoolAction, TransactionResult } from "../types/pool.types";
@@ -70,36 +69,25 @@ export function usePoolAction() {
           throw new Error(`Unsupported action: ${action}`);
       }
 
-      const signed = await signTransaction(result.xdr, {
+      const txResult = await executeTransaction({
+        xdr: result.xdr,
+        signTransaction,
         networkPassphrase: result.networkPassphrase,
+        address,
+        confirmation: "poll",
+        pollOptions: { attempts: 30 },
       });
 
-      const signedXdr =
-        typeof signed === "string"
-          ? signed
-          : ((signed as { signedTxXdr?: string }).signedTxXdr ?? "");
-
-      const server = new rpc.Server(rpcUrl, { allowHttp: true });
-      const tx = TransactionBuilder.fromXDR(
-        signedXdr,
-        result.networkPassphrase
-      );
-      const txResult = await server.sendTransaction(tx);
-
-      if (txResult.status === "ERROR") {
-        throw new Error(`Transaction failed: ${txResult.status}`);
+      if (txResult.status === "user_rejected") {
+        throw new Error("Transaction cancelled");
+      }
+      if (txResult.status === "contract_error") {
+        throw new Error(txResult.error.message);
+      }
+      if (txResult.status === "network_error") {
+        throw new Error(txResult.message);
       }
 
-      const confirmed = await server.pollTransaction(txResult.hash, {
-        attempts: 30,
-      });
-      if (confirmed.status !== "SUCCESS") {
-        throw new Error(
-          confirmed.status === "FAILED"
-            ? "Transaction failed on-chain"
-            : "Transaction confirmation timeout"
-        );
-      }
       return txResult.hash;
     },
 

--- a/apps/web-app/src/lib/services/lending.service.ts
+++ b/apps/web-app/src/lib/services/lending.service.ts
@@ -41,6 +41,7 @@ import {
   buildFillBadDebtAuctionXdr,
 } from "../helpers/stellar/lending";
 import { extractContractError } from "../helpers/stellar/contractErrors";
+import { getSorobanServer } from "../helpers/stellar/sorobanServer";
 
 type LendingOperationResult = { xdr: string; error?: string };
 type CollateralOperationResult = {
@@ -63,7 +64,7 @@ export class LendingService {
   private lendingClient: RwaLendingClient;
 
   constructor() {
-    this.sorobanServer = new rpc.Server(rpcUrl, { allowHttp: true });
+    this.sorobanServer = getSorobanServer(rpcUrl);
     this.horizonServer = new Horizon.Server(horizonUrl, {
       allowHttp: allowHttpForHorizon,
     });

--- a/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
@@ -52,6 +52,13 @@ vi.mock("@stellar/stellar-sdk", () => ({
   rpc: { Server: ServerMock },
   TransactionBuilder: { fromXDR: vi.fn() },
 }));
+vi.mock("@/lib/helpers/stellar/executeTransaction", () => ({
+  submitSignedTransaction: vi.fn(),
+  confirmTransactionHash: vi.fn(),
+}));
+vi.mock("@/lib/helpers/stellar/sorobanServer", () => ({
+  getSorobanServer: vi.fn(),
+}));
 vi.mock("@/lib/helpers/stellar/soroswap", () => ({
   sendTransaction: vi.fn(),
   getQuote: vi.fn(),

--- a/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
+++ b/apps/web-app/src/lib/strategy/__tests__/hooks.test.ts
@@ -65,9 +65,6 @@ vi.mock("@/lib/helpers/stellar/soroswap", () => ({
   buildTransaction: vi.fn(),
   getAvailableTokens: vi.fn(() => ({})),
 }));
-vi.mock("@/lib/helpers/stellar/waitForTransaction", () => ({
-  waitForTransaction: vi.fn(),
-}));
 vi.mock("../engine", () => ({
   validateStrategy: vi.fn(),
   simulateStrategy: simulateStrategyMock,

--- a/apps/web-app/src/lib/strategy/hooks.ts
+++ b/apps/web-app/src/lib/strategy/hooks.ts
@@ -2,11 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { rpc, TransactionBuilder } from "@stellar/stellar-sdk";
+import { rpc } from "@stellar/stellar-sdk";
 import { useWallet } from "@/hooks/useWallet";
-import { rpcUrl, stellarNetwork } from "@/lib/constants/network";
 import { sendTransaction as soroswapSendTransaction } from "@/lib/helpers/stellar/soroswap";
-import { waitForTransaction } from "@/lib/helpers/stellar/waitForTransaction";
+import {
+  confirmTransactionHash,
+  submitSignedTransaction,
+} from "@/lib/helpers/stellar/executeTransaction";
+import { getSorobanServer } from "@/lib/helpers/stellar/sorobanServer";
 import type { MappedBalances } from "@/lib/helpers/stellar/wallet";
 import { strategyStepRegistry } from "./registry";
 import "./definitions";
@@ -167,18 +170,10 @@ export function useStrategyPersistence() {
 function makeRpcTransport(): TransportAdapter {
   return {
     async submit(signedXdr, networkPassphrase) {
-      const server = new rpc.Server(rpcUrl, {
-        allowHttp: stellarNetwork === "LOCAL",
-      });
-      const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
-      const result = await server.sendTransaction(tx);
-      return { hash: result.hash };
+      return submitSignedTransaction(signedXdr, networkPassphrase);
     },
     async confirm(hash) {
-      const server = new rpc.Server(rpcUrl, {
-        allowHttp: stellarNetwork === "LOCAL",
-      });
-      return waitForTransaction(hash, server);
+      return confirmTransactionHash(hash);
     },
   };
 }
@@ -193,10 +188,7 @@ function makeSoroswapTransport(): TransportAdapter {
       return { hash: result.txHash };
     },
     async confirm(hash) {
-      const server = new rpc.Server(rpcUrl, {
-        allowHttp: stellarNetwork === "LOCAL",
-      });
-      return waitForTransaction(hash, server);
+      return confirmTransactionHash(hash);
     },
   };
 }
@@ -284,9 +276,7 @@ export function useExecutionRecovery() {
     setIsChecking(true);
     try {
       const unfinished = findResumableExecutions(address);
-      const server = new rpc.Server(rpcUrl, {
-        allowHttp: stellarNetwork === "LOCAL",
-      });
+      const server = getSorobanServer();
       const reconciled = await Promise.all(
         unfinished.map((record) =>
           reconcileExecution(record, {

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
+  test: {
+    setupFiles: ["./vitest.setup.ts"],
+  },
   oxc: {
     jsx: { runtime: "automatic" },
   },

--- a/apps/web-app/vitest.setup.ts
+++ b/apps/web-app/vitest.setup.ts
@@ -1,0 +1,47 @@
+class LocalStorageMock implements Storage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: new LocalStorageMock(),
+  writable: true,
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "window", {
+  value: globalThis,
+  writable: true,
+  configurable: true,
+});
+
+process.env.NEXT_PUBLIC_STELLAR_NETWORK ??= "TESTNET";
+process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??=
+  "Test SDF Network ; September 2015";
+process.env.NEXT_PUBLIC_STELLAR_RPC_URL ??=
+  "https://soroban-testnet.stellar.org";
+process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??=
+  "https://horizon-testnet.stellar.org";


### PR DESCRIPTION
## Summary

- Introduce shared Soroban infrastructure: `getSorobanServer()` (memoized RPC accessor) and `executeTransaction()` (sign → submit → confirm with typed success, contract, network, and user-rejection results). `waitForTransaction` is now only invoked from the execution primitive.
- Migrate all Soroban write paths and remaining `rpc.Server` construction sites under `apps/web-app/src` onto these helpers, including `useLend`, `useVaultAction`, `usePoolAction`, strategy RPC transport, shared read helpers, API routes, and `BlendPoolAdapter`. Behaviour at the five migrated call sites is preserved (vault still uses `confirmation: "none"` + 3s delay; pool actions still poll with 30 attempts).
- Fix six backstop defects: reactive queue expiry via `useCountdown`, pre-sign amount validation, consistent typed contract errors, shared constants, `BackstopAmountInput` adoption, and input clearing only on success. Add tests for the primitive, accessor, error mapping, validation, and backstop behaviours.

## Behaviour preserved

- `useLend` Neko deposit/withdraw path (aggregated orchestrator path unchanged)
- `useVaultAction` submit-without-confirm + 3s refetch delay
- `usePoolAction` poll confirmation (30 attempts) and toast handling
- Strategy execution engine transport contract (submit/confirm split via `submitSignedTransaction` / `confirmTransactionHash`)
- Existing test suites: `useLend.test.ts`, `useVaultInvest.test.ts`, `BlendPoolAdapter.test.ts`, and all seven `lib/strategy/__tests__/` files (162 tests in the migration scope)

## Behaviour changed (backstop only)

- Withdraw button and `QueueCountdown` stay in sync when the queue period elapses while the page is open
- Deposit/queue/withdraw amounts validated against wallet, active, and queued balances before signing
- Empty, invalid, or over-limit amounts show a toast and preserve the input
- Contract errors (including queue-not-expired) mapped consistently via `mapContractError` — no raw `#72` string matching

## How verified

```bash
# rpc.Server only in accessor
rg 'new rpc\.Server' apps/web-app/src

# waitForTransaction only in primitive + its module
rg 'waitForTransaction' apps/web-app/src --glob '!**/waitForTransaction.ts'

# Backstop clean
rg '#72|String\(err\)\.includes' apps/web-app/src/features/backstop

# Migration-scoped tests (162 passing)
npm run test -- \
  src/features/lending/hooks/__tests__/useLend.test.ts \
  src/features/vault/hooks/__tests__/useVaultInvest.test.ts \
  src/lib/orchestrator/adapters/__tests__/BlendPoolAdapter.test.ts \
  src/lib/strategy/__tests__/ \
  src/lib/helpers/stellar/__tests__/ \
  src/features/backstop/
```

## Commits (14 atomic)

1. `feat(stellar): add memoized getSorobanServer accessor`
2. `feat(stellar): add typed contract error mapping`
3. `feat(stellar): add executeTransaction primitive`
4. `refactor(stellar): migrate shared read helpers to getSorobanServer`
5. `refactor(api): migrate API routes to getSorobanServer`
6. `refactor(orchestrator): use getSorobanServer in BlendPoolAdapter`
7. `refactor(lending): migrate useLend to executeTransaction`
8. `refactor(vault): migrate useVaultAction to executeTransaction`
9. `refactor(orchestrator): migrate usePoolAction to executeTransaction`
10. `refactor(strategy): migrate RPC transport to executeTransaction`
11. `feat(backstop): add constants and amount validation`
12. `fix(backstop): reactive queue expiry and migrate hook to primitive`
13. `fix(backstop): adopt BackstopAmountInput and fix submit flow`
14. `chore(test): add vitest setup for env and localStorage`

## Test plan

- [x] Connect wallet and deposit/withdraw on a Neko lending pool (direct path, not orchestrator)
- [x] Execute a Blend pool action via orchestrator (deposit or withdraw)
- [x] Vault deposit and withdraw — confirm 3s delay behaviour unchanged
- [x] Run a multi-step strategy execution and confirm resume/recovery still works
- [x] Backstop: deposit over wallet balance → error toast, input preserved
- [x] Backstop: queue withdrawal, wait for countdown → withdraw button enables without reload
- [x] Backstop: attempt withdraw before queue expires → typed error message
- [x] CI: lint, typecheck, test


Closes #293 