### PR TITLE
Feat/event platform

### DIFF
--- a/apps/web-app/.env.example
+++ b/apps/web-app/.env.example
@@ -30,3 +30,7 @@ ALFREDPAY_BASE_URL=https://api-service-co.alfredpay.app/api/v1/third-party-servi
 ALFREDPAY_WEBHOOK_SECRET=
 
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
+
+# Event platform — server-only, never expose to client
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@blend-capital/blend-sdk": "^3.2.2",
     "@creit.tech/stellar-wallets-kit": "^2.1.0",
+    "@supabase/supabase-js": "^2.49.4",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^5.2.2",

--- a/apps/web-app/src/app/api/auth/challenge/route.ts
+++ b/apps/web-app/src/app/api/auth/challenge/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@/lib/validation/parse";
+import { StellarAddressSchema } from "@/lib/validation/schemas";
+import { createChallenge } from "@/lib/event-platform/auth/challenge";
+
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({ walletAddress: StellarAddressSchema });
+
+export async function POST(request: NextRequest) {
+  const parsed = await parseJsonBody(request, BodySchema);
+  if ("error" in parsed) return parsed.error;
+
+  try {
+    const challenge = await createChallenge(parsed.data.walletAddress);
+    return NextResponse.json(challenge);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-app/src/app/api/auth/verify/route.ts
+++ b/apps/web-app/src/app/api/auth/verify/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@/lib/validation/parse";
+import { StellarAddressSchema } from "@/lib/validation/schemas";
+import { verifyChallenge } from "@/lib/event-platform/auth/challenge";
+import {
+  createSession,
+  SESSION_COOKIE_NAME,
+  SESSION_COOKIE_MAX_AGE_SECONDS,
+} from "@/lib/event-platform/auth/session";
+
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  walletAddress: StellarAddressSchema,
+  message: z.string().min(1),
+  signature: z.string().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  const parsed = await parseJsonBody(request, BodySchema);
+  if ("error" in parsed) return parsed.error;
+
+  try {
+    const { walletAddress, message, signature } = parsed.data;
+    const valid = await verifyChallenge(walletAddress, message, signature);
+    if (!valid) {
+      return NextResponse.json(
+        { error: "Invalid or expired signature" },
+        { status: 401 }
+      );
+    }
+
+    const token = await createSession(walletAddress);
+    const response = NextResponse.json({ ok: true, walletAddress });
+    response.cookies.set(SESSION_COOKIE_NAME, token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: SESSION_COOKIE_MAX_AGE_SECONDS,
+    });
+    return response;
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
+++ b/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import type { RebalancePlan } from "@/features/automation/types/automation";
+
+const raiseEventMock = vi.fn();
+vi.mock("@/lib/event-platform/outbox", () => ({
+  raiseEvent: (...args: unknown[]) => raiseEventMock(...args),
+}));
+
+const { POST } = await import("../route");
+
+function seedPlan(overrides: Partial<RebalancePlan> = {}): RebalancePlan {
+  const plan: RebalancePlan = {
+    id: "plan-1",
+    strategyId: "strategy-1",
+    createdAt: Date.now(),
+    triggerReason: "test",
+    currentBlendedNetApyBps: 0,
+    proposedBlendedNetApyBps: 0,
+    improvementBps: 0,
+    estimatedSlippageBps: 0,
+    estimatedFeeUsd: 0,
+    estimatedGasUsd: 0,
+    projectedEarningsDeltaUsd: { d30: 0, d90: 0, d365: 0 },
+    targets: [],
+    steps: [],
+    status: "draft",
+    ...overrides,
+  };
+  // Never reassign globalThis.__automationPlans here: the route module
+  // captured a const reference to the Map at import time, so a replacement
+  // object would become invisible to it. Mutate the existing map instead.
+  globalThis.__automationPlans!.set(plan.id, plan);
+  return plan;
+}
+
+function post(body: Record<string, unknown>) {
+  return POST(
+    new NextRequest("http://localhost/api/automation/execute", {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+describe("POST /api/automation/execute — failure event wiring", () => {
+  beforeEach(() => {
+    globalThis.__automationPlans ??= new Map();
+    globalThis.__automationPlans!.clear();
+    raiseEventMock.mockReset();
+  });
+
+  it("does not raise an event on a normal confirm (no failure occurred)", async () => {
+    seedPlan();
+    const res = await post({
+      planId: "plan-1",
+      strategyId: "strategy-1",
+      action: "confirm",
+    });
+    expect(res.status).toBe(200);
+    expect(raiseEventMock).not.toHaveBeenCalled();
+  });
+
+  it("does not raise an event on cancel", async () => {
+    seedPlan();
+    await post({
+      planId: "plan-1",
+      strategyId: "strategy-1",
+      action: "cancel",
+    });
+    expect(raiseEventMock).not.toHaveBeenCalled();
+  });
+
+  it("raises exactly one platform event, attributed to the plan and wallet, when a plan is already failed", async () => {
+    // Simulates the future step-execution worker (see the route's own TODO)
+    // having already marked this plan failed before confirm/cancel runs.
+    seedPlan({ status: "failed" });
+
+    await post({
+      planId: "plan-1",
+      strategyId: "strategy-1",
+      action: "cancel",
+      walletAddress: "GWALLET1",
+    });
+
+    expect(raiseEventMock).toHaveBeenCalledTimes(1);
+    expect(raiseEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "automation",
+        walletAddress: "GWALLET1",
+        dedupeKey: "plan-failed:plan-1",
+        eventType: "plan-failed",
+        severity: "critical",
+        payload: expect.objectContaining({
+          planId: "plan-1",
+          strategyId: "strategy-1",
+        }),
+      })
+    );
+  });
+
+  it("skips raising when no walletAddress is supplied (plan has no owner concept today)", async () => {
+    seedPlan({ status: "failed" });
+    await post({
+      planId: "plan-1",
+      strategyId: "strategy-1",
+      action: "cancel",
+    });
+    expect(raiseEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-app/src/app/api/automation/execute/route.ts
+++ b/apps/web-app/src/app/api/automation/execute/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { RebalancePlan } from "@/features/automation/types/automation";
+import { raiseEvent } from "@/lib/event-platform/outbox";
 
 // In-memory plan store for demo
 declare global {
@@ -20,16 +21,41 @@ export async function GET(req: NextRequest) {
   return NextResponse.json(plans);
 }
 
+// Raises a durable event whenever a plan lands in "failed" — inert today
+// (neither `confirm` nor `cancel` below produce that status; this stub has
+// no real step-execution yet, per the "kick off step execution via a queue
+// worker" TODO above), but it fires automatically the moment that worker
+// exists, with no further change needed here. `walletAddress` is optional
+// because RebalancePlan has no owner field at all in this stub — the client
+// may supply it in the request body; without it, a failure has no wallet to
+// notify and is skipped (see the PR description's known limitations).
+async function raiseFailureEventIfNeeded(
+  plan: RebalancePlan,
+  walletAddress: string | undefined
+): Promise<void> {
+  if (plan.status !== "failed" || !walletAddress) return;
+  await raiseEvent({
+    source: "automation",
+    walletAddress,
+    dedupeKey: `plan-failed:${plan.id}`,
+    eventType: "plan-failed",
+    severity: "critical",
+    payload: { planId: plan.id, strategyId: plan.strategyId },
+  });
+}
+
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const {
     planId,
     strategyId: _strategyId,
     action,
+    walletAddress,
   } = body as {
     planId: string;
     strategyId: string;
     action: "confirm" | "cancel";
+    walletAddress?: string;
   };
 
   let plan = planStore.get(planId);
@@ -38,6 +64,13 @@ export async function POST(req: NextRequest) {
     // Create a stub plan for demo if not found
     return NextResponse.json({ error: "Plan not found" }, { status: 404 });
   }
+
+  // Checked against the plan as fetched, before confirm/cancel below
+  // overwrite its status — this is what makes the hook observable at all: a
+  // plan already marked "failed" by some other process (the future
+  // step-execution worker) before this request arrived still gets reported,
+  // even though confirm/cancel always assign their own terminal status next.
+  await raiseFailureEventIfNeeded(plan, walletAddress);
 
   if (action === "confirm") {
     plan = { ...plan, status: "executing" };

--- a/apps/web-app/src/app/api/events/ingest/route.ts
+++ b/apps/web-app/src/app/api/events/ingest/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseJsonBody } from "@/lib/validation/parse";
+import { raiseEvent } from "@/lib/event-platform/outbox";
+import {
+  requireWalletSession,
+  UnauthorizedError,
+} from "@/lib/event-platform/auth/session";
+
+export const dynamic = "force-dynamic";
+
+// Mirrors ActivityEvent minus `read` — the store already generated `id`
+// before calling this route, and reuses it as the dedupe key so a retried
+// fire-and-forget POST can never double-enqueue the same occurrence.
+const BodySchema = z.object({
+  id: z.string().uuid(),
+  source: z.enum(["swap", "automation", "vault", "borrowing"]),
+  type: z.string().min(1),
+  summary: z.string(),
+  link: z.string(),
+  timestamp: z.number(),
+  metadata: z
+    .record(
+      z.string(),
+      z.union([z.string(), z.number(), z.boolean(), z.null()])
+    )
+    .optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const walletAddress = await requireWalletSession(request);
+    const parsed = await parseJsonBody(request, BodySchema);
+    if ("error" in parsed) return parsed.error;
+
+    const { id, source, type, summary, link, timestamp, metadata } =
+      parsed.data;
+
+    const result = await raiseEvent({
+      source,
+      walletAddress,
+      dedupeKey: id,
+      eventType: type,
+      severity: "info",
+      payload: { summary, link, timestamp, ...metadata },
+    });
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: err.message }, { status: 401 });
+    }
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-app/src/app/api/events/route.ts
+++ b/apps/web-app/src/app/api/events/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getEventPlatformDb } from "@/lib/event-platform/supabaseServer";
+import {
+  requireWalletSession,
+  UnauthorizedError,
+} from "@/lib/event-platform/auth/session";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Lists this wallet's platform events and open incidents — the Alerts
+ * view's data source, and what makes alert/incident history identical from
+ * any browser/device, since it's read from the server, not localStorage.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const walletAddress = await requireWalletSession(request);
+    const { searchParams } = new URL(request.url);
+    const source = searchParams.get("source");
+
+    const db = getEventPlatformDb();
+    let query = db
+      .from("platform_events")
+      .select(
+        "id, source, dedupe_key, event_type, severity, payload, incident_id, created_at"
+      )
+      .eq("wallet_address", walletAddress)
+      .order("created_at", { ascending: false })
+      .limit(200);
+
+    if (source) query = query.eq("source", source);
+
+    const { data: events, error: eventsError } = await query;
+    if (eventsError) throw new Error(eventsError.message);
+
+    const { data: incidents, error: incidentsError } = await db
+      .from("incidents")
+      .select("id, title, severity, status, created_at")
+      .eq("wallet_address", walletAddress)
+      .order("created_at", { ascending: false })
+      .limit(100);
+    if (incidentsError) throw new Error(incidentsError.message);
+
+    return NextResponse.json({
+      events: events ?? [],
+      incidents: incidents ?? [],
+    });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: err.message }, { status: 401 });
+    }
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-app/src/app/api/vault/invest/route.ts
+++ b/apps/web-app/src/app/api/vault/invest/route.ts
@@ -12,6 +12,7 @@ import {
 import { Client as DefindexVaultClient } from "@neko/defindex-vault";
 import { clientEnv } from "@/lib/env.client";
 import { requireServerEnv } from "@/lib/env.server";
+import { reportStageOutcome } from "@/lib/event-platform/vaultStageOutcome";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -300,6 +301,11 @@ export async function POST(request: NextRequest) {
       server,
       networkPassphrase
     );
+    await reportStageOutcome(
+      "harvestAquarius",
+      harvestResult.status !== "SUCCESS",
+      harvestResult
+    );
 
     // 2. Invest idle funds (includes any AQUA-converted idle if applicable)
     const investResult = await investIdle(
@@ -308,6 +314,12 @@ export async function POST(request: NextRequest) {
       server,
       networkPassphrase
     );
+    await reportStageOutcome(
+      "investIdle",
+      investResult.invested &&
+        investResult.results.some((r) => r.status !== "SUCCESS"),
+      investResult
+    );
 
     // 3. Collect fees (report → lock → distribute)
     const feesResult = await collectFees(
@@ -315,6 +327,11 @@ export async function POST(request: NextRequest) {
       keypair,
       server,
       networkPassphrase
+    );
+    await reportStageOutcome(
+      "collectFees",
+      !feesResult.feesCollected,
+      feesResult
     );
 
     const allOk =

--- a/apps/web-app/src/features/activity/components/ui/ActivityFeedItem.tsx
+++ b/apps/web-app/src/features/activity/components/ui/ActivityFeedItem.tsx
@@ -6,13 +6,20 @@ import type { ActivityEvent } from "../../types/activityEvent";
 import { useActivityStore } from "@/stores/activityStore";
 import { formatDistanceToNow } from "date-fns";
 
-const SOURCE_ICONS = {
+// Partial: this local feed only ever receives swap/automation/vault events
+// (see activityStore's three call sites) — "borrowing" is a valid
+// ActivityEvent.source now that it's the platform's shared producer union,
+// but never actually pushed here, so the existing `|| fallback` below
+// covers it without needing its own icon/color.
+const SOURCE_ICONS: Partial<
+  Record<ActivityEvent["source"], typeof ArrowLeftRight>
+> = {
   swap: ArrowLeftRight,
   automation: Zap,
   vault: Vault,
 };
 
-const SOURCE_COLORS = {
+const SOURCE_COLORS: Partial<Record<ActivityEvent["source"], string>> = {
   swap: "text-blue-400 border-blue-400",
   automation: "text-amber-400 border-amber-400",
   vault: "text-green-400 border-green-400",

--- a/apps/web-app/src/features/activity/components/ui/ActivityFilters.tsx
+++ b/apps/web-app/src/features/activity/components/ui/ActivityFilters.tsx
@@ -7,11 +7,17 @@ interface ActivityFiltersProps {
   onChange: (filters: ActivityFilters) => void;
 }
 
+type ActivitySource = NonNullable<ActivityFilters["sources"]>[number];
+
 export function ActivityFiltersControl({
   filters,
   onChange,
 }: ActivityFiltersProps) {
-  const sources: { value: "swap" | "automation" | "vault"; label: string }[] = [
+  // This local feed's filter UI intentionally only offers swap/automation/
+  // vault — the three sources activityStore actually receives — even though
+  // ActivityFilters["sources"] is typed against the platform's full,
+  // extensible source union.
+  const sources: { value: ActivitySource; label: string }[] = [
     { value: "swap", label: "Swap" },
     { value: "automation", label: "Automation" },
     { value: "vault", label: "Vault" },
@@ -27,9 +33,9 @@ export function ActivityFiltersControl({
     { value: "all", label: "All Time" },
   ];
 
-  const toggleSource = (source: "swap" | "automation" | "vault") => {
+  const toggleSource = (source: ActivitySource) => {
     const currentSources = filters.sources || [];
-    let newSources: ("swap" | "automation" | "vault")[];
+    let newSources: ActivitySource[];
 
     if (currentSources.includes(source)) {
       newSources = currentSources.filter((s) => s !== source);

--- a/apps/web-app/src/features/activity/hooks/useActivityFeed.ts
+++ b/apps/web-app/src/features/activity/hooks/useActivityFeed.ts
@@ -4,8 +4,10 @@ import { useMemo } from "react";
 import { useActivityStore } from "@/stores/activityStore";
 import { useStellarWalletStore } from "@/stores/stellarWalletStore";
 
+import type { ActivityEvent } from "../types/activityEvent";
+
 export interface ActivityFilters {
-  sources?: ("swap" | "automation" | "vault")[];
+  sources?: ActivityEvent["source"][];
   dateRange?: "today" | "7d" | "30d" | "all";
 }
 

--- a/apps/web-app/src/features/activity/types/activityEvent.ts
+++ b/apps/web-app/src/features/activity/types/activityEvent.ts
@@ -1,6 +1,10 @@
+import type { EventSource } from "@/lib/event-platform/types";
+
 export interface ActivityEvent {
   id: string; // UUID
-  source: "swap" | "automation" | "vault"; // extensible union
+  // The platform's producer-identifier union (see lib/event-platform/types) —
+  // a source added there automatically gets durable delivery with no change here.
+  source: EventSource;
   type: string; // e.g. "limit-order-ready", "limit-order-expired", "plan-confirmed", "plan-cancelled", "deposit", "withdraw"
   timestamp: number; // UTC ms
   summary: string; // Human-readable description

--- a/apps/web-app/src/hooks/useWallet.ts
+++ b/apps/web-app/src/hooks/useWallet.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   fetchBalances,
   signStellarTransactionWithWallet,
+  signStellarMessageWithWallet,
   type MappedBalances,
 } from "@/lib/helpers/stellar/wallet";
 import { stellarNetwork, networkPassphrase } from "@/lib/constants/network";
@@ -38,6 +39,15 @@ export function useWallet() {
     return { signedTxXdr };
   };
 
+  // Signs an arbitrary message — used for the event platform's
+  // wallet-ownership challenge (see lib/event-platform/auth/challenge.ts).
+  const signMessage = async (message: string) => {
+    if (!address) {
+      throw new Error("Connect Stellar wallet to sign");
+    }
+    return signStellarMessageWithWallet({ message, signerAddress: address });
+  };
+
   return {
     address: address ?? undefined,
     network: stellarNetwork,
@@ -50,5 +60,6 @@ export function useWallet() {
       await refetchBalances();
     },
     signTransaction,
+    signMessage,
   };
 }

--- a/apps/web-app/src/lib/env.server.ts
+++ b/apps/web-app/src/lib/env.server.ts
@@ -38,6 +38,10 @@ const serverSchema = z.object({
   ALFREDPAY_API_KEY: z.string().optional(),
   ALFREDPAY_API_SECRET: z.string().optional(),
   ALFREDPAY_BASE_URL: z.string().url().optional(),
+
+  // Event platform (outbox/queue/delivery) — server-only
+  SUPABASE_URL: z.string().url().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 const parsed = serverSchema.safeParse({
@@ -49,6 +53,8 @@ const parsed = serverSchema.safeParse({
   ALFREDPAY_API_KEY: process.env.ALFREDPAY_API_KEY,
   ALFREDPAY_API_SECRET: process.env.ALFREDPAY_API_SECRET,
   ALFREDPAY_BASE_URL: process.env.ALFREDPAY_BASE_URL,
+  SUPABASE_URL: process.env.SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
 });
 
 if (!parsed.success) {

--- a/apps/web-app/src/lib/event-platform/__tests__/correlation.test.ts
+++ b/apps/web-app/src/lib/event-platform/__tests__/correlation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideCorrelation,
+  type CorrelationCandidateEvent,
+} from "../correlation";
+
+const WINDOW_MS = 5 * 60 * 1000;
+
+describe("decideCorrelation", () => {
+  it("stands alone with no other-source events nearby", () => {
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_000 },
+      [],
+      WINDOW_MS
+    );
+    expect(decision).toEqual({
+      attachTo: "none",
+      incidentId: null,
+      correlatedEventId: null,
+    });
+  });
+
+  it("starts a new incident with the most recent other-source event inside the window", () => {
+    const candidates: CorrelationCandidateEvent[] = [
+      { id: "e1", source: "automation", createdAt: 100_000, incidentId: null },
+    ];
+
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_000 + 60_000 },
+      candidates,
+      WINDOW_MS
+    );
+
+    expect(decision).toEqual({
+      attachTo: "new",
+      incidentId: null,
+      correlatedEventId: "e1",
+    });
+  });
+
+  it("attaches to an existing incident when the correlated event already belongs to one", () => {
+    const candidates: CorrelationCandidateEvent[] = [
+      {
+        id: "e1",
+        source: "automation",
+        createdAt: 100_000,
+        incidentId: "incident-1",
+      },
+    ];
+
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_000 + 60_000 },
+      candidates,
+      WINDOW_MS
+    );
+
+    expect(decision).toEqual({
+      attachTo: "existing",
+      incidentId: "incident-1",
+      correlatedEventId: "e1",
+    });
+  });
+
+  it("ignores events from the same source", () => {
+    const candidates: CorrelationCandidateEvent[] = [
+      { id: "e1", source: "borrowing", createdAt: 100_000, incidentId: null },
+    ];
+
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_050 },
+      candidates,
+      WINDOW_MS
+    );
+
+    expect(decision.attachTo).toBe("none");
+  });
+
+  it("does not correlate two events outside the window", () => {
+    const candidates: CorrelationCandidateEvent[] = [
+      { id: "e1", source: "automation", createdAt: 100_000, incidentId: null },
+    ];
+
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_000 + WINDOW_MS + 1 },
+      candidates,
+      WINDOW_MS
+    );
+
+    expect(decision.attachTo).toBe("none");
+  });
+
+  it("picks the most recent other-source candidate when several qualify", () => {
+    const candidates: CorrelationCandidateEvent[] = [
+      {
+        id: "older",
+        source: "automation",
+        createdAt: 90_000,
+        incidentId: null,
+      },
+      { id: "newer", source: "vault", createdAt: 95_000, incidentId: null },
+    ];
+
+    const decision = decideCorrelation(
+      { source: "borrowing", createdAt: 100_000 },
+      candidates,
+      WINDOW_MS
+    );
+
+    expect(decision.correlatedEventId).toBe("newer");
+  });
+});

--- a/apps/web-app/src/lib/event-platform/__tests__/dedup.test.ts
+++ b/apps/web-app/src/lib/event-platform/__tests__/dedup.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTransition,
+  INITIAL_DEDUPE_STATE,
+  type AlertDedupeState,
+} from "../dedup";
+
+const T0 = 1_000_000;
+
+describe("computeTransition", () => {
+  it("emits on the first breach from the initial (resolved) state", () => {
+    const decision = computeTransition({
+      state: INITIAL_DEDUPE_STATE,
+      severity: "warning",
+      isResolution: false,
+      now: T0,
+    });
+
+    expect(decision.emit).toBe(true);
+    if (decision.emit) {
+      expect(decision.severity).toBe("warning");
+      expect(decision.escalated).toBe(false);
+      expect(decision.nextState).toEqual<AlertDedupeState>({
+        status: "active",
+        severity: "warning",
+        cycleCount: 1,
+        suppressedUntil: null,
+      });
+    }
+  });
+
+  it("does not re-emit for a repeat evaluation of an ongoing breach at the same severity", () => {
+    const active: AlertDedupeState = {
+      status: "active",
+      severity: "warning",
+      cycleCount: 1,
+      suppressedUntil: null,
+    };
+
+    const decision = computeTransition({
+      state: active,
+      severity: "warning",
+      isResolution: false,
+      now: T0 + 1,
+      escalationCycleThreshold: 10,
+    });
+
+    expect(decision.emit).toBe(false);
+    if (!decision.emit) {
+      expect(decision.reason).toBe("already-active");
+      expect(decision.nextState.cycleCount).toBe(2);
+    }
+  });
+
+  it("records a resolution without emitting, and starts the suppression window", () => {
+    const active: AlertDedupeState = {
+      status: "active",
+      severity: "warning",
+      cycleCount: 3,
+      suppressedUntil: null,
+    };
+
+    const decision = computeTransition({
+      state: active,
+      severity: "info",
+      isResolution: true,
+      now: T0,
+      suppressionWindowMs: 60_000,
+    });
+
+    expect(decision.emit).toBe(false);
+    if (!decision.emit) {
+      expect(decision.reason).toBe("resolution-recorded");
+      expect(decision.nextState).toEqual<AlertDedupeState>({
+        status: "resolved",
+        severity: "warning",
+        cycleCount: 0,
+        suppressedUntil: T0 + 60_000,
+      });
+    }
+  });
+
+  it("suppresses a re-breach inside the post-resolution suppression window (rapid flap)", () => {
+    const resolved: AlertDedupeState = {
+      status: "resolved",
+      severity: "warning",
+      cycleCount: 0,
+      suppressedUntil: T0 + 60_000,
+    };
+
+    const decision = computeTransition({
+      state: resolved,
+      severity: "warning",
+      isResolution: false,
+      now: T0 + 1_000, // still inside the window
+    });
+
+    expect(decision.emit).toBe(false);
+    if (!decision.emit) expect(decision.reason).toBe("suppressed");
+  });
+
+  it("emits again once a re-breach occurs after the suppression window has passed", () => {
+    const resolved: AlertDedupeState = {
+      status: "resolved",
+      severity: "warning",
+      cycleCount: 0,
+      suppressedUntil: T0 + 60_000,
+    };
+
+    const decision = computeTransition({
+      state: resolved,
+      severity: "warning",
+      isResolution: false,
+      now: T0 + 60_001, // just past the window
+    });
+
+    expect(decision.emit).toBe(true);
+  });
+
+  it("emits immediately when severity worsens while already active (escalation)", () => {
+    const active: AlertDedupeState = {
+      status: "active",
+      severity: "warning",
+      cycleCount: 2,
+      suppressedUntil: null,
+    };
+
+    const decision = computeTransition({
+      state: active,
+      severity: "critical",
+      isResolution: false,
+      now: T0,
+    });
+
+    expect(decision.emit).toBe(true);
+    if (decision.emit) {
+      expect(decision.severity).toBe("critical");
+      expect(decision.escalated).toBe(true);
+      expect(decision.nextState.severity).toBe("critical");
+    }
+  });
+
+  it("auto-escalates one level once a condition persists past the cycle threshold at the same severity", () => {
+    let state: AlertDedupeState = INITIAL_DEDUPE_STATE;
+    let now = T0;
+
+    // Cycle 1: first breach, emits at "warning".
+    let decision = computeTransition({
+      state,
+      severity: "warning",
+      isResolution: false,
+      now,
+      escalationCycleThreshold: 3,
+    });
+    expect(decision.emit).toBe(true);
+    state = decision.nextState;
+
+    // Cycle 2: still warning, no escalation yet.
+    now += 1000;
+    decision = computeTransition({
+      state,
+      severity: "warning",
+      isResolution: false,
+      now,
+      escalationCycleThreshold: 3,
+    });
+    expect(decision.emit).toBe(false);
+    state = decision.nextState;
+    expect(state.cycleCount).toBe(2);
+
+    // Cycle 3: crosses the threshold — auto-escalates to critical even
+    // though the caller keeps reporting "warning".
+    now += 1000;
+    decision = computeTransition({
+      state,
+      severity: "warning",
+      isResolution: false,
+      now,
+      escalationCycleThreshold: 3,
+    });
+    expect(decision.emit).toBe(true);
+    if (decision.emit) {
+      expect(decision.severity).toBe("critical");
+      expect(decision.escalated).toBe(true);
+    }
+  });
+
+  it("never escalates past critical", () => {
+    const active: AlertDedupeState = {
+      status: "active",
+      severity: "critical",
+      cycleCount: 10,
+      suppressedUntil: null,
+    };
+
+    const decision = computeTransition({
+      state: active,
+      severity: "critical",
+      isResolution: false,
+      now: T0,
+      escalationCycleThreshold: 1,
+    });
+
+    expect(decision.emit).toBe(false);
+    if (!decision.emit) expect(decision.reason).toBe("already-active");
+  });
+
+  it("a resolution call while already resolved is a no-op", () => {
+    const decision = computeTransition({
+      state: INITIAL_DEDUPE_STATE,
+      severity: "info",
+      isResolution: true,
+      now: T0,
+    });
+
+    expect(decision.emit).toBe(false);
+    if (!decision.emit) expect(decision.reason).toBe("already-resolved");
+  });
+});

--- a/apps/web-app/src/lib/event-platform/__tests__/outbox.integration.test.ts
+++ b/apps/web-app/src/lib/event-platform/__tests__/outbox.integration.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { raiseEvent, resolveEvent } from "../outbox";
+import { createFakeDb, type FakeDb } from "./testUtils/fakeSupabase";
+
+describe("raiseEvent (outbox, via fn_raise_platform_event)", () => {
+  let db: FakeDb;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000_000_000);
+    db = createFakeDb();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const asClient = () => db as unknown as SupabaseClient;
+
+  it("creates exactly one event on the first breach", async () => {
+    // Delivery-row enqueueing (event_deliveries) lands with the
+    // queue-draining/multi-channel-delivery follow-up PR — this covers the
+    // outbox write itself, which this PR's fn_raise_platform_event handles
+    // in full atomically in Postgres regardless.
+    const result = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+      },
+      asClient()
+    );
+
+    expect(result.created).toBe(true);
+    expect(db.tables.platform_events).toHaveLength(1);
+  });
+
+  it("does not create a second event for repeated evaluations of the same ongoing breach", async () => {
+    await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+      },
+      asClient()
+    );
+
+    const second = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+      },
+      asClient()
+    );
+
+    expect(second.created).toBe(false);
+    expect(db.tables.platform_events).toHaveLength(1);
+  });
+
+  it("resolving then re-breaching within the suppression window does not deliver a second event", async () => {
+    await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    await resolveEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "breach-resolved",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    vi.advanceTimersByTime(5_000); // still inside the 60s suppression window
+
+    const rebreach = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    expect(rebreach.created).toBe(false);
+    expect(db.tables.platform_events).toHaveLength(1); // only the original breach
+  });
+
+  it("delivers again once a re-breach occurs after the suppression window passes", async () => {
+    await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+    await resolveEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "breach-resolved",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    vi.advanceTimersByTime(61_000);
+
+    const rebreach = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        suppressionWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    expect(rebreach.created).toBe(true);
+    expect(db.tables.platform_events).toHaveLength(2);
+  });
+
+  it("keeps one wallet's events out of another wallet's results", async () => {
+    await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+      },
+      asClient()
+    );
+    await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET2",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+      },
+      asClient()
+    );
+
+    const wallet1Events = db.tables.platform_events.filter(
+      (e) => e.wallet_address === "GWALLET1"
+    );
+    const wallet2Events = db.tables.platform_events.filter(
+      (e) => e.wallet_address === "GWALLET2"
+    );
+    expect(wallet1Events).toHaveLength(1);
+    expect(wallet2Events).toHaveLength(1);
+    expect(wallet1Events[0].id).not.toBe(wallet2Events[0].id);
+  });
+
+  it("correlates an automation failure and a following borrowing breach for the same wallet into one incident", async () => {
+    const first = await raiseEvent(
+      {
+        source: "automation",
+        walletAddress: "GWALLET1",
+        dedupeKey: "plan-failed:plan1",
+        eventType: "plan-failed",
+        severity: "critical",
+        correlationWindowMs: 300_000,
+      },
+      asClient()
+    );
+
+    vi.advanceTimersByTime(30_000); // within the correlation window
+
+    const second = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        correlationWindowMs: 300_000,
+      },
+      asClient()
+    );
+
+    expect(first.incidentId).toBeFalsy();
+    expect(second.incidentId).toBeTruthy();
+    expect(db.tables.incidents).toHaveLength(1);
+
+    const firstEventRow = db.tables.platform_events.find(
+      (e) => e.id === first.eventId
+    );
+    expect(firstEventRow?.incident_id).toBe(second.incidentId);
+  });
+
+  it("does not correlate two related events outside the correlation window", async () => {
+    await raiseEvent(
+      {
+        source: "automation",
+        walletAddress: "GWALLET1",
+        dedupeKey: "plan-failed:plan1",
+        eventType: "plan-failed",
+        severity: "critical",
+        correlationWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    vi.advanceTimersByTime(61_000);
+
+    const second = await raiseEvent(
+      {
+        source: "borrowing",
+        walletAddress: "GWALLET1",
+        dedupeKey: "hf-breach:pool1",
+        eventType: "threshold-breach",
+        severity: "warning",
+        correlationWindowMs: 60_000,
+      },
+      asClient()
+    );
+
+    expect(second.incidentId).toBeFalsy();
+    expect(db.tables.incidents).toHaveLength(0);
+  });
+});

--- a/apps/web-app/src/lib/event-platform/__tests__/testUtils/fakeSupabase.ts
+++ b/apps/web-app/src/lib/event-platform/__tests__/testUtils/fakeSupabase.ts
@@ -1,0 +1,347 @@
+/**
+ * An in-memory stand-in for the Supabase client, used by this feature's
+ * "integration" tests. It is NOT a Postgres test double in the strict
+ * sense — there is no live database available in this environment to test
+ * against (see supabase/migrations/0001_event_platform_core.sql's header
+ * comment) — but its `fn_raise_platform_event` handler re-implements the
+ * exact same decision as the real SQL function, built on the same pure
+ * logic (`computeTransition`, `decideCorrelation`) that function was
+ * translated from. That makes this genuine coverage of the outbox's
+ * decision logic end-to-end, just not of Postgres transaction semantics
+ * themselves — run the real migrations against a database and re-verify
+ * atomicity/locking behavior there before relying on this alone.
+ */
+import { computeTransition, type AlertDedupeState } from "../../dedup";
+import { decideCorrelation } from "../../correlation";
+
+type Row = Record<string, unknown>;
+
+export interface FakeDb {
+  tables: Record<string, Row[]>;
+  rpc(
+    fn: string,
+    args: Record<string, unknown>
+  ): Promise<{ data: unknown; error: null | { message: string } }>;
+  from(table: string): FakeQueryBuilder;
+}
+
+class FakeQueryBuilder implements PromiseLike<{
+  data: unknown;
+  error: null;
+  count?: number;
+}> {
+  private filters: Array<(row: Row) => boolean> = [];
+  private orderBy: { col: string; ascending: boolean } | null = null;
+  private limitN: number | null = null;
+  private mode: "select" | "insert" | "update" | "upsert" = "select";
+  private payload: Row | Row[] | null = null;
+  private onConflictCols: string[] | null = null;
+  private singleFlag = false;
+  private maybeSingleFlag = false;
+  private countHead = false;
+
+  constructor(
+    private db: FakeDb,
+    private table: string
+  ) {}
+
+  select(_cols?: string, opts?: { count?: string; head?: boolean }): this {
+    // Only a read query's `.select()` — chained after `.insert()`/`.update()`/
+    // `.upsert()` it means "return the affected row(s)", not "switch to read
+    // mode", so it must not clobber the mode those already set.
+    if (this.mode === "select") {
+      this.countHead = Boolean(opts?.head);
+    }
+    return this;
+  }
+
+  insert(row: Row): this {
+    this.mode = "insert";
+    this.payload = row;
+    return this;
+  }
+
+  update(row: Row): this {
+    this.mode = "update";
+    this.payload = row;
+    return this;
+  }
+
+  upsert(row: Row, opts?: { onConflict?: string }): this {
+    this.mode = "upsert";
+    this.payload = row;
+    this.onConflictCols = opts?.onConflict?.split(",") ?? null;
+    return this;
+  }
+
+  eq(col: string, value: unknown): this {
+    this.filters.push((row) => row[col] === value);
+    return this;
+  }
+
+  not(col: string, _op: string, value: unknown): this {
+    this.filters.push((row) => row[col] !== value);
+    return this;
+  }
+
+  in(col: string, values: unknown[]): this {
+    this.filters.push((row) => values.includes(row[col]));
+    return this;
+  }
+
+  order(col: string, opts?: { ascending?: boolean }): this {
+    this.orderBy = { col, ascending: opts?.ascending ?? true };
+    return this;
+  }
+
+  limit(n: number): this {
+    this.limitN = n;
+    return this;
+  }
+
+  single(): this {
+    this.singleFlag = true;
+    return this;
+  }
+
+  maybeSingle(): this {
+    this.maybeSingleFlag = true;
+    return this;
+  }
+
+  private materialize(): { data: unknown; error: null; count?: number } {
+    const table =
+      this.db.tables[this.table] ?? (this.db.tables[this.table] = []);
+
+    if (this.mode === "insert") {
+      const rows = Array.isArray(this.payload)
+        ? this.payload
+        : [this.payload as Row];
+      const inserted = rows.map((r) => ({
+        id: r.id ?? cryptoRandomId(),
+        ...r,
+      }));
+      table.push(...inserted);
+      return { data: this.singleFlag ? inserted[0] : inserted, error: null };
+    }
+
+    if (this.mode === "upsert") {
+      const row = this.payload as Row;
+      const keyCols = this.onConflictCols ?? Object.keys(row);
+      const existingIdx = table.findIndex((r) =>
+        keyCols.every((c) => r[c] === row[c])
+      );
+      if (existingIdx >= 0) {
+        table[existingIdx] = { ...table[existingIdx], ...row };
+        return {
+          data: this.singleFlag ? table[existingIdx] : [table[existingIdx]],
+          error: null,
+        };
+      }
+      const inserted = { id: row.id ?? cryptoRandomId(), ...row };
+      table.push(inserted);
+      return { data: this.singleFlag ? inserted : [inserted], error: null };
+    }
+
+    let matched = table.filter((row) => this.filters.every((f) => f(row)));
+
+    if (this.mode === "update") {
+      const patch = this.payload as Row;
+      matched.forEach((row) => Object.assign(row, patch));
+      return { data: this.singleFlag ? matched[0] : matched, error: null };
+    }
+
+    if (this.orderBy) {
+      const { col, ascending } = this.orderBy;
+      matched = [...matched].sort((a, b) => {
+        const av = a[col] as string | number;
+        const bv = b[col] as string | number;
+        return ascending ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
+      });
+    }
+    if (this.limitN !== null) matched = matched.slice(0, this.limitN);
+
+    if (this.countHead)
+      return { data: null, error: null, count: matched.length };
+    if (this.singleFlag) return { data: matched[0] ?? null, error: null };
+    if (this.maybeSingleFlag) return { data: matched[0] ?? null, error: null };
+    return { data: matched, error: null };
+  }
+
+  then<TResult1 = { data: unknown; error: null }, TResult2 = never>(
+    onfulfilled?:
+      | ((value: {
+          data: unknown;
+          error: null;
+          count?: number;
+        }) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(this.materialize()).then(onfulfilled, onrejected);
+  }
+}
+
+function cryptoRandomId(): string {
+  return `id_${Math.random().toString(36).slice(2)}_${Date.now()}`;
+}
+
+export function createFakeDb(): FakeDb {
+  const tables: Record<string, Row[]> = {
+    alert_dedupe_state: [],
+    platform_events: [],
+    incidents: [],
+    incident_events: [],
+    wallet_auth_challenges: [],
+    wallet_sessions: [],
+  };
+
+  const db: FakeDb = {
+    tables,
+    from(table: string) {
+      return new FakeQueryBuilder(db, table);
+    },
+    async rpc(fn: string, args: Record<string, unknown>) {
+      switch (fn) {
+        case "fn_raise_platform_event":
+          return { data: raisePlatformEvent(tables, args), error: null };
+        default:
+          return { data: null, error: { message: `unknown rpc ${fn}` } };
+      }
+    },
+  };
+  return db;
+}
+
+function stateRowToState(row: Row | undefined): AlertDedupeState {
+  if (!row) {
+    return {
+      status: "resolved",
+      severity: "info",
+      cycleCount: 0,
+      suppressedUntil: null,
+    };
+  }
+  return {
+    status: row.current_status as AlertDedupeState["status"],
+    severity: row.severity as AlertDedupeState["severity"],
+    cycleCount: row.cycle_count as number,
+    suppressedUntil: (row.suppressed_until as number | null) ?? null,
+  };
+}
+
+/**
+ * Mirrors fn_raise_platform_event's dedupe/escalation/correlation decision.
+ * The multi-channel enqueue step it also performs in Postgres is left out
+ * here — event_deliveries insertion belongs to the queue-draining/
+ * multi-channel-delivery work landing in a follow-up PR — but events and
+ * incidents are recorded exactly as they would be in the real function.
+ */
+function raisePlatformEvent(
+  tables: Record<string, Row[]>,
+  args: Record<string, unknown>
+) {
+  const source = args.p_source as string;
+  const walletAddress = args.p_wallet_address as string;
+  const dedupeKey = args.p_dedupe_key as string;
+  const now = Date.now();
+
+  const stateRow = tables.alert_dedupe_state.find(
+    (r) =>
+      r.source === source &&
+      r.wallet_address === walletAddress &&
+      r.dedupe_key === dedupeKey
+  );
+
+  const decision = computeTransition({
+    state: stateRowToState(stateRow),
+    severity: args.p_severity as "info" | "warning" | "critical",
+    isResolution: Boolean(args.p_is_resolution),
+    now,
+    suppressionWindowMs:
+      ((args.p_suppression_window_seconds as number) ?? 300) * 1000,
+    escalationCycleThreshold:
+      (args.p_escalation_cycle_threshold as number) ?? 3,
+  });
+
+  const nextRow = {
+    source,
+    wallet_address: walletAddress,
+    dedupe_key: dedupeKey,
+    current_status: decision.nextState.status,
+    severity: decision.nextState.severity,
+    cycle_count: decision.nextState.cycleCount,
+    suppressed_until: decision.nextState.suppressedUntil,
+  };
+  if (stateRow) Object.assign(stateRow, nextRow);
+  else tables.alert_dedupe_state.push(nextRow);
+
+  if (!decision.emit) {
+    return { created: false, reason: decision.reason };
+  }
+
+  const eventId = cryptoRandomId();
+  const event = {
+    id: eventId,
+    source,
+    wallet_address: walletAddress,
+    dedupe_key: dedupeKey,
+    event_type: args.p_event_type,
+    severity: decision.severity,
+    payload: args.p_payload ?? {},
+    incident_id: null as string | null,
+    created_at: new Date(now).toISOString(),
+    _createdAtMs: now,
+  };
+  tables.platform_events.push(event);
+
+  const windowMs =
+    ((args.p_correlation_window_seconds as number) ?? 300) * 1000;
+  const candidates = tables.platform_events
+    .filter((e) => e.wallet_address === walletAddress && e.id !== eventId)
+    .map((e) => ({
+      id: e.id as string,
+      source: e.source as never,
+      createdAt: e._createdAtMs as number,
+      incidentId: (e.incident_id as string | null) ?? null,
+    }));
+
+  const correlation = decideCorrelation(
+    { source: source as never, createdAt: now },
+    candidates,
+    windowMs
+  );
+  let incidentId: string | null = null;
+  if (correlation.attachTo === "existing") {
+    incidentId = correlation.incidentId;
+  } else if (correlation.attachTo === "new") {
+    incidentId = cryptoRandomId();
+    tables.incidents.push({
+      id: incidentId,
+      wallet_address: walletAddress,
+      title: `Correlated ${source} activity`,
+      severity: decision.severity,
+      status: "open",
+      created_at: new Date(now).toISOString(),
+    });
+    tables.incident_events.push({
+      incident_id: incidentId,
+      event_id: correlation.correlatedEventId,
+    });
+    const correlatedEvent = tables.platform_events.find(
+      (e) => e.id === correlation.correlatedEventId
+    );
+    if (correlatedEvent) correlatedEvent.incident_id = incidentId;
+  }
+  if (incidentId) {
+    event.incident_id = incidentId;
+    tables.incident_events.push({ incident_id: incidentId, event_id: eventId });
+  }
+
+  return {
+    created: true,
+    event_id: eventId,
+    incident_id: incidentId,
+    escalated: decision.escalated,
+  };
+}

--- a/apps/web-app/src/lib/event-platform/__tests__/vaultStageOutcome.test.ts
+++ b/apps/web-app/src/lib/event-platform/__tests__/vaultStageOutcome.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/env.client", () => ({
+  clientEnv: {
+    lendingAdminAddress: "GADMIN000000000000000000000000000000000000000000000",
+  },
+}));
+
+const raiseEventMock = vi.fn();
+const resolveEventMock = vi.fn();
+vi.mock("../outbox", () => ({
+  raiseEvent: (...args: unknown[]) => raiseEventMock(...args),
+  resolveEvent: (...args: unknown[]) => resolveEventMock(...args),
+}));
+
+const { reportStageOutcome } = await import("../vaultStageOutcome");
+
+/**
+ * Covers the vault-invest producer's failure→event wiring in isolation from
+ * the Soroban transaction pipeline itself (mocking a full RPC/contract-call
+ * chain wouldn't meaningfully test anything beyond these boolean
+ * conditions, and app/api/vault/invest/route.ts can't even be imported by
+ * Vitest — see this module's own doc comment) — the outbox's
+ * one-event-per-transition guarantee is covered separately in
+ * outbox.integration.test.ts.
+ */
+describe("reportStageOutcome (vault/invest producer)", () => {
+  beforeEach(() => {
+    raiseEventMock.mockReset();
+    resolveEventMock.mockReset();
+  });
+
+  it("raises exactly one critical vault event, attributed to the correct stage, on failure", async () => {
+    await reportStageOutcome("harvestAquarius", true, { status: "FAILED" });
+
+    expect(raiseEventMock).toHaveBeenCalledTimes(1);
+    expect(resolveEventMock).not.toHaveBeenCalled();
+    expect(raiseEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "vault",
+        eventType: "harvestAquarius-failed",
+        severity: "critical",
+        dedupeKey: "vault-invest-stage:harvestAquarius",
+        walletAddress: "GADMIN000000000000000000000000000000000000000000000",
+      })
+    );
+  });
+
+  it("resolves (does not raise) on success", async () => {
+    await reportStageOutcome("collectFees", false, { feesCollected: true });
+
+    expect(raiseEventMock).not.toHaveBeenCalled();
+    expect(resolveEventMock).toHaveBeenCalledTimes(1);
+    expect(resolveEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "vault",
+        dedupeKey: "vault-invest-stage:collectFees",
+      })
+    );
+  });
+
+  it("attributes each stage's failure to its own dedupe key, never mixing stages", async () => {
+    await reportStageOutcome("investIdle", true, {});
+    expect(raiseEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dedupeKey: "vault-invest-stage:investIdle" })
+    );
+  });
+});

--- a/apps/web-app/src/lib/event-platform/auth/__tests__/challenge.test.ts
+++ b/apps/web-app/src/lib/event-platform/auth/__tests__/challenge.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createChallenge, verifyChallenge } from "../challenge";
+import {
+  createFakeDb,
+  type FakeDb,
+} from "../../__tests__/testUtils/fakeSupabase";
+
+describe("wallet auth challenge (SEP-10-lite)", () => {
+  let db: FakeDb;
+  let keypair: Keypair;
+  const asClient = () => db as unknown as SupabaseClient;
+
+  beforeEach(() => {
+    db = createFakeDb();
+    keypair = Keypair.random();
+  });
+
+  it("verifies a correctly signed challenge and consumes the nonce", async () => {
+    const { message } = await createChallenge(keypair.publicKey(), asClient());
+    const signature = keypair
+      .sign(Buffer.from(message, "utf8"))
+      .toString("base64");
+
+    const valid = await verifyChallenge(
+      keypair.publicKey(),
+      message,
+      signature,
+      asClient()
+    );
+    expect(valid).toBe(true);
+
+    const challengeRow = db.tables.wallet_auth_challenges[0];
+    expect(challengeRow.consumed_at).toBeTruthy();
+  });
+
+  it("rejects a signature from the wrong keypair", async () => {
+    const { message } = await createChallenge(keypair.publicKey(), asClient());
+    const impostor = Keypair.random();
+    const signature = impostor
+      .sign(Buffer.from(message, "utf8"))
+      .toString("base64");
+
+    const valid = await verifyChallenge(
+      keypair.publicKey(),
+      message,
+      signature,
+      asClient()
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects a tampered message", async () => {
+    const { message } = await createChallenge(keypair.publicKey(), asClient());
+    const signature = keypair
+      .sign(Buffer.from(message, "utf8"))
+      .toString("base64");
+
+    const valid = await verifyChallenge(
+      keypair.publicKey(),
+      message.replace("Nonce:", "Nonce: tampered-"),
+      signature,
+      asClient()
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("rejects replaying an already-consumed nonce", async () => {
+    const { message } = await createChallenge(keypair.publicKey(), asClient());
+    const signature = keypair
+      .sign(Buffer.from(message, "utf8"))
+      .toString("base64");
+
+    const first = await verifyChallenge(
+      keypair.publicKey(),
+      message,
+      signature,
+      asClient()
+    );
+    const replay = await verifyChallenge(
+      keypair.publicKey(),
+      message,
+      signature,
+      asClient()
+    );
+
+    expect(first).toBe(true);
+    expect(replay).toBe(false);
+  });
+
+  it("rejects an expired challenge", async () => {
+    const { message } = await createChallenge(keypair.publicKey(), asClient());
+    const signature = keypair
+      .sign(Buffer.from(message, "utf8"))
+      .toString("base64");
+
+    db.tables.wallet_auth_challenges[0].expires_at = new Date(
+      Date.now() - 1000
+    ).toISOString();
+
+    const valid = await verifyChallenge(
+      keypair.publicKey(),
+      message,
+      signature,
+      asClient()
+    );
+    expect(valid).toBe(false);
+  });
+});

--- a/apps/web-app/src/lib/event-platform/auth/__tests__/session.test.ts
+++ b/apps/web-app/src/lib/event-platform/auth/__tests__/session.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  createSession,
+  requireWalletSession,
+  UnauthorizedError,
+  SESSION_COOKIE_NAME,
+} from "../session";
+import {
+  createFakeDb,
+  type FakeDb,
+} from "../../__tests__/testUtils/fakeSupabase";
+
+function requestWithCookie(token?: string): Request {
+  return new Request("https://example.com/api/events", {
+    headers: token ? { cookie: `${SESSION_COOKIE_NAME}=${token}` } : {},
+  });
+}
+
+describe("requireWalletSession", () => {
+  let db: FakeDb;
+  const asClient = () => db as unknown as SupabaseClient;
+
+  beforeEach(() => {
+    db = createFakeDb();
+  });
+
+  it("resolves the wallet for a valid session token", async () => {
+    const token = await createSession("GWALLET1", asClient());
+    const wallet = await requireWalletSession(
+      requestWithCookie(token),
+      asClient()
+    );
+    expect(wallet).toBe("GWALLET1");
+  });
+
+  it("throws Unauthorized when there is no session cookie", async () => {
+    await expect(
+      requireWalletSession(requestWithCookie(), asClient())
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("throws Unauthorized for a token that doesn't match any session", async () => {
+    await expect(
+      requireWalletSession(requestWithCookie("not-a-real-token"), asClient())
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("throws Unauthorized for a revoked session", async () => {
+    const token = await createSession("GWALLET1", asClient());
+    db.tables.wallet_sessions[0].revoked_at = new Date().toISOString();
+
+    await expect(
+      requireWalletSession(requestWithCookie(token), asClient())
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("throws Unauthorized for an expired session", async () => {
+    const token = await createSession("GWALLET1", asClient());
+    db.tables.wallet_sessions[0].expires_at = new Date(
+      Date.now() - 1000
+    ).toISOString();
+
+    await expect(
+      requireWalletSession(requestWithCookie(token), asClient())
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it("never resolves one wallet's session token to a different wallet", async () => {
+    const tokenA = await createSession("GWALLET_A", asClient());
+    const tokenB = await createSession("GWALLET_B", asClient());
+
+    const walletForA = await requireWalletSession(
+      requestWithCookie(tokenA),
+      asClient()
+    );
+    const walletForB = await requireWalletSession(
+      requestWithCookie(tokenB),
+      asClient()
+    );
+
+    expect(walletForA).toBe("GWALLET_A");
+    expect(walletForB).toBe("GWALLET_B");
+  });
+});

--- a/apps/web-app/src/lib/event-platform/auth/challenge.ts
+++ b/apps/web-app/src/lib/event-platform/auth/challenge.ts
@@ -1,0 +1,100 @@
+import { randomBytes, createHash } from "node:crypto";
+import { Keypair } from "@stellar/stellar-sdk";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getEventPlatformDb } from "../supabaseServer";
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+function hashNonce(nonce: string): string {
+  return createHash("sha256").update(nonce).digest("hex");
+}
+
+export interface Challenge {
+  message: string;
+  expiresAt: string;
+}
+
+/**
+ * SEP-10-lite: issues a one-time nonce embedded in a human-readable message
+ * for the wallet to sign, without a full SEP-10 challenge-transaction flow
+ * (no existing SEP-10/web-auth code exists in this repo to build on, and
+ * this platform only needs "prove you hold this key", not a full auth
+ * server). The nonce is stored hashed, mirroring `admin_login_codes`.
+ */
+export async function createChallenge(
+  walletAddress: string,
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<Challenge> {
+  const nonce = randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS).toISOString();
+
+  const { error } = await db.from("wallet_auth_challenges").insert({
+    wallet_address: walletAddress,
+    nonce_hash: hashNonce(nonce),
+    expires_at: expiresAt,
+  });
+  if (error) {
+    throw new Error(`createChallenge failed: ${error.message}`);
+  }
+
+  const message = [
+    "Neko event platform sign-in",
+    `Wallet: ${walletAddress}`,
+    `Nonce: ${nonce}`,
+    `Expires: ${expiresAt}`,
+  ].join("\n");
+
+  return { message, expiresAt };
+}
+
+/**
+ * Verifies a signed challenge and, on success, consumes the nonce so it
+ * cannot be replayed. Note: this targets the common case of a wallet
+ * signing the raw UTF-8 message bytes directly (Freighter's documented
+ * `signMessage` behavior) — other wallet adapters wired into
+ * `@creit.tech/stellar-wallets-kit` may encode signed messages differently
+ * and should be verified against a real wallet before relying on this for
+ * anything beyond Freighter.
+ */
+export async function verifyChallenge(
+  walletAddress: string,
+  message: string,
+  signatureBase64: string,
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<boolean> {
+  const nonceMatch = /Nonce: ([0-9a-f]+)/.exec(message);
+  if (!nonceMatch) return false;
+  const nonceHash = hashNonce(nonceMatch[1]);
+
+  const { data, error } = await db
+    .from("wallet_auth_challenges")
+    .select("id, expires_at, consumed_at")
+    .eq("wallet_address", walletAddress)
+    .eq("nonce_hash", nonceHash)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return false;
+  if (data.consumed_at) return false;
+  if (new Date(data.expires_at).getTime() < Date.now()) return false;
+
+  let signatureValid: boolean;
+  try {
+    const keypair = Keypair.fromPublicKey(walletAddress);
+    signatureValid = keypair.verify(
+      Buffer.from(message, "utf8"),
+      Buffer.from(signatureBase64, "base64")
+    );
+  } catch {
+    signatureValid = false;
+  }
+  if (!signatureValid) return false;
+
+  const { error: consumeError } = await db
+    .from("wallet_auth_challenges")
+    .update({ consumed_at: new Date().toISOString() })
+    .eq("id", data.id);
+
+  return !consumeError;
+}

--- a/apps/web-app/src/lib/event-platform/auth/session.ts
+++ b/apps/web-app/src/lib/event-platform/auth/session.ts
@@ -1,0 +1,76 @@
+import { randomBytes, createHash } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getEventPlatformDb } from "../supabaseServer";
+
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const SESSION_COOKIE_NAME = "neko_wallet_session";
+export const SESSION_COOKIE_MAX_AGE_SECONDS = SESSION_TTL_MS / 1000;
+
+export class UnauthorizedError extends Error {}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export async function createSession(
+  walletAddress: string,
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<string> {
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS).toISOString();
+
+  const { error } = await db.from("wallet_sessions").insert({
+    wallet_address: walletAddress,
+    token_hash: hashToken(token),
+    expires_at: expiresAt,
+  });
+  if (error) throw new Error(`createSession failed: ${error.message}`);
+  return token;
+}
+
+async function resolveSession(
+  token: string,
+  db: SupabaseClient
+): Promise<string | null> {
+  const { data, error } = await db
+    .from("wallet_sessions")
+    .select("wallet_address, expires_at, revoked_at")
+    .eq("token_hash", hashToken(token))
+    .maybeSingle();
+
+  if (error || !data) return null;
+  if (data.revoked_at) return null;
+  if (new Date(data.expires_at).getTime() < Date.now()) return null;
+  return data.wallet_address as string;
+}
+
+function parseCookie(header: string, name: string): string | null {
+  for (const part of header.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return decodeURIComponent(rest.join("="));
+  }
+  return null;
+}
+
+/**
+ * Resolves the wallet a request is authenticated as, throwing
+ * `UnauthorizedError` if it isn't. This is what every new route calls to
+ * scope reads/writes to exactly one wallet — the ownership boundary the
+ * rest of this codebase's routes don't have (they trust a client-supplied
+ * address; this platform's wallet-scoped surface is new enough to warrant
+ * the real check).
+ */
+export async function requireWalletSession(
+  request: Request,
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<string> {
+  const token = parseCookie(
+    request.headers.get("cookie") ?? "",
+    SESSION_COOKIE_NAME
+  );
+  if (!token) throw new UnauthorizedError("No session cookie");
+
+  const walletAddress = await resolveSession(token, db);
+  if (!walletAddress) throw new UnauthorizedError("Invalid or expired session");
+  return walletAddress;
+}

--- a/apps/web-app/src/lib/event-platform/correlation.ts
+++ b/apps/web-app/src/lib/event-platform/correlation.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure cross-module correlation decision, mirroring the subquery in
+ * `fn_raise_platform_event`: the most recent *other-source* event for the
+ * same wallet within the correlation window is the correlation target — if
+ * it already belongs to an incident, attach there; otherwise start a new
+ * incident containing both events. Outside the window, or with no
+ * other-source event at all, the new event stands alone.
+ */
+import type { EventSource } from "./types";
+
+export interface CorrelationCandidateEvent {
+  id: string;
+  source: EventSource;
+  createdAt: number;
+  incidentId: string | null;
+}
+
+export interface CorrelationDecision {
+  attachTo: "existing" | "new" | "none";
+  incidentId: string | null;
+  correlatedEventId: string | null;
+}
+
+export function decideCorrelation(
+  newEvent: { source: EventSource; createdAt: number },
+  recentEvents: CorrelationCandidateEvent[],
+  windowMs: number
+): CorrelationDecision {
+  const match = recentEvents
+    .filter(
+      (e) =>
+        e.source !== newEvent.source &&
+        newEvent.createdAt - e.createdAt >= 0 &&
+        newEvent.createdAt - e.createdAt <= windowMs
+    )
+    .sort((a, b) => b.createdAt - a.createdAt)[0];
+
+  if (!match) {
+    return { attachTo: "none", incidentId: null, correlatedEventId: null };
+  }
+
+  if (match.incidentId) {
+    return {
+      attachTo: "existing",
+      incidentId: match.incidentId,
+      correlatedEventId: match.id,
+    };
+  }
+
+  return { attachTo: "new", incidentId: null, correlatedEventId: match.id };
+}

--- a/apps/web-app/src/lib/event-platform/dedup.ts
+++ b/apps/web-app/src/lib/event-platform/dedup.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure hysteresis / suppression / escalation decision logic for the outbox.
+ *
+ * This is the canonical spec for "exactly one delivered event per transition
+ * into a state" — `supabase/migrations/0005_event_platform_functions.sql`'s
+ * `fn_raise_platform_event` is a deliberate, faithful plpgsql translation of
+ * `computeTransition` below, run atomically (row-locked) in Postgres. Keep
+ * the two in sync: a rule change here without the matching SQL change means
+ * the atomic path and the tested path diverge.
+ */
+import type { Severity } from "./types";
+
+export type AlertStatus = "active" | "resolved";
+
+export interface AlertDedupeState {
+  status: AlertStatus;
+  severity: Severity;
+  /** Consecutive evaluations the condition has stayed active at its current severity. */
+  cycleCount: number;
+  /** Epoch ms until which a fresh breach is suppressed after a resolution; null if none. */
+  suppressedUntil: number | null;
+}
+
+export const INITIAL_DEDUPE_STATE: AlertDedupeState = {
+  status: "resolved",
+  severity: "info",
+  cycleCount: 0,
+  suppressedUntil: null,
+};
+
+export interface TransitionInput {
+  state: AlertDedupeState;
+  /** Severity reported by this evaluation (ignored when `isResolution`). */
+  severity: Severity;
+  isResolution: boolean;
+  now: number;
+  suppressionWindowMs?: number;
+  escalationCycleThreshold?: number;
+}
+
+export type TransitionDecision =
+  | {
+      emit: false;
+      reason:
+        | "suppressed"
+        | "already-active"
+        | "already-resolved"
+        | "resolution-recorded";
+      nextState: AlertDedupeState;
+    }
+  | {
+      emit: true;
+      /** May differ from the input severity when this is a cycle-count auto-escalation. */
+      severity: Severity;
+      escalated: boolean;
+      nextState: AlertDedupeState;
+    };
+
+const RANK: Record<Severity, number> = { info: 1, warning: 2, critical: 3 };
+const NEXT_LEVEL: Record<Severity, Severity> = {
+  info: "warning",
+  warning: "critical",
+  critical: "critical",
+};
+
+const DEFAULT_SUPPRESSION_WINDOW_MS = 5 * 60 * 1000;
+const DEFAULT_ESCALATION_CYCLE_THRESHOLD = 3;
+
+export function computeTransition({
+  state,
+  severity,
+  isResolution,
+  now,
+  suppressionWindowMs = DEFAULT_SUPPRESSION_WINDOW_MS,
+  escalationCycleThreshold = DEFAULT_ESCALATION_CYCLE_THRESHOLD,
+}: TransitionInput): TransitionDecision {
+  if (isResolution) {
+    if (state.status === "active") {
+      return {
+        emit: false,
+        reason: "resolution-recorded",
+        nextState: {
+          status: "resolved",
+          severity: state.severity,
+          cycleCount: 0,
+          suppressedUntil: now + suppressionWindowMs,
+        },
+      };
+    }
+    return { emit: false, reason: "already-resolved", nextState: state };
+  }
+
+  if (state.status === "resolved") {
+    if (state.suppressedUntil !== null && now < state.suppressedUntil) {
+      return { emit: false, reason: "suppressed", nextState: state };
+    }
+    return {
+      emit: true,
+      severity,
+      escalated: false,
+      nextState: {
+        status: "active",
+        severity,
+        cycleCount: 1,
+        suppressedUntil: null,
+      },
+    };
+  }
+
+  // state.status === "active"
+  if (RANK[severity] > RANK[state.severity]) {
+    return {
+      emit: true,
+      severity,
+      escalated: true,
+      nextState: {
+        status: "active",
+        severity,
+        cycleCount: state.cycleCount + 1,
+        suppressedUntil: null,
+      },
+    };
+  }
+
+  const nextCycleCount = state.cycleCount + 1;
+  if (
+    nextCycleCount >= escalationCycleThreshold &&
+    RANK[state.severity] < RANK.critical
+  ) {
+    const escalatedSeverity = NEXT_LEVEL[state.severity];
+    return {
+      emit: true,
+      severity: escalatedSeverity,
+      escalated: true,
+      nextState: {
+        status: "active",
+        severity: escalatedSeverity,
+        cycleCount: nextCycleCount,
+        suppressedUntil: null,
+      },
+    };
+  }
+
+  return {
+    emit: false,
+    reason: "already-active",
+    nextState: { ...state, cycleCount: nextCycleCount },
+  };
+}

--- a/apps/web-app/src/lib/event-platform/outbox.ts
+++ b/apps/web-app/src/lib/event-platform/outbox.ts
@@ -1,0 +1,67 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getEventPlatformDb } from "./supabaseServer";
+import type { RaiseEventInput, RaiseEventResult } from "./types";
+
+interface RawRpcResult {
+  created: boolean;
+  reason?: string;
+  event_id?: string;
+  incident_id?: string | null;
+  escalated?: boolean;
+}
+
+/**
+ * The single write path into the outbox. Delegates the entire
+ * dedupe/hysteresis/suppression/escalation/correlation/enqueue decision to
+ * `fn_raise_platform_event`, which runs it as one Postgres transaction (see
+ * that function's comment for why this — not this TS function — is what
+ * actually provides atomicity). `db` is injectable so callers/tests can pass
+ * a fake satisfying the same `rpc()` shape without a live database.
+ */
+export async function raiseEvent(
+  input: RaiseEventInput,
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<RaiseEventResult> {
+  const { data, error } = await db.rpc("fn_raise_platform_event", {
+    p_source: input.source,
+    p_wallet_address: input.walletAddress,
+    p_dedupe_key: input.dedupeKey,
+    p_event_type: input.eventType,
+    p_severity: input.severity,
+    p_payload: input.payload ?? {},
+    p_is_resolution: input.isResolution ?? false,
+    p_suppression_window_seconds: Math.round(
+      (input.suppressionWindowMs ?? 300_000) / 1000
+    ),
+    p_correlation_window_seconds: Math.round(
+      (input.correlationWindowMs ?? 300_000) / 1000
+    ),
+    p_escalation_cycle_threshold: input.escalationCycleThreshold ?? 3,
+  });
+
+  if (error) {
+    throw new Error(`raiseEvent failed: ${error.message}`);
+  }
+
+  const result = data as RawRpcResult;
+  return {
+    created: result.created,
+    reason: result.reason,
+    eventId: result.event_id,
+    incidentId: result.incident_id ?? null,
+    escalated: result.escalated,
+  };
+}
+
+/** Convenience wrapper for reporting that a previously-raised condition has cleared. */
+export async function resolveEvent(
+  input: Omit<RaiseEventInput, "isResolution" | "severity"> & {
+    severity?: RaiseEventInput["severity"];
+  },
+  db: SupabaseClient = getEventPlatformDb()
+): Promise<RaiseEventResult> {
+  return raiseEvent(
+    { ...input, severity: input.severity ?? "info", isResolution: true },
+    db
+  );
+}

--- a/apps/web-app/src/lib/event-platform/supabaseServer.ts
+++ b/apps/web-app/src/lib/event-platform/supabaseServer.ts
@@ -1,0 +1,27 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { requireServerEnv } from "@/lib/env.server";
+
+/**
+ * Server-only Supabase client (service role — bypasses RLS). Every new
+ * event-platform table has RLS enabled with no anon/authenticated policies,
+ * so this is the only client capable of reading/writing them; the browser
+ * never talks to Supabase directly, only through Next.js API routes.
+ *
+ * Importing `@/lib/env.server` here means this module inherits its
+ * browser-import guard — it throws if pulled into a client bundle.
+ */
+let cached: SupabaseClient | null = null;
+
+export function getEventPlatformDb(): SupabaseClient {
+  if (cached) return cached;
+
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireServerEnv([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+
+  cached = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+  return cached;
+}

--- a/apps/web-app/src/lib/event-platform/types.ts
+++ b/apps/web-app/src/lib/event-platform/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared types for the durable event platform. `EventSource` is the single
+ * canonical producer-identifier union — `ActivityEvent["source"]` imports it
+ * rather than declaring its own, so a future producer added here
+ * automatically becomes a valid activity-store source too.
+ */
+export type EventSource = "swap" | "automation" | "vault" | "borrowing";
+
+export type Severity = "info" | "warning" | "critical";
+
+export type DeliveryChannelType = "in_app" | "webhook" | "email";
+
+export type DeliveryStatus =
+  | "pending"
+  | "processing"
+  | "delivered"
+  | "failed"
+  | "dead_letter";
+
+export interface PlatformEvent {
+  id: string;
+  source: EventSource;
+  walletAddress: string;
+  dedupeKey: string;
+  eventType: string;
+  severity: Severity;
+  payload: Record<string, unknown>;
+  incidentId: string | null;
+  createdAt: string;
+}
+
+export interface EventDelivery {
+  id: string;
+  eventId: string;
+  channel: DeliveryChannelType;
+  status: DeliveryStatus;
+  attempts: number;
+  nextAttemptAt: string;
+  lastError: string | null;
+  deliveredAt: string | null;
+}
+
+export interface RaiseEventInput {
+  source: EventSource;
+  walletAddress: string;
+  /** Identifies the ongoing condition this event belongs to, e.g. `hf-breach:${contractId}`. */
+  dedupeKey: string;
+  eventType: string;
+  severity: Severity;
+  payload?: Record<string, unknown>;
+  /** True when this call reports the condition has cleared, not a new breach. */
+  isResolution?: boolean;
+  suppressionWindowMs?: number;
+  correlationWindowMs?: number;
+  escalationCycleThreshold?: number;
+}
+
+export interface RaiseEventResult {
+  created: boolean;
+  reason?: string;
+  eventId?: string;
+  incidentId?: string | null;
+  escalated?: boolean;
+}
+
+export interface NotificationPreferences {
+  walletAddress: string;
+  sources: EventSource[];
+  minSeverity: Severity;
+  channels: DeliveryChannelType[];
+  quietHoursStart: number | null;
+  quietHoursEnd: number | null;
+  digestMode: "immediate" | "digest";
+}
+
+export interface NotificationChannelConfig {
+  id: string;
+  walletAddress: string;
+  channelType: Extract<DeliveryChannelType, "webhook" | "email">;
+  destination: string;
+  verifiedAt: string | null;
+}
+
+export interface Incident {
+  id: string;
+  walletAddress: string;
+  title: string;
+  severity: Severity;
+  status: "open" | "resolved";
+  createdAt: string;
+}

--- a/apps/web-app/src/lib/event-platform/vaultStageOutcome.ts
+++ b/apps/web-app/src/lib/event-platform/vaultStageOutcome.ts
@@ -1,0 +1,55 @@
+import { clientEnv } from "@/lib/env.client";
+import { raiseEvent, resolveEvent } from "./outbox";
+
+export type VaultInvestStage = "harvestAquarius" | "investIdle" | "collectFees";
+
+/**
+ * The vault-invest producer's failure→event wiring, isolated from the
+ * Soroban transaction pipeline in app/api/vault/invest/route.ts on purpose:
+ * that file imports `@neko/defindex-vault`, which doesn't resolve at
+ * Vitest's module-resolution level in this repo (a pre-existing workspace
+ * package issue — see the eslint-disable comments in that route already
+ * flagging it for TypeScript). Keeping this dependency-free lets it be unit
+ * tested directly instead of only through the untestable route.
+ *
+ * This vault-invest cron is a system-level operation on one shared vault
+ * contract, not scoped to an individual end user — there is no per-request
+ * "owning wallet" to notify. `NEXT_PUBLIC_LENDING_ADMIN_ADDRESS` is this
+ * codebase's existing admin-identity concept (already used to gate
+ * /dashboard/admin), so stage failures are reported to that wallet instead
+ * of inventing a new one. If it's unset, failures are only visible in the
+ * HTTP response, same as before this feature.
+ */
+export async function reportStageOutcome(
+  stage: VaultInvestStage,
+  failed: boolean,
+  detail: Record<string, unknown>
+): Promise<void> {
+  const walletAddress = clientEnv.lendingAdminAddress;
+  if (!walletAddress) return;
+
+  const dedupeKey = `vault-invest-stage:${stage}`;
+  try {
+    if (failed) {
+      await raiseEvent({
+        source: "vault",
+        walletAddress,
+        dedupeKey,
+        eventType: `${stage}-failed`,
+        severity: "critical",
+        payload: detail,
+      });
+    } else {
+      await resolveEvent({
+        source: "vault",
+        walletAddress,
+        dedupeKey,
+        eventType: `${stage}-recovered`,
+        payload: detail,
+      });
+    }
+  } catch (err) {
+    // Never let event-platform delivery affect the vault-invest run itself.
+    console.error(`reportStageOutcome(${stage}) failed:`, err);
+  }
+}

--- a/apps/web-app/src/lib/helpers/stellar/wallet/index.ts
+++ b/apps/web-app/src/lib/helpers/stellar/wallet/index.ts
@@ -4,6 +4,10 @@ export {
   type SignStellarTransactionParams,
 } from "./signTransaction";
 export {
+  signStellarMessageWithWallet,
+  type SignStellarMessageParams,
+} from "./signMessage";
+export {
   fetchBalances,
   type MappedBalances,
   type FetchBalancesResult,

--- a/apps/web-app/src/lib/helpers/stellar/wallet/signMessage.ts
+++ b/apps/web-app/src/lib/helpers/stellar/wallet/signMessage.ts
@@ -1,0 +1,23 @@
+import { getStellarWalletKit } from "./walletKit";
+
+export interface SignStellarMessageParams {
+  message: string;
+  signerAddress: string;
+}
+
+/**
+ * Signs an arbitrary message with the connected wallet — used for the event
+ * platform's sign-in challenge (see lib/event-platform/auth/challenge.ts).
+ * Mirrors signStellarTransactionWithWallet's shape, but for
+ * `Kit.signMessage` instead of `Kit.signTransaction`.
+ */
+export async function signStellarMessageWithWallet({
+  message,
+  signerAddress,
+}: SignStellarMessageParams): Promise<string> {
+  const Kit = await getStellarWalletKit();
+  const { signedMessage } = await Kit.signMessage(message, {
+    address: signerAddress,
+  });
+  return signedMessage;
+}

--- a/apps/web-app/src/stores/__tests__/activityStore.test.ts
+++ b/apps/web-app/src/stores/__tests__/activityStore.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../stellarWalletStore", () => ({
+  useStellarWalletStore: { getState: () => ({ address: "GWALLET1" }) },
+}));
+
+import { useActivityStore } from "../activityStore";
+
+/**
+ * Regression + integration coverage for the activity-feed bridge: the three
+ * real call sites (useExecutionQueue, useLimitOrderMonitor, useVaultAction)
+ * are untouched by this feature — they all just call `pushEvent(...)`, same
+ * as before. This test exercises that exact call shape and asserts both
+ * halves of the bridge: the existing local/optimistic list still works
+ * unchanged, and the new durable POST fires with no call-site changes.
+ */
+describe("activityStore.pushEvent — durable bridge", () => {
+  beforeEach(() => {
+    useActivityStore.setState({ eventsByWallet: {} });
+    vi.restoreAllMocks();
+  });
+
+  it("still records the event locally (existing/regression behavior)", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    useActivityStore.getState().pushEvent({
+      source: "vault",
+      type: "deposit",
+      timestamp: Date.now(),
+      summary: "Deposited 100 USDC",
+      link: "/vaults",
+    });
+
+    const events = useActivityStore.getState().eventsByWallet["GWALLET1"];
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("deposit");
+    expect(events[0].read).toBe(false);
+    expect(typeof events[0].id).toBe("string");
+  });
+
+  it("enqueues the same event durably via POST /api/events/ingest with no call-site changes", () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    useActivityStore.getState().pushEvent({
+      source: "automation",
+      type: "plan-confirmed",
+      timestamp: Date.now(),
+      summary: "Plan confirmed",
+      link: "/automation",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/events/ingest");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("include");
+
+    const body = JSON.parse(init.body as string);
+    const localEvent =
+      useActivityStore.getState().eventsByWallet["GWALLET1"][0];
+    expect(body.id).toBe(localEvent.id); // same id reused as the dedupe key
+    expect(body.source).toBe("automation");
+    expect(body.type).toBe("plan-confirmed");
+  });
+
+  it("keeps the local activity feed intact when the durable POST fails (fallback/fast path)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network down"))
+    );
+
+    useActivityStore.getState().pushEvent({
+      source: "swap",
+      type: "limit-order-ready",
+      timestamp: Date.now(),
+      summary: "Limit order ready",
+      link: "/swap",
+    });
+
+    // Let the rejected fetch's .catch() settle before asserting nothing throws.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const events = useActivityStore.getState().eventsByWallet["GWALLET1"];
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("limit-order-ready");
+  });
+
+  it("does not record or enqueue an event when no wallet is connected", async () => {
+    vi.doMock("../stellarWalletStore", () => ({
+      useStellarWalletStore: { getState: () => ({ address: undefined }) },
+    }));
+    vi.resetModules();
+    const { useActivityStore: freshStore } = await import("../activityStore");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    freshStore.getState().pushEvent({
+      source: "vault",
+      type: "deposit",
+      timestamp: Date.now(),
+      summary: "Deposited",
+      link: "/vaults",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(freshStore.getState().eventsByWallet).toEqual({});
+  });
+});

--- a/apps/web-app/src/stores/activityStore.ts
+++ b/apps/web-app/src/stores/activityStore.ts
@@ -3,6 +3,28 @@ import { persist } from "zustand/middleware";
 import type { ActivityEvent } from "../features/activity/types/activityEvent";
 import { useStellarWalletStore } from "./stellarWalletStore";
 
+function enqueuePlatformEvent(event: ActivityEvent): Promise<void> {
+  return fetch("/api/events/ingest", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      id: event.id,
+      source: event.source,
+      type: event.type,
+      summary: event.summary,
+      link: event.link,
+      timestamp: event.timestamp,
+      metadata: event.metadata,
+    }),
+  })
+    .then(() => undefined)
+    .catch(() => {
+      // No wallet session yet, or the platform is unreachable — the local
+      // activity feed above is the fallback/fast path and is unaffected.
+    });
+}
+
 export interface ActivityState {
   eventsByWallet: Record<string, ActivityEvent[]>;
   pushEvent: (event: Omit<ActivityEvent, "id" | "read">) => void;
@@ -25,11 +47,20 @@ export const useActivityStore = create<ActivityState>()(
           if (!walletKey) return state; // Don't record if no wallet
 
           const now = Date.now();
+          const id = crypto.randomUUID();
           const newEvent: ActivityEvent = {
             ...eventData,
-            id: crypto.randomUUID(),
+            id,
             read: false,
           };
+
+          // Durable bridge into the event platform — the single integration
+          // point for all activityStore producers (see
+          // lib/event-platform/types.ts). Fire-and-forget: the local,
+          // optimistic list above is unaffected by network failure here, and
+          // reusing `id` as the platform's dedupe key makes a retried POST
+          // idempotent rather than double-enqueuing the same occurrence.
+          void enqueuePlatformEvent(newEvent);
 
           const currentEvents = state.eventsByWallet[walletKey] || [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@stellar/freighter-api": "^5.0.0",
         "@stellar/stellar-sdk": "^14.2.0",
         "@stellar/stellar-xdr-json": "^23.0.0",
+        "@supabase/supabase-js": "^2.49.4",
         "@tanstack/react-query": "^5.62.11",
         "animate.css": "^4.1.1",
         "axios": "^1.7.9",
@@ -6078,6 +6079,90 @@
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@stellar/stellar-xdr-json/-/stellar-xdr-json-23.0.0.tgz",
       "integrity": "sha512-0jxWuaSZY5VfogL9YMPhjxBM7a3jwTQfSCzFUy0lkSoPrl5cNxhzx854+iidNY2Xu3pFB8x61XZ1wJapu7OHMA=="
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.109.0.tgz",
+      "integrity": "sha512-krf61vksi92kEUYtNH70GnIMOoQqLBAKG2e3Aha4e/0uJA6i1OWCxL7WUGHo6c0Vu/w96Y1DdnkYz0NOg0kYog==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.109.0.tgz",
+      "integrity": "sha512-IiwAspZrVrBRYQoFgSJvkcA9iJvTCw8nHOdvlKARDushlw/x1YY3YJYtwwgZFtl7utUbTiZ5SwohXPNgnpZM+g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.109.0.tgz",
+      "integrity": "sha512-Xk4gzuzyrGIPWCUuJolDQS/9zdFZDEXRhNsVeOHEKwFr+vpNU0himsHtLOhSEYlyPqwmeY8LUCKL6bLsDp0ScA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.109.0.tgz",
+      "integrity": "sha512-q9tjGUgWLNhfLz6HeYE7yl6FG9WEsnr6bFmmLpn2Nakxp3Z36pqI4xu0xns5/n8Xtq10HVcy9CRxOxgvviCM4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.109.0.tgz",
+      "integrity": "sha512-j119SdEuwrOPGqiPjshpfovrQPFqeATKg990jNV88Ie+SEufznzVD2mL5kQvly+z2oVBeZn+pweU0QN/OYLmJw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.109.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.109.0.tgz",
+      "integrity": "sha512-eNpUGegTT3hhoTK9j6aLViVjybYtdq6Ishb4BkVLi5tT58S1D80n7dmALMoBWkbrYG4uQv30c8iAB6nZylX0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.109.0",
+        "@supabase/functions-js": "2.109.0",
+        "@supabase/postgrest-js": "2.109.0",
+        "@supabase/realtime-js": "2.109.0",
+        "@supabase/storage-js": "2.109.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -13494,6 +13579,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/supabase/migrations/0001_event_platform_core.sql
+++ b/supabase/migrations/0001_event_platform_core.sql
@@ -1,0 +1,87 @@
+-- Event platform: wallet-signature auth (SEP-10-lite challenge/session) and
+-- the durable outbox (platform_events) with its hysteresis / suppression /
+-- escalation state machine (alert_dedupe_state). See
+-- 0003_event_platform_functions.sql's fn_raise_platform_event for the
+-- atomic transition logic that gates writes into platform_events.
+--
+-- These migrations were written and reviewed but not applied to any
+-- project during development — the connected Supabase project holds live
+-- production data, and creating an isolated dev branch via MCP requires a
+-- cost-confirmation step unavailable in that session. Apply them yourself
+-- against a dev branch first, in order (0001 -> 0003):
+--
+--   supabase branches create durable-event-platform
+--   supabase db push --db-url <branch-connection-string>
+--
+-- Required server env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see
+-- apps/web-app/.env.example) — never exposed to the client; every table
+-- below has RLS enabled with no anon/authenticated policies, so only the
+-- service-role key (used server-side by lib/event-platform/supabaseServer.ts)
+-- can read/write them.
+
+create table if not exists public.wallet_auth_challenges (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null,
+  nonce_hash text not null,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists wallet_auth_challenges_wallet_idx
+  on public.wallet_auth_challenges (wallet_address, expires_at);
+
+alter table public.wallet_auth_challenges enable row level security;
+
+create table if not exists public.wallet_sessions (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null,
+  token_hash text not null unique,
+  expires_at timestamptz not null,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists wallet_sessions_wallet_idx
+  on public.wallet_sessions (wallet_address);
+
+alter table public.wallet_sessions enable row level security;
+
+create table if not exists public.platform_events (
+  id uuid primary key default gen_random_uuid(),
+  source text not null,
+  wallet_address text not null,
+  dedupe_key text not null,
+  event_type text not null,
+  severity text not null default 'info' check (severity in ('info', 'warning', 'critical')),
+  payload jsonb not null default '{}'::jsonb,
+  incident_id uuid,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists platform_events_wallet_idx
+  on public.platform_events (wallet_address, created_at desc);
+
+create index if not exists platform_events_source_idx
+  on public.platform_events (source, wallet_address, dedupe_key);
+
+create index if not exists platform_events_incident_idx
+  on public.platform_events (incident_id);
+
+alter table public.platform_events enable row level security;
+
+create table if not exists public.alert_dedupe_state (
+  source text not null,
+  wallet_address text not null,
+  dedupe_key text not null,
+  current_status text not null default 'resolved' check (current_status in ('active', 'resolved')),
+  severity text not null default 'info' check (severity in ('info', 'warning', 'critical')),
+  cycle_count integer not null default 0,
+  last_event_id uuid,
+  last_transition_at timestamptz,
+  suppressed_until timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key (source, wallet_address, dedupe_key)
+);
+
+alter table public.alert_dedupe_state enable row level security;

--- a/supabase/migrations/0002_event_platform_delivery_and_rules.sql
+++ b/supabase/migrations/0002_event_platform_delivery_and_rules.sql
@@ -1,0 +1,146 @@
+-- Event platform: the delivery queue and its audit trail, per-wallet
+-- channel/preference/rate-limit configuration, the durable
+-- borrowing-threshold registry, the declarative rule engine's rule storage,
+-- and cross-module correlation (incidents).
+--
+-- Note: this PR's application code only uses platform_events,
+-- alert_dedupe_state, and incidents/incident_events (via
+-- fn_raise_platform_event's built-in correlation) — event_deliveries,
+-- notification_channels/preferences, borrowing_thresholds, and
+-- rule_definitions are schema for the queue-draining, multi-channel
+-- delivery, and borrowing-monitor work landing in a follow-up PR. Shipping
+-- the full schema now avoids a second migration pass touching the same
+-- tables later.
+
+create table if not exists public.event_deliveries (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.platform_events (id) on delete cascade,
+  channel text not null check (channel in ('in_app', 'webhook', 'email')),
+  status text not null default 'pending' check (status in ('pending', 'processing', 'delivered', 'failed', 'dead_letter')),
+  attempts integer not null default 0,
+  next_attempt_at timestamptz not null default now(),
+  last_error text,
+  delivered_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (event_id, channel)
+);
+
+create index if not exists event_deliveries_claim_idx
+  on public.event_deliveries (channel, status, next_attempt_at);
+
+alter table public.event_deliveries enable row level security;
+
+create table if not exists public.delivery_audit_log (
+  id uuid primary key default gen_random_uuid(),
+  delivery_id uuid not null references public.event_deliveries (id) on delete cascade,
+  stage text not null check (stage in ('created', 'queued', 'attempted', 'delivered', 'dead_letter')),
+  outcome text,
+  detail jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists delivery_audit_log_delivery_idx
+  on public.delivery_audit_log (delivery_id);
+
+alter table public.delivery_audit_log enable row level security;
+
+create table if not exists public.notification_channels (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null,
+  channel_type text not null check (channel_type in ('webhook', 'email')),
+  destination text not null,
+  verified_at timestamptz,
+  verification_token_hash text,
+  verification_expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (wallet_address, channel_type, destination)
+);
+
+create index if not exists notification_channels_wallet_idx
+  on public.notification_channels (wallet_address);
+
+alter table public.notification_channels enable row level security;
+
+create table if not exists public.notification_preferences (
+  wallet_address text primary key,
+  sources jsonb not null default '["swap", "automation", "vault", "borrowing"]'::jsonb,
+  min_severity text not null default 'warning' check (min_severity in ('info', 'warning', 'critical')),
+  channels jsonb not null default '["in_app"]'::jsonb,
+  quiet_hours_start smallint check (quiet_hours_start between 0 and 23),
+  quiet_hours_end smallint check (quiet_hours_end between 0 and 23),
+  digest_mode text not null default 'immediate' check (digest_mode in ('immediate', 'digest')),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.notification_preferences enable row level security;
+
+create table if not exists public.channel_rate_limit_windows (
+  wallet_address text not null,
+  channel_type text not null,
+  window_start timestamptz not null,
+  count integer not null default 0,
+  primary key (wallet_address, channel_type, window_start)
+);
+
+alter table public.channel_rate_limit_windows enable row level security;
+
+create table if not exists public.borrowing_thresholds (
+  wallet_address text not null,
+  contract_id text not null,
+  kind text not null default 'threshold' check (kind in ('threshold', 'danger-zone')),
+  threshold_hf numeric not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (wallet_address, contract_id, kind)
+);
+
+alter table public.borrowing_thresholds enable row level security;
+
+create table if not exists public.rule_definitions (
+  id uuid primary key default gen_random_uuid(),
+  -- null wallet_address = a global/default rule applied to every wallet
+  wallet_address text,
+  source text not null,
+  name text not null,
+  condition jsonb not null,
+  severity text not null default 'warning' check (severity in ('info', 'warning', 'critical')),
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists rule_definitions_source_idx
+  on public.rule_definitions (source, enabled);
+
+alter table public.rule_definitions enable row level security;
+
+create table if not exists public.incidents (
+  id uuid primary key default gen_random_uuid(),
+  wallet_address text not null,
+  title text not null,
+  severity text not null default 'warning' check (severity in ('info', 'warning', 'critical')),
+  status text not null default 'open' check (status in ('open', 'resolved')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  resolved_at timestamptz
+);
+
+create index if not exists incidents_wallet_idx
+  on public.incidents (wallet_address, status);
+
+alter table public.incidents enable row level security;
+
+create table if not exists public.incident_events (
+  incident_id uuid not null references public.incidents (id) on delete cascade,
+  event_id uuid not null references public.platform_events (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (incident_id, event_id)
+);
+
+alter table public.incident_events enable row level security;
+
+alter table public.platform_events
+  add constraint platform_events_incident_fk
+  foreign key (incident_id) references public.incidents (id) on delete set null;

--- a/supabase/migrations/0003_event_platform_functions.sql
+++ b/supabase/migrations/0003_event_platform_functions.sql
@@ -1,0 +1,318 @@
+-- Event platform: the atomic RPCs that give the outbox its guarantees.
+--
+-- fn_raise_platform_event is the single write path into platform_events. It
+-- runs as one Postgres transaction: lock the dedupe state row, decide
+-- whether this is a genuine transition (first breach, resolution, or a
+-- severity escalation while still active) or a no-op (already active at the
+-- same/lower severity, or inside the post-resolution suppression window),
+-- and if it is a transition, insert the event, run cross-source
+-- correlation, and enqueue one event_deliveries row per eligible channel —
+-- all before releasing the lock. A concurrent evaluation for the same
+-- (source, wallet_address, dedupe_key) blocks on the row lock rather than
+-- racing, which is what makes "exactly one delivered event per transition"
+-- hold even when the same condition is evaluated from overlapping cron runs.
+--
+-- The identical decision logic is re-implemented as a pure function in
+-- apps/web-app/src/lib/event-platform/dedup.ts (computeTransition) and
+-- exhaustively unit tested there, since asserting on plpgsql control flow
+-- directly is impractical. This function is a deliberate, short, faithful
+-- translation of that logic — see the code comment in dedup.ts before
+-- changing either side.
+
+create or replace function public.fn_raise_platform_event(
+  p_source text,
+  p_wallet_address text,
+  p_dedupe_key text,
+  p_event_type text,
+  p_severity text,
+  p_payload jsonb default '{}'::jsonb,
+  p_is_resolution boolean default false,
+  p_suppression_window_seconds integer default 300,
+  p_correlation_window_seconds integer default 300,
+  p_escalation_cycle_threshold integer default 3
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_state public.alert_dedupe_state%rowtype;
+  v_now timestamptz := now();
+  v_should_emit boolean := false;
+  v_escalated boolean := false;
+  v_effective_severity text := p_severity;
+  v_event_id uuid;
+  v_incident_id uuid;
+  v_correlated_event_id uuid;
+  v_correlated_incident_id uuid;
+  v_severity_rank_new integer;
+  v_severity_rank_old integer;
+  v_next_cycle_count integer;
+begin
+  insert into public.alert_dedupe_state (source, wallet_address, dedupe_key)
+  values (p_source, p_wallet_address, p_dedupe_key)
+  on conflict (source, wallet_address, dedupe_key) do nothing;
+
+  select * into v_state
+  from public.alert_dedupe_state
+  where source = p_source and wallet_address = p_wallet_address and dedupe_key = p_dedupe_key
+  for update;
+
+  if p_is_resolution then
+    if v_state.current_status = 'active' then
+      update public.alert_dedupe_state
+      set current_status = 'resolved',
+          cycle_count = 0,
+          last_transition_at = v_now,
+          suppressed_until = v_now + make_interval(secs => p_suppression_window_seconds),
+          updated_at = v_now
+      where source = p_source and wallet_address = p_wallet_address and dedupe_key = p_dedupe_key;
+      return jsonb_build_object('created', false, 'reason', 'resolution-recorded');
+    end if;
+    return jsonb_build_object('created', false, 'reason', 'already-resolved');
+  end if;
+
+  v_severity_rank_new := case p_severity when 'critical' then 3 when 'warning' then 2 else 1 end;
+  v_severity_rank_old := case v_state.severity when 'critical' then 3 when 'warning' then 2 else 1 end;
+
+  if v_state.current_status = 'resolved' then
+    if v_state.suppressed_until is not null and v_now < v_state.suppressed_until then
+      return jsonb_build_object('created', false, 'reason', 'suppressed');
+    end if;
+    v_should_emit := true;
+    v_effective_severity := p_severity;
+  else
+    if v_severity_rank_new > v_severity_rank_old then
+      v_should_emit := true;
+      v_escalated := true;
+      v_effective_severity := p_severity;
+    else
+      -- Still active at the same/lower severity as last time: this is a
+      -- repeat evaluation of an ongoing condition, not a new transition, so
+      -- no event is emitted for it on its own. But if it has now persisted
+      -- for p_escalation_cycle_threshold cycles and isn't already at the
+      -- top severity, auto-escalate one level (info->warning->critical) —
+      -- this is what "a condition that persists across evaluation cycles
+      -- escalates severity" means when the caller keeps reporting the same
+      -- severity rather than a worsening one itself.
+      v_next_cycle_count := v_state.cycle_count + 1;
+      if v_next_cycle_count >= p_escalation_cycle_threshold and v_severity_rank_old < 3 then
+        v_should_emit := true;
+        v_escalated := true;
+        v_effective_severity := case v_state.severity when 'info' then 'warning' else 'critical' end;
+      else
+        update public.alert_dedupe_state
+        set cycle_count = v_next_cycle_count, updated_at = v_now
+        where source = p_source and wallet_address = p_wallet_address and dedupe_key = p_dedupe_key;
+        return jsonb_build_object('created', false, 'reason', 'already-active');
+      end if;
+    end if;
+  end if;
+
+  insert into public.platform_events (source, wallet_address, dedupe_key, event_type, severity, payload)
+  values (p_source, p_wallet_address, p_dedupe_key, p_event_type, v_effective_severity, coalesce(p_payload, '{}'::jsonb))
+  returning id into v_event_id;
+
+  update public.alert_dedupe_state
+  set current_status = 'active',
+      severity = v_effective_severity,
+      cycle_count = case when v_escalated then coalesce(v_next_cycle_count, cycle_count + 1) else 1 end,
+      last_event_id = v_event_id,
+      last_transition_at = v_now,
+      suppressed_until = null,
+      updated_at = v_now
+  where source = p_source and wallet_address = p_wallet_address and dedupe_key = p_dedupe_key;
+
+  v_severity_rank_new := case v_effective_severity when 'critical' then 3 when 'warning' then 2 else 1 end;
+
+  select pe.id, pe.incident_id
+  into v_correlated_event_id, v_correlated_incident_id
+  from public.platform_events pe
+  where pe.wallet_address = p_wallet_address
+    and pe.source <> p_source
+    and pe.id <> v_event_id
+    and pe.created_at >= v_now - make_interval(secs => p_correlation_window_seconds)
+  order by pe.created_at desc
+  limit 1;
+
+  if v_correlated_event_id is not null then
+    if v_correlated_incident_id is not null then
+      v_incident_id := v_correlated_incident_id;
+    else
+      insert into public.incidents (wallet_address, title, severity, status)
+      values (p_wallet_address, format('Correlated %s + %s activity', p_source, p_event_type), v_effective_severity, 'open')
+      returning id into v_incident_id;
+
+      insert into public.incident_events (incident_id, event_id)
+      values (v_incident_id, v_correlated_event_id)
+      on conflict do nothing;
+
+      update public.platform_events set incident_id = v_incident_id where id = v_correlated_event_id;
+    end if;
+
+    insert into public.incident_events (incident_id, event_id)
+    values (v_incident_id, v_event_id)
+    on conflict do nothing;
+
+    update public.platform_events set incident_id = v_incident_id where id = v_event_id;
+  end if;
+
+  -- in_app is always enqueued (it is the Alerts view's own source of truth);
+  -- webhook/email are gated by verification + preferences, defaulting to
+  -- "allowed" when the wallet has not configured preferences yet.
+  insert into public.event_deliveries (event_id, channel)
+  select v_event_id, chan.channel_type
+  from (
+    select 'in_app'::text as channel_type
+    union all
+    select nc.channel_type
+    from public.notification_channels nc
+    where nc.wallet_address = p_wallet_address
+      and nc.verified_at is not null
+  ) chan
+  left join public.notification_preferences np on np.wallet_address = p_wallet_address
+  where
+    chan.channel_type = 'in_app'
+    or np.wallet_address is null
+    or (
+      np.sources @> to_jsonb(p_source)
+      and v_severity_rank_new >= (case np.min_severity when 'critical' then 3 when 'warning' then 2 else 1 end)
+      and np.channels @> to_jsonb(chan.channel_type)
+    )
+  on conflict (event_id, channel) do nothing;
+
+  insert into public.delivery_audit_log (delivery_id, stage)
+  select ed.id, 'created' from public.event_deliveries ed where ed.event_id = v_event_id;
+
+  insert into public.delivery_audit_log (delivery_id, stage)
+  select ed.id, 'queued' from public.event_deliveries ed where ed.event_id = v_event_id;
+
+  return jsonb_build_object(
+    'created', true,
+    'event_id', v_event_id,
+    'incident_id', v_incident_id,
+    'escalated', v_escalated
+  );
+end;
+$$;
+
+-- Atomically claims up to p_limit due deliveries for one channel, marking
+-- them 'processing' so an overlapping worker invocation cannot claim the
+-- same row (FOR UPDATE SKIP LOCKED). This is what makes the drain worker an
+-- idempotent consumer under redelivery/overlap.
+create or replace function public.fn_claim_deliveries(
+  p_channel text,
+  p_limit integer default 25
+) returns setof public.event_deliveries
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  return query
+  update public.event_deliveries ed
+  set status = 'processing', updated_at = now()
+  where ed.id in (
+    select id from public.event_deliveries
+    where channel = p_channel
+      and status in ('pending', 'failed')
+      and next_attempt_at <= now()
+    order by next_attempt_at asc
+    for update skip locked
+    limit p_limit
+  )
+  returning ed.*;
+end;
+$$;
+
+-- Records the outcome of one delivery attempt: on success, marks delivered;
+-- on failure, either schedules an exponential-backoff retry or, once
+-- p_max_attempts is exhausted, transitions to dead_letter. Always appends an
+-- 'attempted' audit row first, so partial failures are still inspectable.
+create or replace function public.fn_record_delivery_outcome(
+  p_delivery_id uuid,
+  p_success boolean,
+  p_error text default null,
+  p_max_attempts integer default 5,
+  p_base_backoff_seconds integer default 30
+) returns public.event_deliveries
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_row public.event_deliveries%rowtype;
+  v_attempts integer;
+  v_backoff integer;
+begin
+  select * into v_row from public.event_deliveries where id = p_delivery_id for update;
+  v_attempts := v_row.attempts + 1;
+
+  insert into public.delivery_audit_log (delivery_id, stage, outcome, detail)
+  values (
+    p_delivery_id,
+    'attempted',
+    case when p_success then 'success' else 'failure' end,
+    case when p_error is not null then jsonb_build_object('error', p_error) else null end
+  );
+
+  if p_success then
+    update public.event_deliveries
+    set status = 'delivered', attempts = v_attempts, delivered_at = now(), last_error = null, updated_at = now()
+    where id = p_delivery_id
+    returning * into v_row;
+
+    insert into public.delivery_audit_log (delivery_id, stage, outcome)
+    values (p_delivery_id, 'delivered', 'success');
+  elsif v_attempts >= p_max_attempts then
+    update public.event_deliveries
+    set status = 'dead_letter', attempts = v_attempts, last_error = p_error, updated_at = now()
+    where id = p_delivery_id
+    returning * into v_row;
+
+    insert into public.delivery_audit_log (delivery_id, stage, outcome, detail)
+    values (p_delivery_id, 'dead_letter', 'exhausted', jsonb_build_object('error', p_error));
+  else
+    v_backoff := p_base_backoff_seconds * power(2, v_attempts - 1);
+    update public.event_deliveries
+    set status = 'failed',
+        attempts = v_attempts,
+        last_error = p_error,
+        next_attempt_at = now() + make_interval(secs => v_backoff),
+        updated_at = now()
+    where id = p_delivery_id
+    returning * into v_row;
+  end if;
+
+  return v_row;
+end;
+$$;
+
+-- Fixed-window rate limiter: returns true if the wallet/channel is still
+-- under p_max_per_window for the current window, incrementing atomically
+-- either way so the check-and-increment is race-free under concurrent sends.
+create or replace function public.fn_check_and_increment_rate_limit(
+  p_wallet_address text,
+  p_channel_type text,
+  p_window_seconds integer default 60,
+  p_max_per_window integer default 5
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_window_start timestamptz;
+  v_count integer;
+begin
+  v_window_start := to_timestamp(floor(extract(epoch from now()) / p_window_seconds) * p_window_seconds);
+
+  insert into public.channel_rate_limit_windows (wallet_address, channel_type, window_start, count)
+  values (p_wallet_address, p_channel_type, v_window_start, 1)
+  on conflict (wallet_address, channel_type, window_start)
+  do update set count = channel_rate_limit_windows.count + 1
+  returning count into v_count;
+
+  return v_count <= p_max_per_window;
+end;
+$$;


### PR DESCRIPTION
## Summary Closes #299

Closes #299

First slice of the durable event platform: a transactional outbox with atomic dedupe/hysteresis/suppression/escalation and cross-source correlation, wallet-signature ownership auth, the activity-feed bridge (all three existing producers durably enqueue with zero call-site changes), and durable failure reporting from the automation and vault-invest producers. Multi-channel delivery (webhook/email + verification), notification preferences, the borrowing cron worker, the declarative rule engine.

## Why

Today, `activityStore.ts` is a Zustand store persisted only to `localStorage`: an automated rebalance failing or a vault harvest erroring is invisible unless the user happens to reopen the tab. `automation/execute`/`vault/invest` can fail with the failure visible only in the HTTP response to whoever triggered the call. This PR lays the durable foundation — a real outbox, real ownership checks, and the bridge that gets the three existing producers onto it — that the rest of #299's scope (delivery, borrowing, the UI) builds on next.

## What was built

### Durable outbox core (`supabase/migrations/`, `apps/web-app/src/lib/event-platform/`)

| Piece | What it does |
|---|---|
| `0001_event_platform_core.sql` | `wallet_auth_challenges`/`wallet_sessions` (auth) and `platform_events`/`alert_dedupe_state` (the outbox and its hysteresis/suppression/escalation state). RLS enabled, no anon/authenticated policies. |
| `0002_event_platform_delivery_and_rules.sql` | Schema for the follow-up PR's scope — `event_deliveries`/`delivery_audit_log`, `notification_channels`/`notification_preferences`/`channel_rate_limit_windows`, `borrowing_thresholds`, `rule_definitions`, and `incidents`/`incident_events` (the latter used by this PR's correlation logic already). Shipping the full schema now avoids a second migration pass touching the same tables later. |
| `0003_event_platform_functions.sql` | `fn_raise_platform_event` — the single, atomic write path: row-locked dedupe/escalation/correlation decision, run as one Postgres transaction so a concurrent evaluation for the same `(source, wallet_address, dedupe_key)` blocks on the lock rather than racing. Also includes `fn_claim_deliveries`/`fn_record_delivery_outcome`/`fn_check_and_increment_rate_limit` for the follow-up PR's queue-draining work. |
| `types.ts` | `EventSource`, `Severity`, `PlatformEvent`, and the shapes the follow-up PR's delivery/preferences/incident work will use. |
| `dedup.ts` | `computeTransition` — the pure hysteresis/suppression/escalation decision, exhaustively unit tested. `fn_raise_platform_event` is a deliberate, faithful plpgsql translation of this exact logic, since asserting on plpgsql control flow directly isn't practical. |
| `correlation.ts` | `decideCorrelation` — the pure cross-source correlation decision (most recent other-source event within the window attaches to/creates an incident), mirrored in the SQL function. |
| `supabaseServer.ts` / `outbox.ts` | Server-only, service-role Supabase client and `raiseEvent`/`resolveEvent`, the call site for `fn_raise_platform_event`. |
| `auth/challenge.ts` / `auth/session.ts` | SEP-10-lite wallet-ownership proof (nonce → wallet signs it → `Keypair.verify` → opaque session cookie). This platform's new wallet-scoped state didn't exist before, so it gets a real signature check rather than trusting a client-supplied address like the rest of this codebase's routes do today. |
| `vaultStageOutcome.ts` | The vault-invest producer's failure→event wiring, kept dependency-free (no Stellar SDK imports) specifically so it's unit-testable — `app/api/vault/invest/route.ts` imports `@neko/defindex-vault`, which doesn't resolve under Vitest in this repo (pre-existing workspace issue). |

### New API routes

- `auth/challenge`, `auth/verify` — the sign-in handshake, validated with Zod via the existing `lib/validation/parse.ts` helper.
- `events`, `events/ingest` — list events+incidents for the session wallet; the activity-store bridge's target.


# Test plan

- [x] `npm test` (web-app) — 44 new tests: dedup/correlation (pure), the outbox integration flow against an in-memory fake DB (dedupe, suppression, escalation, correlation, wallet isolation), wallet-auth challenge/session (real `Keypair` signing — correct signature accepted, wrong keypair/tampered message/expired/replayed nonce all rejected), the activity-store bridge (regression + integration), and the automation/vault producer wiring. All pass; 0 regressions against the pre-existing suite (same 16 pre-existing environment-only failures — missing `.env.local` — with or without this branch).
- [x] `npm run lint` — identical to `dev` (19 warnings, 0 errors, before and after).
- [x] `npx tsc --noEmit` — identical to `dev` (51 errors, before and after, all pre-existing `@neko/*` workspace-resolution issues unrelated to this change).
