### PR TITLE
Feature/leverage loop alejandro

### DIFF
--- a/apps/web-app/src/app/(app)/strategies/page.tsx
+++ b/apps/web-app/src/app/(app)/strategies/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import Strategies from "@/features/strategies/components/Strategies";
 
 export const metadata: Metadata = {
@@ -8,5 +9,9 @@ export const metadata: Metadata = {
 };
 
 export default function StrategiesPage() {
-  return <Strategies />;
+  return (
+    <Suspense fallback={null}>
+      <Strategies />
+    </Suspense>
+  );
 }

--- a/apps/web-app/src/app/api/leverage/delegation/route.ts
+++ b/apps/web-app/src/app/api/leverage/delegation/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getCoordinatorLedgerStore } from "@/lib/coordinator/ledger";
+import {
+  createDelegationGrant,
+  revokeDelegationGrant,
+} from "@/lib/coordinator/delegation";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Grant/revoke management for a position's deleveraging delegation (Scope
+ * §5/§7). The client (features/strategies's leverage builder) has ALREADY
+ * collected the user's wallet signatures for every unwind tranche via the
+ * same SignFn the manual strategy engine uses — this route only persists
+ * the resulting fully-signed payload into the durable coordinator ledger
+ * and never itself asks for or holds a signature.
+ */
+
+const signedStepSchema = z.object({
+  stepId: z.string(),
+  operationType: z.enum(["repay", "withdrawCollateral"]),
+  protocol: z.string(),
+  poolType: z.enum(["blend", "neko", "soroswap", "custom"]),
+  assetCode: z.string(),
+  amount: z.string(),
+  submissionMode: z.enum(["rpc", "soroswapApi"]),
+  signedXdr: z.string().min(1),
+  networkPassphrase: z.string().min(1),
+});
+
+const trancheSchema = z.object({
+  id: z.string(),
+  order: z.number(),
+  collateralAmount: z.string(),
+  debtAmount: z.string(),
+  collateralPoolId: z.string().min(1),
+  borrowPoolId: z.string().min(1),
+  steps: z.array(signedStepSchema).min(1),
+});
+
+const createGrantSchema = z.object({
+  positionId: z.string().min(1),
+  walletAddress: z.string().min(1),
+  assetCode: z.string().min(1),
+  borrowAssetCode: z.string().min(1),
+  tranches: z.array(trancheSchema).min(1),
+  /** Milliseconds; defaults to 90 days if omitted. */
+  validityMs: z.number().positive().optional(),
+  guardConfig: z.object({
+    deleverageThreshold: z.number().positive(),
+    hysteresis: z.number().min(0),
+  }),
+});
+
+const DEFAULT_VALIDITY_MS = 90 * 24 * 60 * 60 * 1000;
+
+export async function GET(request: NextRequest) {
+  const positionId = request.nextUrl.searchParams.get("positionId");
+  if (!positionId) {
+    return NextResponse.json(
+      { error: "positionId query param is required" },
+      { status: 400 }
+    );
+  }
+  const grant = await getCoordinatorLedgerStore().getGrant(positionId);
+  return NextResponse.json({ grant });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+  const parsed = createGrantSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Invalid delegation grant payload",
+        issues: parsed.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+
+  const store = getCoordinatorLedgerStore();
+  const existing = await store.getGrant(parsed.data.positionId);
+  if (existing && existing.status === "active") {
+    return NextResponse.json(
+      {
+        error:
+          "An active delegation already exists for this position — revoke it before granting a new one.",
+      },
+      { status: 409 }
+    );
+  }
+
+  const grant = createDelegationGrant({
+    positionId: parsed.data.positionId,
+    walletAddress: parsed.data.walletAddress,
+    assetCode: parsed.data.assetCode,
+    borrowAssetCode: parsed.data.borrowAssetCode,
+    tranches: parsed.data.tranches,
+    validityMs: parsed.data.validityMs ?? DEFAULT_VALIDITY_MS,
+    guardConfig: parsed.data.guardConfig,
+  });
+  await store.saveGrant(grant);
+
+  return NextResponse.json({ grant }, { status: 201 });
+}
+
+export async function DELETE(request: NextRequest) {
+  const positionId = request.nextUrl.searchParams.get("positionId");
+  if (!positionId) {
+    return NextResponse.json(
+      { error: "positionId query param is required" },
+      { status: 400 }
+    );
+  }
+
+  const store = getCoordinatorLedgerStore();
+  const existing = await store.getGrant(positionId);
+  if (!existing) {
+    return NextResponse.json({ error: "No delegation found" }, { status: 404 });
+  }
+
+  const revoked = revokeDelegationGrant(existing);
+  await store.saveGrant(revoked);
+  return NextResponse.json({ grant: revoked });
+}

--- a/apps/web-app/src/app/api/leverage/guard/route.ts
+++ b/apps/web-app/src/app/api/leverage/guard/route.ts
@@ -1,0 +1,335 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  BASE_FEE,
+  Keypair,
+  Transaction,
+  TransactionBuilder,
+  rpc,
+} from "@stellar/stellar-sdk";
+import { rpcUrl } from "@/lib/constants/network";
+import { serverEnv } from "@/lib/env.server";
+import { getAssetsConfig } from "@/lib/constants/assets.config";
+import { stellarPriceService } from "@/lib/services/stellar-price.service";
+import { BlendPoolAdapter } from "@/lib/orchestrator/adapters/BlendPoolAdapter";
+import { PoolRegistry } from "@/lib/orchestrator/core/PoolRegistry";
+import { getCoordinatorLedgerStore } from "@/lib/coordinator/ledger";
+import {
+  reconcileCoordinatorRun,
+  runCoordinatorUnwind,
+  type CoordinatorExecutionDeps,
+  type CoordinatorTransportAdapter,
+} from "@/lib/coordinator/execute";
+import { selectTranchesToClearBreach } from "@/lib/coordinator/delegation";
+import {
+  computeGrantRiskSnapshot,
+  evaluatePosition,
+  type PoolPositionReader,
+} from "@/lib/coordinator/deleverageGuard";
+import type { DelegationGrant } from "@/lib/coordinator/types";
+
+/**
+ * Automated deleveraging guard (Scope §6), cron-triggered like
+ * app/api/vault/invest/route.ts. Every tick: reconcile+resume any run left
+ * in-progress by a prior crash, then re-evaluate every active grant's live
+ * health factor and trigger a bounded partial unwind on breach, strictly
+ * within what that position's DelegationGrant authorizes.
+ */
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+let lastRun = 0;
+const COOLDOWN_MS = 60 * 1000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ─── On-chain reads ───────────────────────────────────────────────────────────
+
+/**
+ * Live pool-position reader wired to the real adapters. Blend exposes both
+ * collateral and liabilities per reserve (BlendPoolAdapter.getPoolInfo/
+ * getUserPosition), so it's read directly. Neko's adapter surface has no
+ * debt-read method at all (see NekoLendingAdapter) and its supply-balance
+ * read doesn't cleanly distinguish "collateral" from "plain supply" either
+ * — rather than fabricate a number for either leg, Neko pools report
+ * unreadable (null) here and lib/coordinator/deleverageGuard.ts's documented,
+ * safety-biased fallback takes over (collateral defaults to 0 — the
+ * conservative direction; debt falls back to the tranche's own known
+ * static amount — never silently zeroed).
+ */
+const readPoolPosition: PoolPositionReader = async (poolId, walletAddress) => {
+  if (!poolId.startsWith("blend:")) return null;
+
+  try {
+    const rawId = PoolRegistry.stripPrefix(poolId);
+    const [poolContractId] = rawId.split(":");
+    const adapter = new BlendPoolAdapter(poolContractId);
+    const [info, position] = await Promise.all([
+      adapter.getPoolInfo(rawId),
+      adapter.getUserPosition(rawId, walletAddress),
+    ]);
+    const decimals = info.tokens[0]?.decimals ?? 7;
+    const collateralRaw = BigInt(String(position.metadata.collateral ?? "0"));
+    const liabilitiesRaw = BigInt(String(position.metadata.liabilities ?? "0"));
+    return {
+      collateralUnits: Number(collateralRaw) / 10 ** decimals,
+      debtUnits: Number(liabilitiesRaw) / 10 ** decimals,
+    };
+  } catch {
+    return null;
+  }
+};
+
+async function buildPriceLookup(
+  assetCodes: string[]
+): Promise<(code: string) => number | null> {
+  const assetsConfig = getAssetsConfig();
+  const unique = [...new Set(assetCodes)];
+  const prices = await Promise.all(
+    unique.map((code) =>
+      stellarPriceService
+        .getPrice(code, assetsConfig[code]?.contract)
+        .catch(() => 0)
+    )
+  );
+  const map = new Map<string, number>();
+  unique.forEach((code, i) => {
+    if (prices[i] > 0) map.set(code, prices[i]);
+  });
+  return (code: string) => map.get(code) ?? null;
+}
+
+// ─── Submission transport ────────────────────────────────────────────────────
+
+function makeTransport(): CoordinatorTransportAdapter {
+  return {
+    async submit(xdr, np) {
+      const server = new rpc.Server(rpcUrl);
+      const tx = TransactionBuilder.fromXDR(xdr, np);
+      const result = await server.sendTransaction(tx);
+      if (result.status !== "PENDING") {
+        throw new Error(`Submission rejected with status ${result.status}`);
+      }
+      return { hash: result.hash };
+    },
+    async confirm(hash) {
+      const server = new rpc.Server(rpcUrl);
+      for (let i = 0; i < 25; i++) {
+        await sleep(2000);
+        const status = await server.getTransaction(hash);
+        if (status.status === "SUCCESS") return status;
+        if (status.status === "FAILED") {
+          throw new Error("Transaction failed on-chain");
+        }
+      }
+      throw new Error("Transaction confirmation timed out");
+    },
+  };
+}
+
+/**
+ * Wraps an already wallet-signed inner transaction in a fresh fee-bump
+ * envelope, mirroring VAULT_MANAGER_SECRET_KEY's role in
+ * app/api/vault/invest/route.ts — this key only ever pays and relays a fee
+ * bump; it never signs the inner operation, so it structurally cannot
+ * authorize anything the pre-signed tranche didn't already authorize.
+ * Falls back to submitting the inner XDR unmodified when the key isn't
+ * configured (optional at the schema level, matching every other
+ * integration secret in env.server.ts).
+ */
+async function wrapForSubmission(
+  signedInnerXdr: string,
+  np: string
+): Promise<{ xdr: string }> {
+  if (!serverEnv.LEVERAGE_COORDINATOR_SECRET_KEY)
+    return { xdr: signedInnerXdr };
+
+  const keypair = Keypair.fromSecret(serverEnv.LEVERAGE_COORDINATOR_SECRET_KEY);
+  const inner = TransactionBuilder.fromXDR(signedInnerXdr, np);
+  if (!(inner instanceof Transaction)) return { xdr: signedInnerXdr };
+
+  const feeBumpFee = String(Number(BASE_FEE) * 10);
+  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+    keypair,
+    feeBumpFee,
+    inner,
+    np
+  );
+  feeBump.sign(keypair);
+  return { xdr: feeBump.toXDR() };
+}
+
+async function getTransactionStatus(
+  hash: string
+): Promise<"SUCCESS" | "FAILED" | "PENDING" | "NOT_FOUND"> {
+  const server = new rpc.Server(rpcUrl);
+  const result = await server.getTransaction(hash);
+  if (result.status === "SUCCESS") return "SUCCESS";
+  if (result.status === "FAILED") return "FAILED";
+  if (result.status === "NOT_FOUND") return "NOT_FOUND";
+  return "PENDING";
+}
+
+// ─── One grant's guard tick ───────────────────────────────────────────────────
+
+interface GrantTickResult {
+  positionId: string;
+  action: string;
+  detail?: string;
+}
+
+async function tickGrant(
+  grant: DelegationGrant,
+  deps: CoordinatorExecutionDeps,
+  getPrice: (code: string) => number | null
+): Promise<GrantTickResult> {
+  const store = deps.store;
+
+  const inProgress = await store.findInProgressRunForPosition(grant.positionId);
+  if (inProgress) {
+    const reconciled = await reconcileCoordinatorRun(inProgress, {
+      getTransactionStatus,
+    });
+    await store.saveRun(reconciled);
+    const resumed = await runCoordinatorUnwind(deps, {
+      grant,
+      selection: {
+        trancheIds: reconciled.trancheIdsPlanned,
+        steps: [],
+      },
+      healthFactorAtTrigger: reconciled.healthFactorAtTrigger,
+      healthFactorTarget: reconciled.healthFactorTarget,
+      existingRun: reconciled,
+    });
+    return {
+      positionId: grant.positionId,
+      action: `resumed-run:${resumed.status}`,
+    };
+  }
+
+  const snapshot = await computeGrantRiskSnapshot(
+    grant,
+    readPoolPosition,
+    getPrice
+  );
+  const action = evaluatePosition(
+    snapshot,
+    grant,
+    grant.breached,
+    grant.guardConfig
+  );
+
+  if (action.kind === "recovered") {
+    await store.saveGrant({ ...grant, breached: false });
+    return { positionId: grant.positionId, action: "recovered" };
+  }
+
+  if (action.kind === "hold" || action.kind === "alert-only") {
+    return {
+      positionId: grant.positionId,
+      action: action.kind,
+      detail: action.kind === "alert-only" ? action.reason : undefined,
+    };
+  }
+
+  // trigger-unwind
+  if (!grant.breached) {
+    await store.saveGrant({ ...grant, breached: true });
+  }
+
+  const selection = selectTranchesToClearBreach(
+    grant,
+    action.requiredDebtReliefUnits
+  );
+  if (!selection) {
+    return {
+      positionId: grant.positionId,
+      action: "trigger-unwind-no-tranches-left",
+    };
+  }
+
+  const run = await runCoordinatorUnwind(deps, {
+    grant,
+    selection,
+    healthFactorAtTrigger: snapshot.healthFactor,
+    healthFactorTarget: action.targetHealthFactor,
+  });
+
+  return { positionId: grant.positionId, action: `unwind:${run.status}` };
+}
+
+// ─── Route handlers ───────────────────────────────────────────────────────────
+
+export async function GET() {
+  const store = getCoordinatorLedgerStore();
+  const grants = await store.listActiveGrants();
+  const priceOf = await buildPriceLookup(
+    grants.flatMap((g) => [g.assetCode, g.borrowAssetCode])
+  );
+
+  const statuses = await Promise.all(
+    grants.map(async (grant) => {
+      const snapshot = await computeGrantRiskSnapshot(
+        grant,
+        readPoolPosition,
+        priceOf
+      );
+      return {
+        positionId: grant.positionId,
+        healthFactor: snapshot.healthFactor,
+        deleverageThreshold: grant.guardConfig.deleverageThreshold,
+        breached: grant.breached,
+        tranchesRemaining:
+          grant.tranches.length - grant.consumedTrancheIds.length,
+      };
+    })
+  );
+
+  return NextResponse.json({
+    activeGrants: grants.length,
+    statuses,
+    cooldownRemaining: Math.max(
+      0,
+      Math.ceil((lastRun + COOLDOWN_MS - Date.now()) / 1000)
+    ),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const isCron = request.headers.get("x-vercel-cron") === "1";
+    if (!isCron) {
+      const remaining = lastRun + COOLDOWN_MS - Date.now();
+      if (remaining > 0) {
+        return NextResponse.json(
+          { error: `Please wait ${Math.ceil(remaining / 1000)}s` },
+          { status: 429 }
+        );
+      }
+    }
+    lastRun = Date.now();
+
+    const store = getCoordinatorLedgerStore();
+    const grants = await store.listActiveGrants();
+    const priceOf = await buildPriceLookup(
+      grants.flatMap((g) => [g.assetCode, g.borrowAssetCode])
+    );
+
+    const deps: CoordinatorExecutionDeps = {
+      store,
+      transports: { rpc: makeTransport(), soroswapApi: makeTransport() },
+      wrapForSubmission,
+    };
+
+    const results = await Promise.all(
+      grants.map((grant) => tickGrant(grant, deps, priceOf))
+    );
+
+    return NextResponse.json({ success: true, results });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web-app/src/features/analytics/utils/allocation.ts
+++ b/apps/web-app/src/features/analytics/utils/allocation.ts
@@ -11,6 +11,7 @@ const PROTOCOL_LABELS: Record<ProtocolKind, string> = {
   borrowing: "Collateral",
   vault: "Vault",
   backstop: "Backstop",
+  leverage: "Leverage",
 };
 
 /**

--- a/apps/web-app/src/features/dashboard/components/ui/YourPositions.tsx
+++ b/apps/web-app/src/features/dashboard/components/ui/YourPositions.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import Link from "next/link";
 import { ArrowRight, Layers } from "lucide-react";
 import { useUnifiedPositions } from "@/features/dashboard/hooks/useUnifiedPositions";
-import type { ProtocolKind } from "@/features/dashboard/positions/types";
+import { DelegationPanel } from "@/features/strategies/leverage/DelegationPanel";
+import type {
+  ProtocolKind,
+  UnifiedPosition,
+} from "@/features/dashboard/positions/types";
 
 const PROTOCOL_LABELS: Record<ProtocolKind, string> = {
   wallet: "Wallet",
@@ -13,6 +17,7 @@ const PROTOCOL_LABELS: Record<ProtocolKind, string> = {
   borrowing: "Borrowing",
   vault: "Vault",
   backstop: "Backstop",
+  leverage: "Leverage",
 };
 
 function formatUsd(value: number): string {
@@ -29,6 +34,44 @@ function formatQuantity(value: number): string {
   if (value >= 1000)
     return value.toLocaleString("en-US", { maximumFractionDigits: 2 });
   return parseFloat(value.toFixed(4)).toString();
+}
+
+function PositionCardBody({ position }: { position: UnifiedPosition }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-white/30 rounded-full bg-white/5 px-2 py-0.5">
+            {PROTOCOL_LABELS[position.protocol]}
+          </span>
+          {position.direction === "liability" && (
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-[#E4574B]/80 rounded-full bg-[#E4574B]/10 px-2 py-0.5">
+              Debt
+            </span>
+          )}
+        </div>
+        <p className="text-white font-semibold text-sm mt-1.5 truncate">
+          {position.label}
+        </p>
+        <p className="text-white/40 text-xs mt-0.5">
+          {formatQuantity(position.quantity)} {position.assetCode}
+          {typeof position.apy === "number" &&
+            ` · ${position.apy.toFixed(1)}% APY`}
+        </p>
+      </div>
+      <div className="text-right shrink-0">
+        <p
+          className={`font-semibold text-sm ${
+            position.direction === "liability" ? "text-[#E4574B]" : "text-white"
+          }`}
+        >
+          {position.valueUsd !== null
+            ? `${position.direction === "liability" ? "-" : ""}${formatUsd(position.valueUsd)}`
+            : "—"}
+        </p>
+      </div>
+    </div>
+  );
 }
 
 const YourPositions: React.FC = () => {
@@ -84,51 +127,46 @@ const YourPositions: React.FC = () => {
         </div>
       ) : (
         <div className="space-y-3">
-          {activePositions.map((position) => (
-            <Link
-              key={position.id}
-              href={position.href}
-              className="block rounded-2xl bg-[#1C1C1C] border border-white/5 p-5 hover:border-white/10 hover:bg-[#222222] transition-all duration-200"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[10px] font-semibold uppercase tracking-wide text-white/30 rounded-full bg-white/5 px-2 py-0.5">
-                      {PROTOCOL_LABELS[position.protocol]}
-                    </span>
-                    {position.direction === "liability" && (
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-[#E4574B]/80 rounded-full bg-[#E4574B]/10 px-2 py-0.5">
-                        Debt
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-white font-semibold text-sm mt-1.5 truncate">
-                    {position.label}
-                  </p>
-                  <p className="text-white/40 text-xs mt-0.5">
-                    {formatQuantity(position.quantity)} {position.assetCode}
-                    {typeof position.apy === "number" &&
-                      ` · ${position.apy.toFixed(1)}% APY`}
-                  </p>
+          {activePositions.map((position) => {
+            // Scope §7's delegation panel goes on the leverage position's
+            // OWN card — attached only to the collateral row (id suffix
+            // ":collateral"), not its paired debt row, so it renders once
+            // per position. It needs an interactive revoke control, which
+            // can't nest inside the row's own <Link> (invalid/inaccessible
+            // HTML), so this row alone renders as a <div> with the label
+            // wrapped in its own inner <Link> and the panel as a sibling.
+            const leverageStrategyId =
+              position.protocol === "leverage" &&
+              position.id.endsWith(":collateral")
+                ? position.id.slice("leverage:".length, -":collateral".length)
+                : null;
+
+            const body = <PositionCardBody position={position} />;
+
+            if (leverageStrategyId) {
+              return (
+                <div
+                  key={position.id}
+                  className="rounded-2xl bg-[#1C1C1C] border border-white/5 p-5 hover:border-white/10 transition-all duration-200"
+                >
+                  <Link href={position.href} className="block">
+                    {body}
+                  </Link>
+                  <DelegationPanel positionId={leverageStrategyId} />
                 </div>
-                <div className="text-right shrink-0">
-                  <p
-                    className={`font-semibold text-sm ${
-                      position.direction === "liability"
-                        ? "text-[#E4574B]"
-                        : "text-white"
-                    }`}
-                  >
-                    {position.valueUsd !== null
-                      ? `${position.direction === "liability" ? "-" : ""}${formatUsd(
-                          position.valueUsd
-                        )}`
-                      : "—"}
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ))}
+              );
+            }
+
+            return (
+              <Link
+                key={position.id}
+                href={position.href}
+                className="block rounded-2xl bg-[#1C1C1C] border border-white/5 p-5 hover:border-white/10 hover:bg-[#222222] transition-all duration-200"
+              >
+                {body}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web-app/src/features/dashboard/hooks/useUnifiedPositions.ts
+++ b/apps/web-app/src/features/dashboard/hooks/useUnifiedPositions.ts
@@ -18,12 +18,17 @@ import {
   normalizeBackstopPositions,
   normalizeBorrowPositions,
   normalizeLendingPositions,
+  normalizeLeveragePositions,
   normalizePoolPositions,
   normalizeVaultPosition,
   normalizeWalletHoldings,
   type PriceLookup,
 } from "../positions/normalize";
 import { usePortfolioBackstopPositions } from "../positions/usePortfolioBackstopPositions";
+import {
+  computeLeveragePositionSummary,
+  useLeverageStrategies,
+} from "../positions/leverage";
 import type { PortfolioSummary } from "../positions/types";
 
 const ONE_SHARE = 1_000_000_000_000n;
@@ -55,6 +60,7 @@ export function useUnifiedPositions(): PortfolioSummary {
   const { data: vaultData, isLoading: vaultDataLoading } = useVaultData();
   const { positions: backstopPositions, isLoading: backstopLoading } =
     usePortfolioBackstopPositions();
+  const { strategies: leverageStrategies } = useLeverageStrategies(address);
 
   const vaultQuantity = useMemo(() => {
     if (!vaultData || userShares <= 0n) return 0;
@@ -81,6 +87,10 @@ export function useUnifiedPositions(): PortfolioSummary {
     backstopPositions.forEach((p) => {
       if (p.assetCode) codes.add(p.assetCode);
     });
+    leverageStrategies.forEach(({ meta }) => {
+      codes.add(meta.assetCode);
+      codes.add(meta.borrowAssetCode);
+    });
     return Array.from(codes);
   }, [
     lendingPositions,
@@ -88,6 +98,7 @@ export function useUnifiedPositions(): PortfolioSummary {
     poolPositions,
     vaultQuantity,
     backstopPositions,
+    leverageStrategies,
   ]);
 
   const assetsConfig = getAssetsConfig();
@@ -129,6 +140,11 @@ export function useUnifiedPositions(): PortfolioSummary {
         getPrice
       ),
       ...normalizeBackstopPositions(backstopPositions, getPrice),
+      ...normalizeLeveragePositions(
+        leverageStrategies.map(({ id, name, meta }) =>
+          computeLeveragePositionSummary(id, name, meta, getPrice)
+        )
+      ),
     ];
   }, [
     holdings,
@@ -137,6 +153,7 @@ export function useUnifiedPositions(): PortfolioSummary {
     borrowPositions,
     vaultQuantity,
     backstopPositions,
+    leverageStrategies,
     getPrice,
   ]);
 

--- a/apps/web-app/src/features/dashboard/positions/__tests__/leverage.test.ts
+++ b/apps/web-app/src/features/dashboard/positions/__tests__/leverage.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { computeLeveragePositionSummary } from "../leverage";
+import { normalizeLeveragePositions } from "../normalize";
+import type { LeverageLoopStrategyMeta } from "@/lib/strategy/leverage/types";
+import type { PriceLookup } from "../normalize";
+
+function makeMeta(
+  overrides: Partial<LeverageLoopStrategyMeta> = {}
+): LeverageLoopStrategyMeta {
+  return {
+    kind: "leverage-loop",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    targetMultiple: 1.7,
+    achievedMultiple: 1.69,
+    safetyBufferPct: 5,
+    route: {
+      poolsUsed: [
+        {
+          poolType: "blend",
+          collateralPoolId: "blend:CPOOL:CUSTRY",
+          borrowPoolId: "blend:CPOOL:CUSDC",
+          maxLtvPct: 75,
+          borrowRatePct: 4,
+          availableLiquidity: "1000",
+        },
+      ],
+      iterations: [
+        {
+          index: 1,
+          poolType: "blend",
+          collateralPoolId: "blend:CPOOL:CUSTRY",
+          borrowPoolId: "blend:CPOOL:CUSDC",
+          depositAmount: "100",
+          borrowAmount: "70",
+          swapAmountOut: "69",
+          swapPriceImpactBps: 100,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+const priceOf =
+  (prices: Record<string, number>): PriceLookup =>
+  (code) =>
+    code in prices ? prices[code] : null;
+
+describe("computeLeveragePositionSummary", () => {
+  it("reduces a single-iteration loop's collateral/debt into HF, liquidation price, and effective leverage", () => {
+    const summary = computeLeveragePositionSummary(
+      "strat-1",
+      "USTRY 1.7x",
+      makeMeta(),
+      priceOf({ USTRY: 10, USDC: 1 })
+    );
+
+    // total collateral = initial deposit (100) + final redeposit (69) = 169
+    expect(summary.totalCollateralUnits).toBeCloseTo(169, 6);
+    expect(summary.totalDebtUnits).toBeCloseTo(70, 6);
+    expect(summary.blendedCollateralFactorPct).toBeCloseTo(75, 6);
+    expect(summary.blendedEntryPrice).toBeCloseTo(10 * 1.01, 6);
+    expect(summary.collateralValueUsd).toBeCloseTo(1690, 6);
+    expect(summary.debtValueUsd).toBeCloseTo(70, 6);
+    expect(summary.effectiveLeverage).toBeCloseTo(1690 / 1620, 6);
+    expect(summary.healthFactor).toBeCloseTo((1690 * 0.75) / 70, 6);
+    expect(summary.liquidationPrice).toBeCloseTo(70 / (169 * 0.75), 6);
+  });
+
+  it("blends collateral factor across multiple pools weighted by each pool's share of total debt", () => {
+    const meta = makeMeta({
+      route: {
+        poolsUsed: [
+          {
+            poolType: "blend",
+            collateralPoolId: "blend:CPOOL:CUSTRY",
+            borrowPoolId: "blend:CPOOL:CUSDC",
+            maxLtvPct: 80,
+            borrowRatePct: 4,
+            availableLiquidity: "1000",
+          },
+          {
+            poolType: "neko",
+            collateralPoolId: "neko:USTRY",
+            borrowPoolId: "neko:USDC",
+            maxLtvPct: 70,
+            borrowRatePct: 6,
+            availableLiquidity: "1000",
+          },
+        ],
+        iterations: [
+          {
+            index: 1,
+            poolType: "blend",
+            collateralPoolId: "blend:CPOOL:CUSTRY",
+            borrowPoolId: "blend:CPOOL:CUSDC",
+            depositAmount: "100",
+            borrowAmount: "80", // weight 80
+            swapAmountOut: "80",
+            swapPriceImpactBps: 0,
+          },
+          {
+            index: 2,
+            poolType: "neko",
+            collateralPoolId: "neko:USTRY",
+            borrowPoolId: "neko:USDC",
+            depositAmount: "80",
+            borrowAmount: "20", // weight 20
+            swapAmountOut: "20",
+            swapPriceImpactBps: 0,
+          },
+        ],
+      },
+    });
+
+    const summary = computeLeveragePositionSummary(
+      "strat-2",
+      "USTRY multi-pool",
+      meta,
+      priceOf({ USTRY: 1, USDC: 1 })
+    );
+
+    // weighted: (80*80 + 20*70) / 100 = 78
+    expect(summary.blendedCollateralFactorPct).toBeCloseTo(78, 6);
+  });
+
+  it("returns null risk figures (but keeps unit totals and entry price) when the debt asset has no price", () => {
+    const summary = computeLeveragePositionSummary(
+      "strat-3",
+      "USTRY no debt price",
+      makeMeta(),
+      priceOf({ USTRY: 10 })
+    );
+
+    expect(summary.totalCollateralUnits).toBeCloseTo(169, 6);
+    expect(summary.blendedEntryPrice).not.toBeNull();
+    expect(summary.debtValueUsd).toBeNull();
+    expect(summary.healthFactor).toBeNull();
+    expect(summary.liquidationPrice).toBeNull();
+    expect(summary.effectiveLeverage).toBeNull();
+  });
+
+  it("handles a strategy with zero iterations without crashing", () => {
+    const meta = makeMeta({ route: { poolsUsed: [], iterations: [] } });
+    const summary = computeLeveragePositionSummary(
+      "strat-4",
+      "Empty",
+      meta,
+      priceOf({ USTRY: 10, USDC: 1 })
+    );
+    expect(summary.totalCollateralUnits).toBe(0);
+    expect(summary.totalDebtUnits).toBe(0);
+  });
+});
+
+describe("normalizeLeveragePositions", () => {
+  it("emits a collateral asset row and a debt liability row per position", () => {
+    const summary = computeLeveragePositionSummary(
+      "strat-1",
+      "USTRY 1.7x",
+      makeMeta(),
+      priceOf({ USTRY: 10, USDC: 1 })
+    );
+    const rows = normalizeLeveragePositions([summary]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].direction).toBe("asset");
+    expect(rows[0].protocol).toBe("leverage");
+    expect(rows[1].direction).toBe("liability");
+  });
+
+  it("omits the debt row when there is no outstanding debt", () => {
+    const meta = makeMeta({
+      route: {
+        poolsUsed: [],
+        iterations: [],
+      },
+    });
+    const summary = computeLeveragePositionSummary(
+      "strat-5",
+      "No debt",
+      meta,
+      priceOf({ USTRY: 10, USDC: 1 })
+    );
+    const rows = normalizeLeveragePositions([summary]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].direction).toBe("asset");
+  });
+});

--- a/apps/web-app/src/features/dashboard/positions/leverage.ts
+++ b/apps/web-app/src/features/dashboard/positions/leverage.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  calculateLiquidationPrice,
+  calculateProjectedHealthFactor,
+} from "@/features/borrowing/utils/liquidationPrice";
+import { listStrategies } from "@/lib/strategy/persistence";
+import type { Strategy } from "@/lib/strategy/types";
+import type { LeverageLoopStrategyMeta } from "@/lib/strategy/leverage/types";
+import type { PriceLookup } from "./normalize";
+
+/**
+ * Reduces a leverage-loop strategy's routed iterations — potentially spread
+ * across multiple pools (Scope §2's cross-protocol collateral) — into one
+ * logical position (Scope §4). Deliberately computed from the STRATEGY'S
+ * OWN persisted route rather than re-querying every touched pool's live
+ * on-chain balance: there is no new on-chain "position id" to attribute a
+ * shared pool balance back to one specific strategy (this feature
+ * introduces no new contract), so the aggregated *display* figures here are
+ * a projection of what this strategy itself opened. Live risk MONITORING
+ * for the deleveraging guard (Scope §6) reads actual on-chain health factor
+ * separately in lib/coordinator/deleverageGuard.ts — this module is the
+ * portfolio-display reducer, not the risk-control read path.
+ */
+export interface LeveragePositionSummary {
+  strategyId: string;
+  strategyName: string;
+  assetCode: string;
+  borrowAssetCode: string;
+  /** Total collateral realized across every iteration + the final redeposit, in the asset's own units. */
+  totalCollateralUnits: number;
+  /** Total debt drawn across every iteration, in the borrow asset's own units. */
+  totalDebtUnits: number;
+  /** Weighted-average max LTV across the pools this loop actually used. */
+  blendedCollateralFactorPct: number;
+  /** Spot price adjusted for the loop's cumulative swap slippage. */
+  blendedEntryPrice: number | null;
+  effectiveLeverage: number | null;
+  healthFactor: number | null;
+  liquidationPrice: number | null;
+  collateralValueUsd: number | null;
+  debtValueUsd: number | null;
+}
+
+export function computeLeveragePositionSummary(
+  strategyId: string,
+  strategyName: string,
+  meta: LeverageLoopStrategyMeta,
+  getPrice: PriceLookup
+): LeveragePositionSummary {
+  const { assetCode, borrowAssetCode, route } = meta;
+  const iterations = route.iterations;
+
+  const totalDebtUnits = iterations.reduce(
+    (sum, it) => sum + Number(it.borrowAmount),
+    0
+  );
+  const finalRedeposit = iterations.length
+    ? Number(iterations[iterations.length - 1].swapAmountOut)
+    : 0;
+  const initialDeposit = iterations.length
+    ? Number(iterations[0].depositAmount)
+    : 0;
+  const totalCollateralUnits =
+    initialDeposit +
+    iterations.slice(1).reduce((sum, it) => sum + Number(it.depositAmount), 0) +
+    finalRedeposit;
+
+  const totalSlippageBps = iterations.reduce(
+    (sum, it) => sum + it.swapPriceImpactBps,
+    0
+  );
+
+  const totalBorrowWeight = iterations.reduce(
+    (sum, it) => sum + Number(it.borrowAmount),
+    0
+  );
+  const blendedCollateralFactorPct =
+    totalBorrowWeight > 0
+      ? iterations.reduce((sum, it) => {
+          const pool = route.poolsUsed.find(
+            (p) => p.borrowPoolId === it.borrowPoolId
+          );
+          return (
+            sum +
+            (pool?.maxLtvPct ?? 0) *
+              (Number(it.borrowAmount) / totalBorrowWeight)
+          );
+        }, 0)
+      : (route.poolsUsed[0]?.maxLtvPct ?? 0);
+
+  const collateralPrice = getPrice(assetCode);
+  const debtPrice = getPrice(borrowAssetCode);
+  const blendedEntryPrice =
+    collateralPrice != null
+      ? collateralPrice * (1 + totalSlippageBps / 10_000)
+      : null;
+
+  const collateralValueUsd =
+    collateralPrice != null ? totalCollateralUnits * collateralPrice : null;
+  const debtValueUsd = debtPrice != null ? totalDebtUnits * debtPrice : null;
+
+  const healthFactor =
+    collateralValueUsd != null && debtValueUsd != null
+      ? calculateProjectedHealthFactor(
+          collateralValueUsd,
+          debtValueUsd,
+          blendedCollateralFactorPct
+        )
+      : null;
+
+  const liquidationPrice =
+    debtValueUsd != null
+      ? calculateLiquidationPrice(
+          totalCollateralUnits,
+          debtValueUsd,
+          blendedCollateralFactorPct
+        )
+      : null;
+
+  const effectiveLeverage =
+    collateralValueUsd != null &&
+    debtValueUsd != null &&
+    collateralValueUsd - debtValueUsd > 0
+      ? collateralValueUsd / (collateralValueUsd - debtValueUsd)
+      : null;
+
+  return {
+    strategyId,
+    strategyName,
+    assetCode,
+    borrowAssetCode,
+    totalCollateralUnits,
+    totalDebtUnits,
+    blendedCollateralFactorPct,
+    blendedEntryPrice,
+    effectiveLeverage,
+    healthFactor,
+    liquidationPrice,
+    collateralValueUsd,
+    debtValueUsd,
+  };
+}
+
+// ─── Sourcing persisted leverage strategies ──────────────────────────────────
+
+export interface LeverageStrategyEntry {
+  id: string;
+  name: string;
+  meta: LeverageLoopStrategyMeta;
+}
+
+function loadLeverageStrategies(
+  walletAddress: string
+): LeverageStrategyEntry[] {
+  return listStrategies(walletAddress)
+    .filter(
+      (s): s is Strategy & { leverageMeta: LeverageLoopStrategyMeta } =>
+        s.leverageMeta?.kind === "leverage-loop"
+    )
+    .map((s) => ({ id: s.id, name: s.name, meta: s.leverageMeta }));
+}
+
+/**
+ * Sources every persisted leverage-loop strategy (Scope §3's storage
+ * extension) for the connected wallet, ahead of reduction by
+ * computeLeveragePositionSummary above — the only consumer of both is
+ * useUnifiedPositions, so sourcing and reducing live together in one file.
+ * Mirrors the synchronous-load + rehydrate-on-wallet-change pattern already
+ * used by features/borrowing/hooks/useRiskThresholds — strategy persistence
+ * is a plain localStorage read, not a query, so there's nothing to fetch.
+ */
+export function useLeverageStrategies(walletAddress: string | undefined): {
+  strategies: LeverageStrategyEntry[];
+} {
+  const [strategies, setStrategies] = useState<LeverageStrategyEntry[]>(() =>
+    walletAddress ? loadLeverageStrategies(walletAddress) : []
+  );
+
+  const [loadedWallet, setLoadedWallet] = useState(walletAddress);
+  if (loadedWallet !== walletAddress) {
+    setLoadedWallet(walletAddress);
+    setStrategies(walletAddress ? loadLeverageStrategies(walletAddress) : []);
+  }
+
+  return useMemo(() => ({ strategies }), [strategies]);
+}

--- a/apps/web-app/src/features/dashboard/positions/normalize.ts
+++ b/apps/web-app/src/features/dashboard/positions/normalize.ts
@@ -3,6 +3,7 @@ import type { UserPositionWithPool } from "../hooks/useUserPositions";
 import type { LendingPosition } from "@/features/lending/hooks/useUserLendingPositions";
 import type { BorrowPosition } from "@/features/borrowing/hooks/useUserBorrowPositions";
 import type { BackstopPositionRaw } from "./usePortfolioBackstopPositions";
+import type { LeveragePositionSummary } from "./leverage";
 import type {
   PortfolioSummary,
   ProtocolAllocation,
@@ -182,6 +183,49 @@ export function normalizeBackstopPositions(
       href: "/lending",
     };
   });
+}
+
+/**
+ * Turns an aggregated leverage-loop position (features/dashboard/positions/
+ * leverage.ts's reducer) into two UnifiedPosition rows — a collateral asset
+ * row and a debt liability row — mirroring normalizeBorrowPositions's
+ * pattern so aggregatePortfolio's net-worth math (assets minus liabilities)
+ * falls out for free instead of needing a leverage-specific case.
+ */
+export function normalizeLeveragePositions(
+  positions: LeveragePositionSummary[]
+): UnifiedPosition[] {
+  const result: UnifiedPosition[] = [];
+
+  for (const p of positions) {
+    const multipleLabel =
+      p.effectiveLeverage != null ? ` ${p.effectiveLeverage.toFixed(2)}x` : "";
+    result.push({
+      id: `leverage:${p.strategyId}:collateral`,
+      protocol: "leverage",
+      label: `${p.assetCode} leveraged position${multipleLabel}`,
+      assetCode: p.assetCode,
+      quantity: p.totalCollateralUnits,
+      valueUsd: p.collateralValueUsd,
+      direction: "asset",
+      href: "/strategies",
+    });
+
+    if (p.totalDebtUnits > 0) {
+      result.push({
+        id: `leverage:${p.strategyId}:debt`,
+        protocol: "leverage",
+        label: `${p.borrowAssetCode} borrowed (leverage loop)`,
+        assetCode: p.borrowAssetCode,
+        quantity: p.totalDebtUnits,
+        valueUsd: p.debtValueUsd,
+        direction: "liability",
+        href: "/strategies",
+      });
+    }
+  }
+
+  return result;
 }
 
 export function aggregatePortfolio(

--- a/apps/web-app/src/features/dashboard/positions/types.ts
+++ b/apps/web-app/src/features/dashboard/positions/types.ts
@@ -10,7 +10,8 @@ export type ProtocolKind =
   | "lending"
   | "borrowing"
   | "vault"
-  | "backstop";
+  | "backstop"
+  | "leverage";
 
 /** Whether a position adds to or subtracts from net portfolio value. */
 export type PositionDirection = "asset" | "liability";

--- a/apps/web-app/src/features/stocks/components/pages/AssetDetail.tsx
+++ b/apps/web-app/src/features/stocks/components/pages/AssetDetail.tsx
@@ -7,6 +7,7 @@ import {
   TrendingUp,
   TrendingDown,
   ExternalLink,
+  Layers,
 } from "lucide-react";
 import { useOracle } from "../../hooks/useOracle";
 import { useOracleAssetPrice } from "../../hooks/useOracleAssetPrice";
@@ -20,6 +21,7 @@ import { useParams, useRouter } from "next/navigation";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { ROUTES } from "../../constants/oracle";
+import { stellarPriceService } from "@/lib/services/stellar-price.service";
 
 const AssetDetail: React.FC = () => {
   const params = useParams();
@@ -209,6 +211,31 @@ const AssetDetail: React.FC = () => {
           {stockInfo.summary ?? stockInfo.description}
         </p>
       </div>
+
+      {stellarPriceService.isRWAToken(symbolUpper) && (
+        <div className="rounded-2xl bg-[#1C1C1C] border border-[#229EDF]/20 p-6 mb-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="flex items-center gap-1.5 text-base font-semibold text-white">
+                <Layers className="h-4 w-4 text-[#229EDF]" />
+                Open a leveraged position
+              </h3>
+              <p className="mt-1 max-w-xl text-sm text-white/50">
+                Amplify exposure to {symbolUpper} with a recursive
+                deposit→borrow→swap→redeposit loop, routed for the lowest
+                blended cost across every eligible pool — with optional
+                automated deleveraging if health factor drops.
+              </p>
+            </div>
+            <Link
+              href={`/strategies?template=leverage-loop&asset=${encodeURIComponent(symbolUpper)}`}
+              className="inline-flex shrink-0 items-center gap-2 rounded-full bg-[#229EDF] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#1c8bc4]"
+            >
+              Open leverage builder
+            </Link>
+          </div>
+        </div>
+      )}
 
       {}
       {stockInfo.buyInfo && (

--- a/apps/web-app/src/features/strategies/components/Strategies.tsx
+++ b/apps/web-app/src/features/strategies/components/Strategies.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import {
   Layers,
   Pencil,
   Play,
   RotateCcw,
+  TrendingUp,
   Trash2,
   Workflow,
   X,
@@ -23,6 +25,8 @@ import type { ExecutionRecord, Strategy } from "@/lib/strategy/types";
 import { STRATEGIES_TABS, type StrategiesTab } from "../utils";
 import { createEmptyStrategy, cloneAsEditable } from "../hooks";
 import { StrategyComposer } from "./StrategyComposer";
+import { LeverageBuilder } from "../leverage/LeverageBuilder";
+import { DelegationPanel } from "../leverage/DelegationPanel";
 
 // ─── Strategy list ───────────────────────────────────────────────────────────
 
@@ -78,13 +82,24 @@ export function StrategyList({
                 onClick={() => onOpen(strategy)}
                 className="text-left"
               >
-                <h4 className="text-sm font-semibold text-white">
-                  {strategy.name}
-                </h4>
+                <div className="flex items-center gap-2">
+                  <h4 className="text-sm font-semibold text-white">
+                    {strategy.name}
+                  </h4>
+                  {strategy.leverageMeta && (
+                    <span className="flex items-center gap-1 rounded-full bg-[#229EDF]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#229EDF]">
+                      <TrendingUp size={10} />
+                      {strategy.leverageMeta.targetMultiple.toFixed(1)}x
+                    </span>
+                  )}
+                </div>
                 <p className="mt-1 text-xs text-white/40">
                   {strategy.steps.length} steps
                 </p>
               </button>
+              {strategy.leverageMeta && (
+                <DelegationPanel positionId={strategy.id} />
+              )}
               <div className="mt-3 flex items-center gap-2">
                 <button
                   type="button"
@@ -123,12 +138,42 @@ export function StrategyList({
 
 export interface TemplatePickerProps {
   onUseTemplate: (template: Strategy) => void;
+  onUseLeverageBuilder: () => void;
 }
 
-/** The 4 built-in templates, presented as selectable cards. "Use Template" clones the data, no separate code path. */
-export function TemplatePicker({ onUseTemplate }: TemplatePickerProps) {
+/**
+ * The 4 built-in templates, presented as selectable cards, plus the
+ * leverage-loop builder (Scope §7) as a distinct entry point — it isn't a
+ * fixed Strategy the composer's generic step editor can render, since its
+ * step count/parameters are computed by the loop-sizing calculator from a
+ * target multiple, not authored by hand.
+ */
+export function TemplatePicker({
+  onUseTemplate,
+  onUseLeverageBuilder,
+}: TemplatePickerProps) {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="flex flex-col justify-between rounded-2xl border border-[#229EDF]/30 bg-[#229EDF]/5 p-5">
+        <div>
+          <h3 className="flex items-center gap-1.5 text-sm font-semibold text-white">
+            <TrendingUp size={14} className="text-[#229EDF]" />
+            Leverage Loop
+          </h3>
+          <p className="mt-1 text-xs text-white/50">
+            Recursive deposit→borrow→swap→redeposit leverage on an RWA asset,
+            routed for the lowest blended cost across every eligible pool, with
+            optional automated deleveraging.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onUseLeverageBuilder}
+          className="mt-4 self-start rounded-full bg-[#229EDF] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1c8bc4] focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+        >
+          Open builder
+        </button>
+      </div>
       {STRATEGY_TEMPLATES.map((template) => (
         <div
           key={template.id}
@@ -291,8 +336,15 @@ export function ResumeExecutionBanner({
 
 export function Strategies() {
   const { address } = useWallet();
+  const searchParams = useSearchParams();
   const [tab, setTab] = useState<StrategiesTab>("my-strategies");
   const [composing, setComposing] = useState<Strategy | null>(null);
+  // AssetDetail.tsx links here with ?template=leverage-loop&asset=SYMBOL —
+  // Scope §7's "leverage builder surfaced from AssetDetail.tsx".
+  const [buildingLeverage, setBuildingLeverage] = useState(
+    searchParams.get("template") === "leverage-loop"
+  );
+  const leverageAssetParam = searchParams.get("asset") ?? undefined;
 
   const { strategies, isLoading, saveStrategy, deleteStrategy } =
     useStrategyPersistence();
@@ -313,6 +365,17 @@ export function Strategies() {
             Connect your wallet to build and run strategies.
           </p>
         </div>
+      </PageContainer>
+    );
+  }
+
+  if (buildingLeverage) {
+    return (
+      <PageContainer maxWidth="6xl">
+        <LeverageBuilder
+          initialAssetCode={leverageAssetParam}
+          onClose={() => setBuildingLeverage(false)}
+        />
       </PageContainer>
     );
   }
@@ -389,6 +452,7 @@ export function Strategies() {
             saveStrategy(draft);
             setComposing(draft);
           }}
+          onUseLeverageBuilder={() => setBuildingLeverage(true)}
         />
       )}
 

--- a/apps/web-app/src/features/strategies/leverage/DelegationPanel.tsx
+++ b/apps/web-app/src/features/strategies/leverage/DelegationPanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, ShieldCheck, ShieldOff } from "lucide-react";
+import type { DelegationGrant } from "@/lib/coordinator/types";
+
+export interface DelegationPanelProps {
+  positionId: string;
+}
+
+export const LEVERAGE_DELEGATION_QUERY_KEY = "leverage-delegation";
+
+/**
+ * Reads and revokes a position's coordinator delegation. Grant creation
+ * happens inline in useOpenLeveragePosition, right after the loop's steps
+ * execute — this hook is only for the read/revoke side, and DelegationPanel
+ * (below) is its only consumer, so the two live in one file.
+ */
+function useLeverageDelegation(positionId: string | undefined) {
+  const queryClient = useQueryClient();
+  const queryKey = [LEVERAGE_DELEGATION_QUERY_KEY, positionId];
+
+  const query = useQuery<{ grant: DelegationGrant | null }>({
+    queryKey,
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/leverage/delegation?positionId=${encodeURIComponent(positionId!)}`
+      );
+      if (!response.ok) throw new Error("Failed to load delegation status");
+      return response.json();
+    },
+    enabled: Boolean(positionId),
+    staleTime: 15_000,
+    retry: false,
+    throwOnError: false,
+  });
+
+  const revoke = useCallback(async () => {
+    if (!positionId) return;
+    const response = await fetch(
+      `/api/leverage/delegation?positionId=${encodeURIComponent(positionId)}`,
+      { method: "DELETE" }
+    );
+    if (!response.ok) throw new Error("Failed to revoke delegation");
+    await queryClient.invalidateQueries({ queryKey });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [positionId, queryClient]);
+
+  return {
+    grant: query.data?.grant ?? null,
+    isLoading: query.isLoading,
+    revoke,
+  };
+}
+
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Scope §7's delegation management panel: shows the current grant, its
+ * bounds, and a revoke control. Reads/writes through
+ * app/api/leverage/delegation/route.ts — never asks for a signature itself,
+ * since the grant was already fully signed at position-open time
+ * (useOpenLeveragePosition).
+ */
+export function DelegationPanel({ positionId }: DelegationPanelProps) {
+  const { grant, isLoading, revoke } = useLeverageDelegation(positionId);
+  const [expanded, setExpanded] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  if (isLoading) return null;
+
+  if (!grant) {
+    return (
+      <div className="mt-2 flex items-center gap-2 rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2 text-xs text-white/40">
+        <ShieldOff size={13} />
+        No automated deleveraging delegation for this position.
+      </div>
+    );
+  }
+
+  const remainingTranches =
+    grant.tranches.length - grant.consumedTrancheIds.length;
+  const isActive = grant.status === "active" && Date.now() < grant.expiresAt;
+
+  return (
+    <div className="mt-2 rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2 text-xs">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+        aria-expanded={expanded}
+      >
+        <span
+          className={`flex items-center gap-1.5 font-medium ${isActive ? "text-green-400" : "text-white/40"}`}
+        >
+          {isActive ? <ShieldCheck size={13} /> : <ShieldOff size={13} />}
+          Automated deleveraging {isActive ? "enabled" : grant.status}
+        </span>
+        {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 flex flex-col gap-2 text-white/60">
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <p className="text-white/30">Unwind threshold</p>
+              <p className="text-white/80">
+                {grant.guardConfig.deleverageThreshold.toFixed(2)} HF
+              </p>
+            </div>
+            <div>
+              <p className="text-white/30">Recovery hysteresis</p>
+              <p className="text-white/80">
+                +{grant.guardConfig.hysteresis.toFixed(2)}
+              </p>
+            </div>
+            <div>
+              <p className="text-white/30">Tranches remaining</p>
+              <p className="text-white/80">
+                {remainingTranches} / {grant.tranches.length}
+              </p>
+            </div>
+            <div>
+              <p className="text-white/30">Valid until</p>
+              <p className="text-white/80">{formatDate(grant.expiresAt)}</p>
+            </div>
+          </div>
+          <p className="text-white/30">
+            Scope: repay/withdraw only, only on this position, only up to
+            what&apos;s needed to clear a breach — never opens new leverage,
+            never touches any other position.
+          </p>
+          {isActive && (
+            <button
+              type="button"
+              onClick={async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setIsRevoking(true);
+                try {
+                  await revoke();
+                } finally {
+                  setIsRevoking(false);
+                }
+              }}
+              disabled={isRevoking}
+              className="mt-1 self-start rounded-full border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-300 hover:bg-red-500/20 disabled:opacity-40"
+            >
+              {isRevoking ? "Revoking…" : "Revoke delegation"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DelegationPanel;

--- a/apps/web-app/src/features/strategies/leverage/LeverageBuilder.tsx
+++ b/apps/web-app/src/features/strategies/leverage/LeverageBuilder.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, ChevronLeft, ShieldCheck } from "lucide-react";
+import { getRwaTokenCodes } from "@/lib/constants/assets.config";
+import { HF_DANGER_ZONE } from "@/features/borrowing/const/riskThresholds";
+import {
+  DEFAULT_LEVERAGE_BORROW_ASSET,
+  useLeverageBuilder,
+} from "./useLeverageBuilder";
+import { useOpenLeveragePosition } from "./useOpenLeveragePosition";
+import { ExecutionProgress } from "../components/ExecutionUI";
+import { buildLeverageStrategy } from "@/lib/strategy/leverage/buildStrategy";
+import type { OpenLeveragePositionResult } from "./useOpenLeveragePosition";
+
+export interface LeverageBuilderProps {
+  initialAssetCode?: string;
+  onClose: () => void;
+}
+
+function formatPct(value: number): string {
+  return `${value.toFixed(2)}%`;
+}
+
+/**
+ * The leverage builder (Scope §1-2-7): pick an RWA asset and target
+ * multiple, review the routed loop's pre-trade simulation, and open the
+ * position — composed onto the existing strategy engine
+ * (useOpenLeveragePosition), with the same step-by-step ExecutionProgress
+ * view the generic StrategyComposer uses.
+ */
+export function LeverageBuilder({
+  initialAssetCode,
+  onClose,
+}: LeverageBuilderProps) {
+  const rwaAssets = useMemo(() => getRwaTokenCodes(), []);
+  const [assetCode, setAssetCode] = useState(
+    initialAssetCode ?? rwaAssets[0] ?? ""
+  );
+  const [initialCollateralAmount, setInitialCollateralAmount] = useState("100");
+  const [targetMultiple, setTargetMultiple] = useState(2);
+  const [safetyBufferPct, setSafetyBufferPct] = useState(5);
+  const [grantDelegation, setGrantDelegation] = useState(true);
+  const [deleverageThreshold, setDeleverageThreshold] = useState(
+    HF_DANGER_ZONE + 0.05
+  );
+  const [hysteresis, setHysteresis] = useState(0.05);
+  const [result, setResult] = useState<OpenLeveragePositionResult | null>(null);
+
+  const builderInput = useMemo(
+    () => ({
+      assetCode,
+      borrowAssetCode: DEFAULT_LEVERAGE_BORROW_ASSET,
+      initialCollateralAmount,
+      targetMultiple,
+      safetyBufferPct,
+    }),
+    [assetCode, initialCollateralAmount, targetMultiple, safetyBufferPct]
+  );
+
+  const { route, isLoading, borrowAssetCode, candidatePoolCount } =
+    useLeverageBuilder(assetCode ? builderInput : null);
+  const { open, isOpening, hasWallet } = useOpenLeveragePosition();
+
+  const previewStrategy = useMemo(() => {
+    if (!route || !route.ok) return null;
+    return buildLeverageStrategy(
+      {
+        route,
+        assetCode,
+        borrowAssetCode,
+        initialCollateralAmount,
+      },
+      targetMultiple,
+      1, // achievedMultiple isn't needed for the step preview, only the steps
+      safetyBufferPct
+    );
+  }, [
+    route,
+    assetCode,
+    borrowAssetCode,
+    initialCollateralAmount,
+    targetMultiple,
+    safetyBufferPct,
+  ]);
+
+  const canOpen =
+    hasWallet && !isOpening && route?.ok === true && !result?.execution;
+
+  const handleOpen = async () => {
+    if (!route || !route.ok) return;
+    const outcome = await open({
+      route,
+      assetCode,
+      borrowAssetCode,
+      initialCollateralAmount,
+      targetMultiple,
+      safetyBufferPct,
+      grantDelegation,
+      deleverageThreshold,
+      hysteresis,
+    });
+    if (outcome) setResult(outcome);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Back to strategies"
+          className="rounded-full p-2 text-white/50 hover:bg-white/5 hover:text-white"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <h2 className="text-lg font-semibold text-white">Leverage builder</h2>
+      </div>
+
+      {result?.execution ? (
+        <div className="flex flex-col gap-4">
+          <ExecutionProgress
+            strategy={result.strategy}
+            execution={result.execution}
+          />
+          {result.grant && (
+            <div className="flex items-center gap-2 rounded-xl border border-green-500/20 bg-green-500/10 p-3 text-sm text-green-300">
+              <ShieldCheck size={16} />
+              Automated deleveraging is enabled for this position — manage it
+              from the position card on your Dashboard.
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="self-end rounded-full border border-white/10 px-4 py-2 text-sm text-white/80 hover:bg-white/5"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-1.5 text-sm text-white/70">
+              RWA asset
+              <select
+                value={assetCode}
+                onChange={(e) => setAssetCode(e.target.value)}
+                className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+              >
+                {rwaAssets.map((code) => (
+                  <option key={code} value={code}>
+                    {code}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1.5 text-sm text-white/70">
+              Initial collateral ({assetCode || "asset"})
+              <input
+                type="number"
+                min="0"
+                step="any"
+                value={initialCollateralAmount}
+                onChange={(e) => setInitialCollateralAmount(e.target.value)}
+                className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1.5 text-sm text-white/70">
+              Target multiple
+              <input
+                type="number"
+                min="1.01"
+                step="0.1"
+                value={targetMultiple}
+                onChange={(e) => setTargetMultiple(Number(e.target.value))}
+                className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1.5 text-sm text-white/70">
+              Safety buffer below max LTV (%)
+              <input
+                type="number"
+                min="0"
+                step="0.5"
+                value={safetyBufferPct}
+                onChange={(e) => setSafetyBufferPct(Number(e.target.value))}
+                className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+              />
+            </label>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+            <label className="flex items-center gap-2 text-sm text-white/80">
+              <input
+                type="checkbox"
+                checked={grantDelegation}
+                onChange={(e) => setGrantDelegation(e.target.checked)}
+                className="h-4 w-4 rounded border-white/20 bg-transparent"
+              />
+              Enable automated deleveraging
+            </label>
+            <p className="mt-1 text-xs text-white/40">
+              Signs a bounded set of partial-unwind transactions now, so the
+              coordinator can repay and free collateral automatically if health
+              factor drops below your threshold — never more than needed to
+              clear the breach, and revocable anytime.
+            </p>
+            {grantDelegation && (
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="flex flex-col gap-1.5 text-xs text-white/60">
+                  Auto-unwind health factor threshold
+                  <input
+                    type="number"
+                    min="1.01"
+                    step="0.05"
+                    value={deleverageThreshold}
+                    onChange={(e) =>
+                      setDeleverageThreshold(Number(e.target.value))
+                    }
+                    className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+                  />
+                </label>
+                <label className="flex flex-col gap-1.5 text-xs text-white/60">
+                  Recovery hysteresis
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={hysteresis}
+                    onChange={(e) => setHysteresis(Number(e.target.value))}
+                    className="rounded-lg border border-white/10 bg-[#121212] px-3 py-2 text-white"
+                  />
+                </label>
+              </div>
+            )}
+          </div>
+
+          {isLoading && (
+            <p className="text-sm text-white/40">
+              Evaluating {candidatePoolCount} eligible pools…
+            </p>
+          )}
+
+          {route && !route.ok && (
+            <div
+              className="flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300"
+              role="alert"
+            >
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+              <span>{route.reason}</span>
+            </div>
+          )}
+
+          {route?.ok && (
+            <div className="flex flex-col gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-4">
+              <h3 className="text-sm font-semibold text-white">
+                Route simulation
+              </h3>
+              <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                <div>
+                  <p className="text-xs text-white/40">Iterations</p>
+                  <p className="text-white">{route.iterations.length}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-white/40">Blended entry price</p>
+                  <p className="text-white">
+                    {route.simulation.blendedEntryPrice != null
+                      ? `$${route.simulation.blendedEntryPrice.toFixed(4)}`
+                      : "—"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-white/40">Blended borrow cost</p>
+                  <p className="text-white">
+                    {formatPct(route.simulation.totalBorrowCostPct)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-white/40">Total slippage</p>
+                  <p className="text-white">
+                    {(route.simulation.totalSlippageBps / 100).toFixed(2)}%
+                  </p>
+                </div>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[480px] text-left text-xs">
+                  <thead>
+                    <tr className="text-white/40">
+                      <th className="py-1 pr-3">#</th>
+                      <th className="py-1 pr-3">Pool</th>
+                      <th className="py-1 pr-3">Deposit</th>
+                      <th className="py-1 pr-3">Borrow</th>
+                      <th className="py-1 pr-3">Swap out</th>
+                      <th className="py-1">Slippage</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {route.iterations.map((it) => (
+                      <tr key={it.index} className="text-white/70">
+                        <td className="py-1 pr-3">{it.index}</td>
+                        <td className="py-1 pr-3">{it.poolType}</td>
+                        <td className="py-1 pr-3">{it.depositAmount}</td>
+                        <td className="py-1 pr-3">{it.borrowAmount}</td>
+                        <td className="py-1 pr-3">{it.swapAmountOut}</td>
+                        <td className="py-1">
+                          {(it.swapPriceImpactBps / 100).toFixed(2)}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {previewStrategy && (
+                <details className="text-xs text-white/50">
+                  <summary className="cursor-pointer text-white/70">
+                    Preview {previewStrategy.steps.length} strategy steps
+                  </summary>
+                  <ol className="mt-2 flex flex-col gap-1">
+                    {previewStrategy.steps.map((step, i) => (
+                      <li key={step.id}>
+                        {i + 1}. {step.label}
+                      </li>
+                    ))}
+                  </ol>
+                </details>
+              )}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => void handleOpen()}
+              disabled={!canOpen}
+              className="rounded-full bg-[#229EDF] px-6 py-2.5 text-sm font-semibold text-white hover:bg-[#1c8bc4] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {isOpening ? "Opening…" : "Open leveraged position"}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default LeverageBuilder;

--- a/apps/web-app/src/features/strategies/leverage/useLeverageBuilder.ts
+++ b/apps/web-app/src/features/strategies/leverage/useLeverageBuilder.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { usePools } from "@/lib/orchestrator/hooks/usePools";
+import { getQuote, getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
+import { stellarPriceService } from "@/lib/services/stellar-price.service";
+import { getAssetsConfig } from "@/lib/constants/assets.config";
+import {
+  deriveRouteCandidates,
+  selectRoute,
+} from "@/lib/strategy/leverage/routing";
+import type { PoolInfo } from "@/lib/orchestrator/types/pool.types";
+import type { RouteResult, SwapQuoteFn } from "@/lib/strategy/leverage/types";
+
+export const DEFAULT_LEVERAGE_BORROW_ASSET = "USDC";
+
+export interface UseLeverageBuilderInput {
+  assetCode: string;
+  borrowAssetCode?: string;
+  initialCollateralAmount: string;
+  targetMultiple: number;
+  safetyBufferPct: number;
+}
+
+function matchesAsset(pool: PoolInfo, assetCode: string): boolean {
+  return pool.tokens.some((t) => t.code === assetCode);
+}
+
+/**
+ * Resolves getQuote() a real, addressable pair — the pre-trade route
+ * simulation calls the real Soroswap on-chain quote path (unlike the
+ * strategy step it will eventually generate, which follows the existing
+ * codebase's asset-code convention for swap params — see
+ * lib/strategy/leverage/buildStrategy.ts's comment on that mismatch), so it
+ * needs actual contract addresses.
+ */
+function makeSwapQuoteFn(): SwapQuoteFn {
+  const tokens = getAvailableTokens();
+  return async ({ tokenIn, tokenOut, amountIn }) => {
+    const assetIn = tokens[tokenIn]?.contract;
+    const assetOut = tokens[tokenOut]?.contract;
+    if (!assetIn || !assetOut) return null;
+    try {
+      const quote = await getQuote({
+        assetIn,
+        assetOut,
+        amount: amountIn,
+        tradeType: "EXACT_IN",
+      });
+      if (!quote) return null;
+      const priceImpactBps = Math.round(
+        parseFloat(quote.priceImpact ?? "0") * 100
+      );
+      return {
+        amountOut: quote.amountOut,
+        priceImpactBps: Number.isFinite(priceImpactBps) ? priceImpactBps : 0,
+      };
+    } catch {
+      return null;
+    }
+  };
+}
+
+export const LEVERAGE_ROUTE_QUERY_KEY = "leverage-builder-route";
+
+/**
+ * Scope §1-2's builder: evaluates every registered pool (blend/neko) that
+ * can supply the required collateral/borrow legs for the chosen asset, and
+ * produces the routed loop plan + pre-trade simulation for the composer UI
+ * to confirm before any step executes.
+ */
+export function useLeverageBuilder(input: UseLeverageBuilderInput | null) {
+  const enabled = Boolean(
+    input &&
+    input.assetCode &&
+    Number(input.initialCollateralAmount) > 0 &&
+    input.targetMultiple > 1
+  );
+  const { data: pools = [], isLoading: poolsLoading } = usePools(enabled);
+  const assetsConfig = getAssetsConfig();
+  const borrowAssetCode =
+    input?.borrowAssetCode ?? DEFAULT_LEVERAGE_BORROW_ASSET;
+
+  const priceQuery = useQuery({
+    queryKey: ["leverage-builder-price", input?.assetCode],
+    queryFn: () =>
+      stellarPriceService.getPrice(
+        input!.assetCode,
+        assetsConfig[input!.assetCode]?.contract
+      ),
+    enabled: Boolean(input?.assetCode),
+    staleTime: 15_000,
+  });
+
+  const routeQuery = useQuery<RouteResult>({
+    queryKey: [
+      LEVERAGE_ROUTE_QUERY_KEY,
+      input?.assetCode,
+      borrowAssetCode,
+      input?.initialCollateralAmount,
+      input?.targetMultiple,
+      input?.safetyBufferPct,
+      pools.length,
+    ],
+    queryFn: async () => {
+      const collateralPools = pools.filter((p) =>
+        matchesAsset(p, input!.assetCode)
+      );
+      const borrowPools = pools.filter((p) => matchesAsset(p, borrowAssetCode));
+      const candidates = deriveRouteCandidates(collateralPools, borrowPools);
+
+      return selectRoute({
+        assetCode: input!.assetCode,
+        borrowAssetCode,
+        initialCollateralAmount: input!.initialCollateralAmount,
+        targetMultiple: input!.targetMultiple,
+        safetyBufferPct: input!.safetyBufferPct,
+        candidates,
+        getSwapQuote: makeSwapQuoteFn(),
+        priceUsd: priceQuery.data ?? null,
+      });
+    },
+    enabled: enabled && pools.length > 0,
+    staleTime: 10_000,
+    retry: false,
+    throwOnError: false,
+  });
+
+  const candidatePoolCount = useMemo(
+    () =>
+      pools.filter(
+        (p) =>
+          matchesAsset(p, input?.assetCode ?? "") ||
+          matchesAsset(p, borrowAssetCode)
+      ).length,
+    [pools, input?.assetCode, borrowAssetCode]
+  );
+
+  return {
+    borrowAssetCode,
+    route: routeQuery.data,
+    isLoading: poolsLoading || routeQuery.isFetching,
+    error: routeQuery.error,
+    candidatePoolCount,
+  };
+}

--- a/apps/web-app/src/features/strategies/leverage/useOpenLeveragePosition.ts
+++ b/apps/web-app/src/features/strategies/leverage/useOpenLeveragePosition.ts
@@ -1,0 +1,200 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { nanoid } from "nanoid";
+import { useWallet } from "@/hooks/useWallet";
+import { useToast } from "@/hooks/useToast";
+import {
+  useStrategyPersistence,
+  useStrategyExecution,
+} from "@/lib/strategy/hooks";
+import {
+  buildLeverageStrategy,
+  buildUnwindTranches,
+  type BuildOpenLoopStepsInput,
+} from "@/lib/strategy/leverage/buildStrategy";
+import { signUnwindTranches } from "@/lib/coordinator/delegation";
+import type { ExecutionRecord, Strategy } from "@/lib/strategy/types";
+import type { RoutedLoopPlan } from "@/lib/strategy/leverage/types";
+import type { DelegationGrant } from "@/lib/coordinator/types";
+
+/** Total collateral realized (initial + every iteration's swap-back), divided by the initial deposit. */
+export function computeAchievedMultiple(
+  route: RoutedLoopPlan,
+  initialCollateralAmount: string
+): number {
+  const initial = Number(initialCollateralAmount);
+  if (initial <= 0) return 1;
+  const total =
+    initial +
+    route.iterations.reduce((sum, it) => sum + Number(it.swapAmountOut), 0);
+  return total / initial;
+}
+
+export interface OpenLeveragePositionInput {
+  route: RoutedLoopPlan;
+  assetCode: string;
+  borrowAssetCode: string;
+  initialCollateralAmount: string;
+  targetMultiple: number;
+  safetyBufferPct: number;
+  /** Whether to also collect the pre-signed unwind tranches and register a DelegationGrant for the automated guard (Scope §5-6). */
+  grantDelegation: boolean;
+  deleverageThreshold: number;
+  hysteresis: number;
+}
+
+export interface OpenLeveragePositionResult {
+  strategy: Strategy;
+  execution: ExecutionRecord;
+  grant: DelegationGrant | null;
+  delegationError: string | null;
+}
+
+/**
+ * Orchestrates opening a leveraged position end to end: composes the routed
+ * loop into a Strategy (Scope §3), runs it wallet-present through the
+ * EXISTING lib/strategy execution engine (no new execution primitive for
+ * this path), and — if the user opts in — collects the pre-signed unwind
+ * tranches and registers them as a DelegationGrant so the automated
+ * deleveraging guard (Scope §5-6) can act later without the wallet present.
+ */
+export function useOpenLeveragePosition() {
+  const { address, networkPassphrase, signTransaction } = useWallet();
+  const { saveStrategy } = useStrategyPersistence();
+  const { execute } = useStrategyExecution();
+  const { addNotification } = useToast();
+  const [isOpening, setIsOpening] = useState(false);
+
+  const open = useCallback(
+    async (
+      input: OpenLeveragePositionInput
+    ): Promise<OpenLeveragePositionResult | null> => {
+      if (!address || !networkPassphrase) return null;
+      setIsOpening(true);
+      try {
+        const buildInput: BuildOpenLoopStepsInput = {
+          route: input.route,
+          assetCode: input.assetCode,
+          borrowAssetCode: input.borrowAssetCode,
+          initialCollateralAmount: input.initialCollateralAmount,
+        };
+        const achievedMultiple = computeAchievedMultiple(
+          input.route,
+          input.initialCollateralAmount
+        );
+        const strategy = buildLeverageStrategy(
+          buildInput,
+          input.targetMultiple,
+          achievedMultiple,
+          input.safetyBufferPct
+        );
+        saveStrategy(strategy);
+
+        const record: ExecutionRecord = {
+          id: nanoid(),
+          strategyId: strategy.id,
+          strategySnapshot: strategy,
+          status: "in_progress",
+          startedAt: Date.now(),
+          updatedAt: Date.now(),
+          projectedOutcome: {},
+          steps: [],
+        };
+
+        const result = await execute(strategy, record);
+        if (!result) {
+          addNotification("Wallet not connected", "error", {});
+          return null;
+        }
+
+        if (result.status !== "completed") {
+          addNotification("Leverage loop did not complete", "error", {
+            description:
+              result.record.steps.find((s) => s.status === "failed")
+                ?.errorMessage ??
+              "The position was left in a partial state — check Execution History to resume or inspect it.",
+          });
+          return {
+            strategy,
+            execution: result.record,
+            grant: null,
+            delegationError: null,
+          };
+        }
+
+        let grant: DelegationGrant | null = null;
+        let delegationError: string | null = null;
+
+        if (input.grantDelegation) {
+          try {
+            const tranches = buildUnwindTranches(buildInput);
+            const signedTranches = await signUnwindTranches(
+              tranches,
+              { userAddress: address, networkPassphrase },
+              signTransaction,
+              input.assetCode,
+              input.borrowAssetCode
+            );
+            const response = await fetch("/api/leverage/delegation", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                positionId: strategy.id,
+                walletAddress: address,
+                assetCode: input.assetCode,
+                borrowAssetCode: input.borrowAssetCode,
+                tranches: signedTranches,
+                guardConfig: {
+                  deleverageThreshold: input.deleverageThreshold,
+                  hysteresis: input.hysteresis,
+                },
+              }),
+            });
+            if (response.ok) {
+              const data = (await response.json()) as {
+                grant: DelegationGrant;
+              };
+              grant = data.grant;
+            } else {
+              const data = await response.json().catch(() => ({}));
+              delegationError =
+                (data as { error?: string }).error ??
+                "Failed to register automated deleveraging.";
+            }
+          } catch (err) {
+            delegationError = err instanceof Error ? err.message : String(err);
+          }
+        }
+
+        if (delegationError) {
+          addNotification(
+            "Position opened — automated deleveraging setup failed",
+            "warning",
+            {
+              description: `${delegationError} You can grant delegation later from the position's delegation panel.`,
+            }
+          );
+        } else {
+          addNotification("Leveraged position opened", "success", {
+            description: `${strategy.name} — ${achievedMultiple.toFixed(2)}x achieved.`,
+          });
+        }
+
+        return { strategy, execution: result.record, grant, delegationError };
+      } finally {
+        setIsOpening(false);
+      }
+    },
+    [
+      address,
+      networkPassphrase,
+      signTransaction,
+      saveStrategy,
+      execute,
+      addNotification,
+    ]
+  );
+
+  return { open, isOpening, hasWallet: Boolean(address) };
+}

--- a/apps/web-app/src/lib/coordinator/__tests__/delegation.test.ts
+++ b/apps/web-app/src/lib/coordinator/__tests__/delegation.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDelegationGrant,
+  isDelegationUsable,
+  revokeDelegationGrant,
+  selectTranchesToClearBreach,
+  signUnwindTranches,
+} from "../delegation";
+import type { UnwindTranche } from "@/lib/strategy/leverage/buildStrategy";
+import type { StrategyStepDefinition, TxResult } from "@/lib/strategy/types";
+import type { DelegationGrant, DelegationTrancheRecord } from "../types";
+
+function makeFakeRegistry(): { resolve: () => StrategyStepDefinition } {
+  const definition: StrategyStepDefinition = {
+    stepType: "repay",
+    protocol: "blend",
+    submissionMode: "rpc",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paramsSchema: {} as any,
+    describeOutputs: () => [],
+    validate: () => [],
+    simulate: async () => {
+      throw new Error("not used");
+    },
+    prepare: async (ctx): Promise<TxResult> => ({
+      xdr: `xdr-for-${JSON.stringify(ctx.resolvedParams)}`,
+      networkPassphrase: "Test SDF Network ; September 2015",
+    }),
+  };
+  return { resolve: vi.fn(() => definition) };
+}
+
+function makeTranche(order: number, debtAmount: string): UnwindTranche {
+  return {
+    id: `tranche-${order}`,
+    order,
+    collateralAmount: "100",
+    debtAmount,
+    collateralPoolId: "blend:CPOOL:CUSTRY",
+    borrowPoolId: "blend:CPOOL:CUSDC",
+    steps: [
+      {
+        id: `repay-${order}`,
+        type: "repay",
+        protocol: "blend",
+        label: "Repay",
+        dependsOn: [],
+        params: { amount: { source: "literal", value: debtAmount } },
+      },
+      {
+        id: `withdraw-${order}`,
+        type: "supply",
+        protocol: "blend",
+        label: "Withdraw",
+        dependsOn: [`repay-${order}`],
+        params: {
+          mode: { source: "literal", value: "collateral" },
+          direction: { source: "literal", value: "withdraw" },
+          amount: { source: "literal", value: "100" },
+        },
+      },
+    ],
+  };
+}
+
+describe("signUnwindTranches", () => {
+  it("signs every literal-bound step of every tranche via the provided SignFn", async () => {
+    const registry = makeFakeRegistry();
+    const sign = vi.fn(async (xdr: string) => ({
+      signedTxXdr: `signed(${xdr})`,
+    }));
+    const tranches = [makeTranche(0, "50"), makeTranche(1, "70")];
+
+    const records = await signUnwindTranches(
+      tranches,
+      {
+        userAddress: "GUSER",
+        networkPassphrase: "Test SDF Network ; September 2015",
+      },
+      sign,
+      "USTRY",
+      "USDC",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registry as any
+    );
+
+    expect(records).toHaveLength(2);
+    expect(sign).toHaveBeenCalledTimes(4); // 2 steps x 2 tranches
+    expect(records[0].steps[0].operationType).toBe("repay");
+    expect(records[0].steps[0].assetCode).toBe("USDC");
+    expect(records[0].steps[0].amount).toBe("50");
+    expect(records[0].steps[0].signedXdr).toMatch(/^signed\(/);
+    expect(records[0].steps[1].operationType).toBe("withdrawCollateral");
+    expect(records[0].steps[1].assetCode).toBe("USTRY");
+  });
+
+  it("throws if a tranche step has a non-literal (stepOutput) binding — it wouldn't be pre-signable", async () => {
+    const registry = makeFakeRegistry();
+    const sign = vi.fn(async () => ({ signedTxXdr: "x" }));
+    const badTranche: UnwindTranche = {
+      id: "bad",
+      order: 0,
+      collateralAmount: "1",
+      debtAmount: "1",
+      collateralPoolId: "blend:CPOOL:CUSTRY",
+      borrowPoolId: "blend:CPOOL:CUSDC",
+      steps: [
+        {
+          id: "s1",
+          type: "repay",
+          protocol: "blend",
+          label: "Repay",
+          dependsOn: [],
+          params: {
+            amount: { source: "stepOutput", stepId: "x", portId: "y" },
+          },
+        },
+      ],
+    };
+
+    await expect(
+      signUnwindTranches(
+        [badTranche],
+        { userAddress: "G", networkPassphrase: "net" },
+        sign,
+        "USTRY",
+        "USDC",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registry as any
+      )
+    ).rejects.toThrow(/literal/i);
+  });
+});
+
+function makeGrant(
+  overrides: Partial<DelegationGrant> = {},
+  tranches: DelegationTrancheRecord[] = []
+): DelegationGrant {
+  return {
+    id: "grant-1",
+    positionId: "position-1",
+    walletAddress: "GUSER",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    status: "active",
+    createdAt: 0,
+    expiresAt: Date.now() + 1_000_000,
+    tranches,
+    consumedTrancheIds: [],
+    guardConfig: { deleverageThreshold: 1.15, hysteresis: 0.05 },
+    breached: false,
+    ...overrides,
+  };
+}
+
+function signedTranche(
+  id: string,
+  order: number,
+  debtAmount: string
+): DelegationTrancheRecord {
+  return {
+    id,
+    order,
+    collateralAmount: "100",
+    debtAmount,
+    collateralPoolId: "blend:CPOOL:CUSTRY",
+    borrowPoolId: "blend:CPOOL:CUSDC",
+    steps: [
+      {
+        stepId: `repay-${id}`,
+        operationType: "repay",
+        protocol: "blend",
+        poolType: "blend",
+        assetCode: "USDC",
+        amount: debtAmount,
+        submissionMode: "rpc",
+        signedXdr: `xdr-${id}`,
+        networkPassphrase: "net",
+      },
+    ],
+  };
+}
+
+describe("createDelegationGrant / revokeDelegationGrant / isDelegationUsable", () => {
+  it("creates an active grant with a computed expiry, and revoke marks it unusable", () => {
+    const grant = createDelegationGrant({
+      positionId: "p1",
+      walletAddress: "GUSER",
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      tranches: [],
+      validityMs: 1000,
+      now: 500,
+    });
+    expect(grant.status).toBe("active");
+    expect(grant.expiresAt).toBe(1500);
+    expect(isDelegationUsable(grant, 600)).toBe(true);
+    expect(isDelegationUsable(grant, 1600)).toBe(false); // expired
+
+    const revoked = revokeDelegationGrant(grant, 700);
+    expect(revoked.status).toBe("revoked");
+    expect(isDelegationUsable(revoked, 600)).toBe(false);
+  });
+
+  it("treats a null grant as unusable", () => {
+    expect(isDelegationUsable(null)).toBe(false);
+  });
+});
+
+describe("selectTranchesToClearBreach", () => {
+  it("selects the smallest prefix (by order) whose cumulative debt relief clears the requirement", () => {
+    const grant = makeGrant({}, [
+      signedTranche("t0", 0, "30"),
+      signedTranche("t1", 1, "40"),
+      signedTranche("t2", 2, "50"),
+    ]);
+    const selection = selectTranchesToClearBreach(grant, 50);
+    expect(selection).not.toBeNull();
+    // 30 (t0) + 40 (t1) = 70 >= 50 -> stops there, doesn't touch t2.
+    expect(selection?.trancheIds).toEqual(["t0", "t1"]);
+  });
+
+  it("never selects a tranche once its cumulative total already clears the requirement", () => {
+    const grant = makeGrant({}, [signedTranche("t0", 0, "100")]);
+    const selection = selectTranchesToClearBreach(grant, 10);
+    expect(selection?.trancheIds).toEqual(["t0"]); // one tranche is enough, and it's all there is
+  });
+
+  it("skips already-consumed tranches", () => {
+    const grant = makeGrant({ consumedTrancheIds: ["t0"] }, [
+      signedTranche("t0", 0, "30"),
+      signedTranche("t1", 1, "40"),
+    ]);
+    const selection = selectTranchesToClearBreach(grant, 10);
+    expect(selection?.trancheIds).toEqual(["t1"]);
+  });
+
+  it("returns null when the grant is revoked", () => {
+    const grant = makeGrant({ status: "revoked" }, [
+      signedTranche("t0", 0, "30"),
+    ]);
+    expect(selectTranchesToClearBreach(grant, 10)).toBeNull();
+  });
+
+  it("returns null when the grant is expired", () => {
+    const grant = makeGrant({ expiresAt: 100 }, [signedTranche("t0", 0, "30")]);
+    expect(selectTranchesToClearBreach(grant, 10, 200)).toBeNull();
+  });
+
+  it("returns null when there is nothing left unconsumed to give", () => {
+    const grant = makeGrant({ consumedTrancheIds: ["t0"] }, [
+      signedTranche("t0", 0, "30"),
+    ]);
+    expect(selectTranchesToClearBreach(grant, 10)).toBeNull();
+  });
+
+  it("returns null for a null grant", () => {
+    expect(selectTranchesToClearBreach(null, 10)).toBeNull();
+  });
+});

--- a/apps/web-app/src/lib/coordinator/__tests__/deleverageGuard.test.ts
+++ b/apps/web-app/src/lib/coordinator/__tests__/deleverageGuard.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeGrantRiskSnapshot,
+  computeRequiredDebtReliefUsd,
+  evaluatePosition,
+  hasRecovered,
+  shouldTriggerUnwind,
+} from "../deleverageGuard";
+import type { DelegationGrant, DelegationTrancheRecord } from "../types";
+
+const config = { deleverageThreshold: 1.15, hysteresis: 0.05 };
+
+function makeGrant(overrides: Partial<DelegationGrant> = {}): DelegationGrant {
+  return {
+    id: "g1",
+    positionId: "p1",
+    walletAddress: "GUSER",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    status: "active",
+    createdAt: 0,
+    expiresAt: Date.now() + 1_000_000,
+    tranches: [],
+    consumedTrancheIds: [],
+    guardConfig: {
+      deleverageThreshold: config.deleverageThreshold,
+      hysteresis: config.hysteresis,
+    },
+    breached: false,
+    ...overrides,
+  };
+}
+
+describe("shouldTriggerUnwind / hasRecovered", () => {
+  it("triggers exactly at (just below) the configured threshold, not above it", () => {
+    expect(shouldTriggerUnwind(1.1499999, 1.15)).toBe(true);
+    expect(shouldTriggerUnwind(1.15, 1.15)).toBe(false);
+    expect(shouldTriggerUnwind(1.2, 1.15)).toBe(false);
+    expect(shouldTriggerUnwind(null, 1.15)).toBe(false);
+  });
+
+  it("only recovers once HF clears threshold + hysteresis", () => {
+    expect(hasRecovered(1.19, 1.15, 0.05)).toBe(false); // still below 1.20
+    expect(hasRecovered(1.2, 1.15, 0.05)).toBe(true);
+    expect(hasRecovered(1.25, 1.15, 0.05)).toBe(true);
+  });
+});
+
+describe("computeRequiredDebtReliefUsd", () => {
+  it("solves for the exact debt relief that brings HF to the target, verified by reapplying it", () => {
+    const collateralValueUsd = 1000;
+    const debtValueUsd = 681.8181818;
+    const cf = 75;
+    const target = 1.2;
+
+    const relief = computeRequiredDebtReliefUsd(
+      collateralValueUsd,
+      debtValueUsd,
+      cf,
+      target
+    );
+
+    const newCollateral = collateralValueUsd - relief / (cf / 100);
+    const newDebt = debtValueUsd - relief;
+    const newHf = (newCollateral * (cf / 100)) / newDebt;
+    expect(newHf).toBeCloseTo(target, 4);
+  });
+
+  it("never returns more relief than there is outstanding debt", () => {
+    const relief = computeRequiredDebtReliefUsd(100, 50, 10, 5); // pathological: tiny CF, huge target
+    expect(relief).toBeLessThanOrEqual(50);
+    expect(relief).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns 0 when the position is already healthier than the target (no relief needed)", () => {
+    const relief = computeRequiredDebtReliefUsd(1690, 70, 75, 1.2);
+    expect(relief).toBe(0);
+  });
+});
+
+describe("evaluatePosition", () => {
+  const grant = makeGrant();
+
+  it("holds when health factor is above the deleverage threshold", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.3,
+        collateralValueUsd: 1000,
+        debtValueUsd: 500,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      grant,
+      false,
+      config
+    );
+    expect(action.kind).toBe("hold");
+  });
+
+  it("triggers an unwind sized to clear the breach when HF is below threshold and delegation is usable", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.1,
+        collateralValueUsd: 1000,
+        debtValueUsd: 681.8181818,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      grant,
+      false,
+      config
+    );
+    expect(action.kind).toBe("trigger-unwind");
+    if (action.kind !== "trigger-unwind") return;
+    expect(action.requiredDebtReliefUnits).toBeGreaterThan(0);
+    expect(action.targetHealthFactor).toBeCloseTo(1.2, 6);
+  });
+
+  it("reports recovered once a previously-breached position clears threshold + hysteresis", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.21,
+        collateralValueUsd: 1000,
+        debtValueUsd: 500,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      grant,
+      true, // wasBreached
+      config
+    );
+    expect(action.kind).toBe("recovered");
+  });
+
+  it("does NOT report recovered for a position that was never breached, even above threshold+hysteresis", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.21,
+        collateralValueUsd: 1000,
+        debtValueUsd: 500,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      grant,
+      false,
+      config
+    );
+    expect(action.kind).toBe("hold");
+  });
+
+  it("falls back to alert-only when no delegation has been granted", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.1,
+        collateralValueUsd: 1000,
+        debtValueUsd: 700,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      null,
+      false,
+      config
+    );
+    expect(action.kind).toBe("alert-only");
+  });
+
+  it("falls back to alert-only when the delegation was revoked", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.1,
+        collateralValueUsd: 1000,
+        debtValueUsd: 700,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      makeGrant({ status: "revoked" }),
+      false,
+      config
+    );
+    expect(action.kind).toBe("alert-only");
+  });
+
+  it("falls back to alert-only when the delegation has expired", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: 1.1,
+        collateralValueUsd: 1000,
+        debtValueUsd: 700,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: 1,
+      },
+      makeGrant({ expiresAt: 0 }),
+      false,
+      config,
+      500 // now > expiresAt
+    );
+    expect(action.kind).toBe("alert-only");
+  });
+
+  it("holds (never crashes) when health factor is unavailable", () => {
+    const action = evaluatePosition(
+      {
+        healthFactor: null,
+        collateralValueUsd: null,
+        debtValueUsd: null,
+        blendedCollateralFactorPct: 75,
+        debtAssetPriceUsd: null,
+      },
+      grant,
+      false,
+      config
+    );
+    expect(action.kind).toBe("hold");
+  });
+});
+
+// ─── computeGrantRiskSnapshot ─────────────────────────────────────────────────
+
+function makeTranche(
+  id: string,
+  order: number,
+  collateralAmount: string,
+  debtAmount: string,
+  collateralPoolId = "blend:CPOOL:CUSTRY",
+  borrowPoolId = "blend:CPOOL:CUSDC"
+): DelegationTrancheRecord {
+  return {
+    id,
+    order,
+    collateralAmount,
+    debtAmount,
+    collateralPoolId,
+    borrowPoolId,
+    steps: [],
+  };
+}
+
+function makeRiskGrant(
+  tranches: DelegationTrancheRecord[],
+  consumed: string[] = []
+): DelegationGrant {
+  return {
+    id: "g1",
+    positionId: "p1",
+    walletAddress: "GUSER",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    status: "active",
+    createdAt: 0,
+    expiresAt: Date.now() + 1_000_000,
+    tranches,
+    consumedTrancheIds: consumed,
+    guardConfig: { deleverageThreshold: 1.15, hysteresis: 0.05 },
+    breached: false,
+  };
+}
+
+describe("computeGrantRiskSnapshot", () => {
+  it("sums live collateral/debt across every distinct pool touched by unconsumed tranches", async () => {
+    const g = makeRiskGrant([
+      makeTranche("t0", 0, "100", "70"),
+      makeTranche("t1", 1, "60", "42", "neko:USTRY", "neko:USDC"),
+    ]);
+
+    const reads: Record<
+      string,
+      { collateralUnits: number; debtUnits: number }
+    > = {
+      "blend:CPOOL:CUSTRY": { collateralUnits: 150, debtUnits: 0 },
+      "blend:CPOOL:CUSDC": { collateralUnits: 0, debtUnits: 100 },
+      "neko:USTRY": { collateralUnits: 65, debtUnits: 0 },
+      "neko:USDC": { collateralUnits: 0, debtUnits: 45 },
+    };
+
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async (poolId) => reads[poolId] ?? null,
+      (code) => (code === "USTRY" ? 10 : code === "USDC" ? 1 : null)
+    );
+
+    expect(snapshot.collateralValueUsd).toBeCloseTo((150 + 65) * 10, 6);
+    expect(snapshot.debtValueUsd).toBeCloseTo((100 + 45) * 1, 6);
+    expect(snapshot.healthFactor).not.toBeNull();
+  });
+
+  it("excludes already-consumed tranches' pools from the live snapshot", async () => {
+    const g = makeRiskGrant(
+      [
+        makeTranche("t0", 0, "100", "70"),
+        makeTranche("t1", 1, "60", "42", "neko:USTRY", "neko:USDC"),
+      ],
+      ["t1"]
+    );
+
+    let readCount = 0;
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async (poolId) => {
+        readCount += 1;
+        expect(poolId.startsWith("neko:")).toBe(false); // consumed tranche's pools never read
+        return { collateralUnits: 100, debtUnits: 70 };
+      },
+      () => 1
+    );
+
+    expect(readCount).toBe(2); // only t0's collateral + borrow pool
+    expect(snapshot.debtValueUsd).toBeCloseTo(70, 6);
+  });
+
+  it("returns a null-risk snapshot (never throws) when every tranche is already consumed", async () => {
+    const g = makeRiskGrant([makeTranche("t0", 0, "100", "70")], ["t0"]);
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async () => {
+        throw new Error("should never be called");
+      },
+      () => 1
+    );
+    expect(snapshot.healthFactor).toBeNull();
+  });
+
+  it("degrades gracefully (doesn't crash) when collateral is unreadable — undercounts collateral, the conservative direction", async () => {
+    const g = makeRiskGrant([makeTranche("t0", 0, "100", "70")]);
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async () => null,
+      () => 1
+    );
+    expect(snapshot.collateralValueUsd).toBe(0);
+  });
+
+  it("falls back to the tranche's static debtAmount (never a silent zero) when a debt read is unreadable", async () => {
+    // Zeroing unreadable DEBT would make health factor look artificially
+    // healthy and could suppress a real breach — the dangerous direction.
+    const g = makeRiskGrant([makeTranche("t0", 0, "100", "70")]);
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async () => null,
+      () => 1
+    );
+    expect(snapshot.debtValueUsd).toBe(70);
+  });
+
+  it("returns a conservative (slightly-below-true) blended collateral factor derived from the loop's own effective LTV", async () => {
+    // debt/collateral = 70/100 = 70% effective LTV — always <= the pool's
+    // real max LTV by construction (loopSizing subtracts the safety buffer).
+    const g = makeRiskGrant([makeTranche("t0", 0, "100", "70")]);
+    const snapshot = await computeGrantRiskSnapshot(
+      g,
+      async () => ({ collateralUnits: 100, debtUnits: 70 }),
+      () => 1
+    );
+    expect(snapshot.blendedCollateralFactorPct).toBeCloseTo(70, 6);
+  });
+});

--- a/apps/web-app/src/lib/coordinator/__tests__/execute.test.ts
+++ b/apps/web-app/src/lib/coordinator/__tests__/execute.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryCoordinatorLedgerStore } from "../ledger";
+import {
+  reconcileCoordinatorRun,
+  runCoordinatorUnwind,
+  type CoordinatorExecutionDeps,
+} from "../execute";
+import { DelegationScopeViolationError } from "../types";
+import type { TrancheSelection } from "../delegation";
+import type {
+  CoordinatorRun,
+  DelegationGrant,
+  DelegationTrancheRecord,
+} from "../types";
+
+function makeSignedTranche(
+  id: string,
+  order: number,
+  debtAmount: string,
+  stepCount = 2
+): DelegationTrancheRecord {
+  return {
+    id,
+    order,
+    collateralAmount: "100",
+    debtAmount,
+    collateralPoolId: "blend:CPOOL:CUSTRY",
+    borrowPoolId: "blend:CPOOL:CUSDC",
+    steps: Array.from({ length: stepCount }, (_, i) => ({
+      stepId: `${id}-step-${i}`,
+      operationType:
+        i === 0 ? ("repay" as const) : ("withdrawCollateral" as const),
+      protocol: "blend",
+      poolType: "blend" as const,
+      assetCode: i === 0 ? "USDC" : "USTRY",
+      amount: debtAmount,
+      submissionMode: "rpc" as const,
+      signedXdr: `xdr-${id}-${i}`,
+      networkPassphrase: "net",
+    })),
+  };
+}
+
+function makeGrant(tranches: DelegationTrancheRecord[]): DelegationGrant {
+  return {
+    id: "grant-1",
+    positionId: "position-1",
+    walletAddress: "GUSER",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    status: "active",
+    createdAt: 0,
+    expiresAt: Date.now() + 1_000_000,
+    tranches,
+    consumedTrancheIds: [],
+    guardConfig: { deleverageThreshold: 1.15, hysteresis: 0.05 },
+    breached: false,
+  };
+}
+
+function selectionFor(...trancheIds: string[]): TrancheSelection {
+  return { trancheIds, steps: [] };
+}
+
+function makeDeps(overrides: Partial<CoordinatorExecutionDeps> = {}): {
+  deps: CoordinatorExecutionDeps;
+  submit: ReturnType<typeof vi.fn>;
+  confirm: ReturnType<typeof vi.fn>;
+} {
+  const submit = vi.fn(async (xdr: string) => ({ hash: `hash-${xdr}` }));
+  const confirm = vi.fn(async () => ({ status: "SUCCESS" }));
+  const store = new InMemoryCoordinatorLedgerStore();
+  const deps: CoordinatorExecutionDeps = {
+    store,
+    transports: { rpc: { submit, confirm }, soroswapApi: { submit, confirm } },
+    ...overrides,
+  };
+  return { deps, submit, confirm };
+}
+
+describe("runCoordinatorUnwind", () => {
+  it("submits and confirms every step of every selected tranche, then marks tranches consumed", async () => {
+    const tranche = makeSignedTranche("t0", 0, "50");
+    const grant = makeGrant([tranche]);
+    const { deps, submit, confirm } = makeDeps();
+
+    const run = await runCoordinatorUnwind(deps, {
+      grant,
+      selection: selectionFor("t0"),
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+    });
+
+    expect(run.status).toBe("completed");
+    expect(run.steps).toHaveLength(2);
+    expect(run.steps.every((s) => s.status === "completed")).toBe(true);
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(confirm).toHaveBeenCalledTimes(2);
+
+    const savedGrant = await deps.store.getGrant(grant.positionId);
+    expect(savedGrant?.consumedTrancheIds).toEqual(["t0"]);
+  });
+
+  it("resumes an in-progress run without re-submitting already-completed steps", async () => {
+    const tranche = makeSignedTranche("t0", 0, "50");
+    const grant = makeGrant([tranche]);
+    const { deps, submit } = makeDeps();
+
+    const partialRun: CoordinatorRun = {
+      id: "run-1",
+      positionId: grant.positionId,
+      grantId: grant.id,
+      reason: "deleverage-guard",
+      triggeredAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:t0-step-0",
+          trancheId: "t0",
+          stepId: "t0-step-0",
+          status: "completed",
+          txHash: "hash-xdr-t0-0",
+          confirmedAt: 1,
+        },
+        {
+          idempotencyKey: "run-1:t0:t0-step-1",
+          trancheId: "t0",
+          stepId: "t0-step-1",
+          status: "pending",
+        },
+      ],
+    };
+    await deps.store.saveRun(partialRun);
+
+    const run = await runCoordinatorUnwind(deps, {
+      grant,
+      selection: selectionFor("t0"),
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      existingRun: partialRun,
+    });
+
+    expect(run.status).toBe("completed");
+    // Only the still-pending step (t0-step-1) is submitted — the completed
+    // one is never touched again.
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith("xdr-t0-1", "net");
+  });
+
+  it("marks the run failed and stops (leaving later steps pending) when a step's submission throws", async () => {
+    const tranche = makeSignedTranche("t0", 0, "50");
+    const grant = makeGrant([tranche]);
+    const submit = vi.fn().mockRejectedValueOnce(new Error("network blip"));
+    const store = new InMemoryCoordinatorLedgerStore();
+    const deps: CoordinatorExecutionDeps = {
+      store,
+      transports: {
+        rpc: { submit, confirm: vi.fn() },
+        soroswapApi: { submit, confirm: vi.fn() },
+      },
+    };
+
+    const run = await runCoordinatorUnwind(deps, {
+      grant,
+      selection: selectionFor("t0"),
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+    });
+
+    expect(run.status).toBe("failed");
+    expect(run.steps[0].status).toBe("failed");
+    expect(run.steps[1].status).toBe("pending"); // never attempted — well-defined, inspectable partial state
+    const savedGrant = await deps.store.getGrant(grant.positionId);
+    expect(savedGrant).toBeNull(); // tranche never marked consumed since it didn't fully complete
+  });
+
+  it("rejects a selection referencing a tranche that isn't part of the grant (wrong position/grant)", async () => {
+    const grant = makeGrant([makeSignedTranche("t0", 0, "50")]);
+    const { deps } = makeDeps();
+
+    await expect(
+      runCoordinatorUnwind(deps, {
+        grant,
+        selection: selectionFor("tranche-from-a-different-position"),
+        healthFactorAtTrigger: 1.05,
+        healthFactorTarget: 1.2,
+      })
+    ).rejects.toThrow(DelegationScopeViolationError);
+  });
+
+  it("resumes a multi-tranche run whose FIRST tranche was already marked consumed by that same run's earlier progress", async () => {
+    // Two tranches selected in one run; t0 fully completed (and thus
+    // already marked consumed) on an earlier tick before a crash, t1 still
+    // pending. Resuming must NOT reject t0 as "already consumed" just
+    // because it's a member of consumedTrancheIds by now.
+    const t0 = makeSignedTranche("t0", 0, "30", 1);
+    const t1 = makeSignedTranche("t1", 1, "40", 1);
+    const grantAfterT0Consumed: DelegationGrant = {
+      ...makeGrant([t0, t1]),
+      consumedTrancheIds: ["t0"],
+    };
+    const { deps, submit } = makeDeps();
+
+    const partialRun: CoordinatorRun = {
+      id: "run-1",
+      positionId: grantAfterT0Consumed.positionId,
+      grantId: grantAfterT0Consumed.id,
+      reason: "deleverage-guard",
+      triggeredAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0", "t1"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:t0-step-0",
+          trancheId: "t0",
+          stepId: "t0-step-0",
+          status: "completed",
+          txHash: "hash-xdr-t0-0",
+          confirmedAt: 1,
+        },
+        {
+          idempotencyKey: "run-1:t1:t1-step-0",
+          trancheId: "t1",
+          stepId: "t1-step-0",
+          status: "pending",
+        },
+      ],
+    };
+    await deps.store.saveRun(partialRun);
+
+    const run = await runCoordinatorUnwind(deps, {
+      grant: grantAfterT0Consumed,
+      selection: selectionFor("t0", "t1"),
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      existingRun: partialRun,
+    });
+
+    expect(run.status).toBe("completed");
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith("xdr-t1-0", "net");
+  });
+
+  it("rejects a selection referencing an already-consumed tranche (never re-unwinds beyond what was needed)", async () => {
+    const tranche = makeSignedTranche("t0", 0, "50");
+    const grant = { ...makeGrant([tranche]), consumedTrancheIds: ["t0"] };
+    const { deps } = makeDeps();
+
+    await expect(
+      runCoordinatorUnwind(deps, {
+        grant,
+        selection: selectionFor("t0"),
+        healthFactorAtTrigger: 1.05,
+        healthFactorTarget: 1.2,
+      })
+    ).rejects.toThrow(DelegationScopeViolationError);
+  });
+
+  it("rejects resuming a run that belongs to a different grant or position", async () => {
+    const grant = makeGrant([makeSignedTranche("t0", 0, "50")]);
+    const { deps } = makeDeps();
+    const foreignRun: CoordinatorRun = {
+      id: "run-x",
+      positionId: "some-other-position",
+      grantId: "some-other-grant",
+      reason: "deleverage-guard",
+      triggeredAt: 0,
+      updatedAt: 0,
+      status: "in_progress",
+      healthFactorAtTrigger: null,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [],
+    };
+
+    await expect(
+      runCoordinatorUnwind(deps, {
+        grant,
+        selection: selectionFor("t0"),
+        healthFactorAtTrigger: 1.05,
+        healthFactorTarget: 1.2,
+        existingRun: foreignRun,
+      })
+    ).rejects.toThrow(DelegationScopeViolationError);
+  });
+});
+
+describe("reconcileCoordinatorRun", () => {
+  it("marks a crashed in-flight step completed once chain state confirms it actually succeeded", async () => {
+    const run: CoordinatorRun = {
+      id: "run-1",
+      positionId: "p1",
+      grantId: "g1",
+      reason: "deleverage-guard",
+      triggeredAt: 0,
+      updatedAt: 0,
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:s0",
+          trancheId: "t0",
+          stepId: "s0",
+          status: "confirming",
+          txHash: "hash-1",
+        },
+      ],
+    };
+
+    const reconciled = await reconcileCoordinatorRun(run, {
+      getTransactionStatus: async () => "SUCCESS",
+    });
+
+    expect(reconciled.steps[0].status).toBe("completed");
+  });
+
+  it("marks a crashed in-flight step failed when chain state confirms it actually failed", async () => {
+    const run: CoordinatorRun = {
+      id: "run-1",
+      positionId: "p1",
+      grantId: "g1",
+      reason: "deleverage-guard",
+      triggeredAt: 0,
+      updatedAt: 0,
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:s0",
+          trancheId: "t0",
+          stepId: "s0",
+          status: "submitting",
+          txHash: "hash-1",
+        },
+      ],
+    };
+
+    const reconciled = await reconcileCoordinatorRun(run, {
+      getTransactionStatus: async () => "FAILED",
+    });
+
+    expect(reconciled.steps[0].status).toBe("failed");
+  });
+
+  it("leaves a still-genuinely-pending step untouched so a later resume can retry", async () => {
+    const run: CoordinatorRun = {
+      id: "run-1",
+      positionId: "p1",
+      grantId: "g1",
+      reason: "deleverage-guard",
+      triggeredAt: 0,
+      updatedAt: 0,
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:s0",
+          trancheId: "t0",
+          stepId: "s0",
+          status: "confirming",
+          txHash: "hash-1",
+        },
+      ],
+    };
+
+    const reconciled = await reconcileCoordinatorRun(run, {
+      getTransactionStatus: async () => "PENDING",
+    });
+
+    expect(reconciled.steps[0].status).toBe("confirming");
+  });
+
+  it("full crash-resume flow: reconcile then resume ends the run completed without duplicate submission", async () => {
+    const tranche = makeSignedTranche("t0", 0, "50");
+    const grant = makeGrant([tranche]);
+    const { deps, submit } = makeDeps();
+
+    const crashedRun: CoordinatorRun = {
+      id: "run-1",
+      positionId: grant.positionId,
+      grantId: grant.id,
+      reason: "deleverage-guard",
+      triggeredAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "in_progress",
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      trancheIdsPlanned: ["t0"],
+      steps: [
+        {
+          idempotencyKey: "run-1:t0:t0-step-0",
+          trancheId: "t0",
+          stepId: "t0-step-0",
+          status: "confirming", // process died right after submit, before the confirm write
+          txHash: "hash-xdr-t0-0",
+        },
+        {
+          idempotencyKey: "run-1:t0:t0-step-1",
+          trancheId: "t0",
+          stepId: "t0-step-1",
+          status: "pending",
+        },
+      ],
+    };
+
+    const reconciled = await reconcileCoordinatorRun(crashedRun, {
+      getTransactionStatus: async () => "SUCCESS", // it actually landed before the crash
+    });
+    await deps.store.saveRun(reconciled);
+
+    const run = await runCoordinatorUnwind(deps, {
+      grant,
+      selection: selectionFor("t0"),
+      healthFactorAtTrigger: 1.05,
+      healthFactorTarget: 1.2,
+      existingRun: reconciled,
+    });
+
+    expect(run.status).toBe("completed");
+    // Step 0 was reconciled as already-completed — never resubmitted.
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith("xdr-t0-1", "net");
+  });
+});

--- a/apps/web-app/src/lib/coordinator/delegation.ts
+++ b/apps/web-app/src/lib/coordinator/delegation.ts
@@ -1,0 +1,183 @@
+import { nanoid } from "nanoid";
+import { strategyStepRegistry } from "@/lib/strategy/registry";
+import type { StrategyStepRegistry } from "@/lib/strategy/registry";
+import type { UnwindTranche } from "@/lib/strategy/leverage/buildStrategy";
+import type {
+  DelegationGrant,
+  DelegationTrancheRecord,
+  SignedCoordinatorStep,
+} from "./types";
+
+export type SignFn = (
+  xdr: string,
+  options: { networkPassphrase: string; address?: string }
+) => Promise<{ signedTxXdr: string }>;
+
+function literalValue(binding: { source: string; value?: unknown }): unknown {
+  if (binding.source !== "literal") {
+    throw new Error(
+      "Unwind tranche steps must be fully literal-bound to be pre-signable — got a stepOutput binding."
+    );
+  }
+  return binding.value;
+}
+
+/**
+ * Prepares and signs every step of every unwind tranche through the SAME
+ * wallet-present SignFn the manual open flow uses (lib/strategy/execution.ts's
+ * SignFn shape) — the only time the user's wallet is ever asked to sign
+ * these unwind operations is right now, at grant time. What's produced here
+ * is the entire universe of what the coordinator will ever be able to
+ * submit later; nothing built after this point can extend it.
+ */
+export async function signUnwindTranches(
+  tranches: UnwindTranche[],
+  ctx: { userAddress: string; networkPassphrase: string },
+  sign: SignFn,
+  assetCode: string,
+  borrowAssetCode: string,
+  registry: StrategyStepRegistry = strategyStepRegistry
+): Promise<DelegationTrancheRecord[]> {
+  const records: DelegationTrancheRecord[] = [];
+
+  for (const tranche of tranches) {
+    const signedSteps: SignedCoordinatorStep[] = [];
+    for (const step of tranche.steps) {
+      const definition = registry.resolve(step.type, step.protocol);
+      const resolvedParams: Record<string, unknown> = {};
+      for (const [key, binding] of Object.entries(step.params)) {
+        resolvedParams[key] = literalValue(binding);
+      }
+
+      const tx = await definition.prepare({
+        userAddress: ctx.userAddress,
+        networkPassphrase: ctx.networkPassphrase,
+        resolvedParams,
+        upstreamOutputs: {},
+      });
+      const signed = await sign(tx.xdr, {
+        networkPassphrase: tx.networkPassphrase,
+        address: ctx.userAddress,
+      });
+
+      signedSteps.push({
+        stepId: step.id,
+        operationType: step.type === "repay" ? "repay" : "withdrawCollateral",
+        protocol: step.protocol,
+        poolType: step.protocol === "blend" ? "blend" : "neko",
+        assetCode: step.type === "repay" ? borrowAssetCode : assetCode,
+        amount: String(resolvedParams.amount),
+        submissionMode: definition.submissionMode,
+        signedXdr: signed.signedTxXdr,
+        networkPassphrase: tx.networkPassphrase,
+      });
+    }
+    records.push({
+      id: tranche.id,
+      order: tranche.order,
+      collateralAmount: tranche.collateralAmount,
+      debtAmount: tranche.debtAmount,
+      collateralPoolId: tranche.collateralPoolId,
+      borrowPoolId: tranche.borrowPoolId,
+      steps: signedSteps,
+    });
+  }
+
+  return records;
+}
+
+export interface CreateDelegationGrantInput {
+  positionId: string;
+  walletAddress: string;
+  assetCode: string;
+  borrowAssetCode: string;
+  tranches: DelegationTrancheRecord[];
+  /** How long the pre-signed tranches remain eligible to submit. */
+  validityMs: number;
+  guardConfig: { deleverageThreshold: number; hysteresis: number };
+  now?: number;
+}
+
+export function createDelegationGrant(
+  input: CreateDelegationGrantInput
+): DelegationGrant {
+  const now = input.now ?? Date.now();
+  return {
+    id: nanoid(),
+    positionId: input.positionId,
+    walletAddress: input.walletAddress,
+    assetCode: input.assetCode,
+    borrowAssetCode: input.borrowAssetCode,
+    status: "active",
+    createdAt: now,
+    expiresAt: now + input.validityMs,
+    tranches: input.tranches,
+    consumedTrancheIds: [],
+    guardConfig: input.guardConfig,
+    breached: false,
+  };
+}
+
+export function revokeDelegationGrant(
+  grant: DelegationGrant,
+  now: number = Date.now()
+): DelegationGrant {
+  return { ...grant, status: "revoked", revokedAt: now };
+}
+
+/**
+ * Deliberately returns plain `boolean`, not a `grant is DelegationGrant`
+ * type predicate — a revoked or expired grant is still structurally a
+ * DelegationGrant object (just not usable), so a predicate return type
+ * would make TypeScript wrongly narrow the false branch to "must be null"
+ * everywhere this is checked with `!isDelegationUsable(grant)`.
+ */
+export function isDelegationUsable(
+  grant: DelegationGrant | null,
+  now: number = Date.now()
+): boolean {
+  return grant != null && grant.status === "active" && now < grant.expiresAt;
+}
+
+export interface TrancheSelection {
+  trancheIds: string[];
+  steps: SignedCoordinatorStep[];
+}
+
+/**
+ * Picks the SMALLEST prefix (in deleverage order) of unconsumed tranches
+ * whose cumulative debt relief clears `requiredDebtReliefUnits` — this is
+ * the core "never unwinds more than needed to clear the breach" guarantee
+ * (acceptance criteria / Scope §5-6): once the running total reaches the
+ * requirement, no further tranche is added, and any tranche already
+ * consumed by a prior run is never reselected. Returns null when the grant
+ * isn't usable (revoked/expired) or has nothing left to give — the caller
+ * (the guard) falls back to alert-only in that case, never to "unwind
+ * anyway".
+ */
+export function selectTranchesToClearBreach(
+  grant: DelegationGrant | null,
+  requiredDebtReliefUnits: number,
+  now: number = Date.now()
+): TrancheSelection | null {
+  if (!grant || !isDelegationUsable(grant, now)) return null;
+  if (requiredDebtReliefUnits <= 0) return null;
+
+  const available = grant.tranches
+    .filter((t) => !grant.consumedTrancheIds.includes(t.id))
+    .sort((a, b) => a.order - b.order);
+
+  const selected: DelegationTrancheRecord[] = [];
+  let cumulative = 0;
+  for (const tranche of available) {
+    if (cumulative >= requiredDebtReliefUnits) break;
+    selected.push(tranche);
+    cumulative += Number(tranche.debtAmount);
+  }
+
+  if (selected.length === 0) return null;
+  return {
+    trancheIds: selected.map((t) => t.id),
+    steps: selected.flatMap((t) => t.steps),
+  };
+}

--- a/apps/web-app/src/lib/coordinator/deleverageGuard.ts
+++ b/apps/web-app/src/lib/coordinator/deleverageGuard.ts
@@ -1,0 +1,289 @@
+import { calculateProjectedHealthFactor } from "@/features/borrowing/utils/liquidationPrice";
+import { isDelegationUsable } from "./delegation";
+import type { DelegationGrant } from "./types";
+
+/**
+ * Automated deleveraging guard (Scope §6) — watches a leveraged position
+ * against a user-configured threshold STRICTER than, and distinct from,
+ * features/borrowing/hooks/useRiskAlerts' notify-only threshold, and
+ * triggers a bounded automated unwind through the coordinator on breach.
+ * Reuses the same projected-health-factor formula as
+ * features/borrowing/utils/liquidationPrice.ts (HF = collateral*CF / debt)
+ * — inverted here to solve for how much debt relief clears a target HF.
+ */
+
+export interface PositionRiskSnapshot {
+  healthFactor: number | null;
+  collateralValueUsd: number | null;
+  debtValueUsd: number | null;
+  blendedCollateralFactorPct: number;
+  debtAssetPriceUsd: number | null;
+}
+
+export interface DeleverageGuardConfig {
+  /** Automated-unwind threshold. Must be validated stricter (lower) than the position's notify-only useRiskAlerts threshold by the caller. */
+  deleverageThreshold: number;
+  /** Recovery margin — mirrors HF_ALERT_HYSTERESIS's role in useRiskAlerts, preventing the guard from re-triggering while HF oscillates around the boundary. */
+  hysteresis: number;
+}
+
+export type GuardAction =
+  | { kind: "hold" }
+  | { kind: "recovered" }
+  | { kind: "alert-only"; reason: string }
+  | {
+      kind: "trigger-unwind";
+      requiredDebtReliefUnits: number;
+      targetHealthFactor: number;
+    };
+
+/**
+ * Inverts HF = (collateral * CF) / debt to solve for how much debt (in USD)
+ * must be repaid — funded by withdrawing collateral in the SAME ratio the
+ * loop itself was built at (debt_i = deposit_i * effectiveLtv, so
+ * effectiveLtv ≈ CF here) — to bring health factor up to
+ * `targetHealthFactor`. This is an ESTIMATE sized from blended portfolio
+ * figures, not the exact outcome of whichever discrete tranches get picked
+ * (see lib/coordinator/delegation.ts's selectTranchesToClearBreach) — the
+ * guard re-evaluates on every tick and stops once actually recovered, so an
+ * imperfect estimate self-corrects rather than needing to be exact in one
+ * shot.
+ */
+export function computeRequiredDebtReliefUsd(
+  collateralValueUsd: number,
+  debtValueUsd: number,
+  collateralFactorPct: number,
+  targetHealthFactor: number
+): number {
+  const cf = collateralFactorPct / 100;
+  if (cf <= 0 || debtValueUsd <= 0) return 0;
+  const denominator = targetHealthFactor - 1;
+  if (denominator <= 0) return 0; // target must exceed 1.0 (HF=1.0 is the liquidation boundary itself) for a finite solution
+  const raw =
+    (targetHealthFactor * debtValueUsd - collateralValueUsd * cf) / denominator;
+  return Math.max(0, Math.min(raw, debtValueUsd));
+}
+
+export function shouldTriggerUnwind(
+  healthFactor: number | null,
+  threshold: number
+): boolean {
+  return healthFactor != null && healthFactor < threshold;
+}
+
+export function hasRecovered(
+  healthFactor: number | null,
+  threshold: number,
+  hysteresis: number
+): boolean {
+  return healthFactor != null && healthFactor >= threshold + hysteresis;
+}
+
+/**
+ * The guard's single decision function for one position on one tick.
+ * `wasBreached` is the guard's own persisted breach flag for this position
+ * (mirrors useRiskAlerts' BreachStateMap) — held through the hysteresis
+ * band so the guard doesn't fire again the instant HF ticks a hair above
+ * the raw threshold, only once it clears threshold + hysteresis.
+ */
+export function evaluatePosition(
+  snapshot: PositionRiskSnapshot,
+  grant: DelegationGrant | null,
+  wasBreached: boolean,
+  config: DeleverageGuardConfig,
+  now: number = Date.now()
+): GuardAction {
+  if (snapshot.healthFactor == null) return { kind: "hold" };
+
+  const target = config.deleverageThreshold + config.hysteresis;
+
+  if (
+    wasBreached &&
+    hasRecovered(
+      snapshot.healthFactor,
+      config.deleverageThreshold,
+      config.hysteresis
+    )
+  ) {
+    return { kind: "recovered" };
+  }
+
+  if (!shouldTriggerUnwind(snapshot.healthFactor, config.deleverageThreshold)) {
+    return { kind: "hold" };
+  }
+
+  // Breached. Falls back to alert-only — never blocks the breach from being
+  // reported — whenever there's no usable delegation to act within.
+  if (!isDelegationUsable(grant, now)) {
+    return {
+      kind: "alert-only",
+      reason:
+        grant == null
+          ? "No delegation has been granted for this position."
+          : grant.status === "revoked"
+            ? "Delegation was revoked."
+            : "Delegation has expired.",
+    };
+  }
+
+  if (
+    snapshot.collateralValueUsd == null ||
+    snapshot.debtValueUsd == null ||
+    snapshot.debtAssetPriceUsd == null ||
+    snapshot.debtAssetPriceUsd <= 0
+  ) {
+    return {
+      kind: "alert-only",
+      reason: "Live price data is unavailable to size an automated unwind.",
+    };
+  }
+
+  const requiredUsd = computeRequiredDebtReliefUsd(
+    snapshot.collateralValueUsd,
+    snapshot.debtValueUsd,
+    snapshot.blendedCollateralFactorPct,
+    target
+  );
+  const requiredDebtReliefUnits = requiredUsd / snapshot.debtAssetPriceUsd;
+
+  if (requiredDebtReliefUnits <= 0) return { kind: "hold" };
+
+  return {
+    kind: "trigger-unwind",
+    requiredDebtReliefUnits,
+    targetHealthFactor: target,
+  };
+}
+
+// ─── Live risk read ───────────────────────────────────────────────────────────
+
+/**
+ * Reads one pool's live on-chain position for a wallet, in the pool's own
+ * decimal units — injected so this module stays adapter/SDK-free (mirrors
+ * lib/strategy/execution.ts's transport injection). The real implementation
+ * (app/api/leverage/guard/route.ts) wires BlendPoolAdapter/
+ * NekoLendingAdapter.getUserPosition; tests inject a fixed map.
+ *
+ * Returns null when the pool can't be read (unsupported protocol surface,
+ * transient RPC error) rather than throwing — a single unreadable pool
+ * degrades the snapshot instead of crashing the whole guard tick.
+ */
+export type PoolPositionReader = (
+  poolId: string,
+  walletAddress: string
+) => Promise<{ collateralUnits: number; debtUnits: number } | null>;
+
+export type PriceReader = (assetCode: string) => number | null;
+
+/**
+ * Aggregates a grant's UNCONSUMED tranches' pools into one live
+ * PositionRiskSnapshot evaluatePosition() can consume. Deliberately reads
+ * only the unconsumed portion — a tranche the coordinator already unwound
+ * no longer represents live exposure this grant is responsible for.
+ */
+export async function computeGrantRiskSnapshot(
+  grant: DelegationGrant,
+  readPoolPosition: PoolPositionReader,
+  getPrice: PriceReader
+): Promise<PositionRiskSnapshot> {
+  const unconsumed = grant.tranches.filter(
+    (t) => !grant.consumedTrancheIds.includes(t.id)
+  );
+
+  if (unconsumed.length === 0) {
+    return {
+      healthFactor: null,
+      collateralValueUsd: null,
+      debtValueUsd: null,
+      blendedCollateralFactorPct: 0,
+      debtAssetPriceUsd: getPrice(grant.borrowAssetCode),
+    };
+  }
+
+  const collateralPoolIds = [
+    ...new Set(unconsumed.map((t) => t.collateralPoolId)),
+  ];
+  const borrowPoolIds = [...new Set(unconsumed.map((t) => t.borrowPoolId))];
+
+  // Collateral: an unreadable pool falls back to zero. That undercounts the
+  // numerator of HF = (collateral*CF)/debt, which only ever makes the
+  // computed HF LOWER than reality — the conservative, safe-to-be-wrong-in
+  // direction for a risk control (the guard can only trigger too early,
+  // never too late, from this specific gap).
+  let totalCollateralUnits = 0;
+  for (const poolId of collateralPoolIds) {
+    const position = await readPoolPosition(poolId, grant.walletAddress);
+    if (position) totalCollateralUnits += position.collateralUnits;
+  }
+
+  // Debt: the OPPOSITE bias would be dangerous here — silently treating an
+  // unreadable debt pool as zero would make HF look BETTER than reality
+  // (the denominator undercounted) and could suppress a real breach. When a
+  // debt read is unavailable (a protocol whose adapter doesn't expose one —
+  // see app/api/leverage/guard/route.ts's readPoolPosition for Neko), fall
+  // back to that pool's affected tranches' own known-safe static open-time
+  // debtAmount rather than assuming the debt vanished.
+  let totalDebtUnits = 0;
+  for (const poolId of borrowPoolIds) {
+    const position = await readPoolPosition(poolId, grant.walletAddress);
+    if (position) {
+      totalDebtUnits += position.debtUnits;
+    } else {
+      totalDebtUnits += unconsumed
+        .filter((t) => t.borrowPoolId === poolId)
+        .reduce((sum, t) => sum + Number(t.debtAmount), 0);
+    }
+  }
+
+  // Weighted by each tranche's original debt share — the same blending
+  // approach features/dashboard/positions/leverage.ts uses for display.
+  const totalWeight = unconsumed.reduce(
+    (sum, t) => sum + Number(t.debtAmount),
+    0
+  );
+
+  const collateralPrice = getPrice(grant.assetCode);
+  const debtPrice = getPrice(grant.borrowAssetCode);
+  const collateralValueUsd =
+    collateralPrice != null ? totalCollateralUnits * collateralPrice : null;
+  const debtValueUsd = debtPrice != null ? totalDebtUnits * debtPrice : null;
+
+  // A DelegationTrancheRecord carries only its own collateral/debt amounts,
+  // not the pool's max LTV directly, so the pool's real collateral factor
+  // isn't independently observable from these generic pool-position reads.
+  // Approximate it from the EFFECTIVE LTV the loop was actually built at
+  // (debtAmount / collateralAmount per tranche, debt-weighted across
+  // tranches) — by construction (lib/strategy/leverage/loopSizing.ts) that
+  // effective LTV is maxLtv minus the user's safety buffer, i.e. always
+  // slightly BELOW the real collateral factor. That makes this a
+  // deliberately conservative proxy: the computed health factor comes out
+  // slightly lower than the true one, so the guard can only trigger
+  // earlier than strictly necessary, never later.
+  const blendedCollateralFactorPct =
+    totalWeight > 0
+      ? unconsumed.reduce((sum, t) => {
+          const effectiveLtvPct =
+            Number(t.collateralAmount) > 0
+              ? (Number(t.debtAmount) / Number(t.collateralAmount)) * 100
+              : 0;
+          return sum + effectiveLtvPct * (Number(t.debtAmount) / totalWeight);
+        }, 0)
+      : 0;
+
+  const healthFactor =
+    collateralValueUsd != null && debtValueUsd != null
+      ? calculateProjectedHealthFactor(
+          collateralValueUsd,
+          debtValueUsd,
+          blendedCollateralFactorPct
+        )
+      : null;
+
+  return {
+    healthFactor,
+    collateralValueUsd,
+    debtValueUsd,
+    blendedCollateralFactorPct,
+    debtAssetPriceUsd: debtPrice,
+  };
+}

--- a/apps/web-app/src/lib/coordinator/execute.ts
+++ b/apps/web-app/src/lib/coordinator/execute.ts
@@ -1,0 +1,285 @@
+import { nanoid } from "nanoid";
+import type { CoordinatorLedgerStore } from "./ledger";
+import { DelegationScopeViolationError } from "./types";
+import type { TrancheSelection } from "./delegation";
+import type {
+  CoordinatorRun,
+  CoordinatorStepRecord,
+  DelegationGrant,
+} from "./types";
+
+/**
+ * Uniform submit+confirm transport, keyed by a step's submissionMode —
+ * mirrors lib/strategy/execution.ts's TransportAdapter/SignFn split so this
+ * module never imports the Stellar SDK directly and stays unit-testable
+ * without a network, exactly like the wallet-present engine it complements.
+ */
+export interface CoordinatorTransportAdapter {
+  submit(xdr: string, networkPassphrase: string): Promise<{ hash: string }>;
+  confirm(hash: string): Promise<unknown>;
+}
+
+export interface CoordinatorExecutionDeps {
+  store: CoordinatorLedgerStore;
+  transports: Record<"rpc" | "soroswapApi", CoordinatorTransportAdapter>;
+  /**
+   * Wraps an already wallet-signed inner tx XDR with a fresh fee-bump
+   * (server keypair, mirroring VAULT_MANAGER_SECRET_KEY's role) before
+   * submission — the inner transaction's own fee may be stale by the time a
+   * pre-signed tranche is actually used, months after it was granted.
+   * Injected rather than built here so this module stays SDK-free; omit to
+   * submit the inner XDR unmodified (e.g. in tests).
+   */
+  wrapForSubmission?: (
+    signedInnerXdr: string,
+    networkPassphrase: string
+  ) => Promise<{ xdr: string }>;
+}
+
+export interface RunCoordinatorUnwindParams {
+  grant: DelegationGrant;
+  selection: TrancheSelection;
+  healthFactorAtTrigger: number | null;
+  healthFactorTarget: number;
+  /** An existing in-progress run to resume (already reconciled — see reconcileCoordinatorRun), or omit to start a new one. */
+  existingRun?: CoordinatorRun;
+}
+
+function idempotencyKey(
+  runId: string,
+  trancheId: string,
+  stepId: string
+): string {
+  return `${runId}:${trancheId}:${stepId}`;
+}
+
+/**
+ * Asserts every tranche this run is about to touch is a real member of the
+ * exact grant it claims to run under. This is deliberately redundant with
+ * the structural guarantee that only tranches inside a DelegationGrant are
+ * ever submittable at all (there is no other source of signed XDRs this
+ * module can reach) — a hard runtime check that fails loudly instead of
+ * silently trusting the caller.
+ *
+ * The "already consumed" check is skipped when `isResume` is true: a
+ * resumed run's own EARLIER tranches are expected to already be marked
+ * consumed by that same run's prior progress (a tranche is marked consumed
+ * the moment all its steps complete, which can happen on an earlier guard
+ * tick before a crash) — rejecting that would make resumption impossible.
+ * A tranche consumed by a genuinely DIFFERENT, unrelated run can still
+ * never appear in a fresh selection in the first place, since
+ * selectTranchesToClearBreach always filters consumedTrancheIds first.
+ */
+function assertWithinDelegation(
+  grant: DelegationGrant,
+  selection: TrancheSelection,
+  isResume: boolean
+): void {
+  for (const trancheId of selection.trancheIds) {
+    const tranche = grant.tranches.find((t) => t.id === trancheId);
+    if (!tranche) {
+      throw new DelegationScopeViolationError(
+        grant.positionId,
+        `tranche ${trancheId} is not part of this grant`
+      );
+    }
+    if (!isResume && grant.consumedTrancheIds.includes(trancheId)) {
+      throw new DelegationScopeViolationError(
+        grant.positionId,
+        `tranche ${trancheId} was already consumed by a prior run`
+      );
+    }
+  }
+}
+
+/**
+ * Submits a pre-approved partial unwind through the coordinator, resuming
+ * an in-progress run at its next incomplete step rather than restarting
+ * from scratch. Every step is persisted (pending -> submitting -> confirming
+ * -> completed/failed) BEFORE and AFTER each network call, so a crash at
+ * any point leaves the ledger able to say exactly where it stopped.
+ *
+ * Skips steps already "completed" or "failed" on resume — "failed" is a
+ * definitive on-chain/network outcome (not a crash artifact) and is left
+ * for the next guard tick or manual review to react to, not silently
+ * retried. A step left "submitting"/"confirming" by a crash must be
+ * reconciled against chain state FIRST (see reconcileCoordinatorRun) before
+ * being passed back in as `existingRun` — this function treats any
+ * non-completed/non-failed step as safe to (re)submit.
+ */
+export async function runCoordinatorUnwind(
+  deps: CoordinatorExecutionDeps,
+  params: RunCoordinatorUnwindParams
+): Promise<CoordinatorRun> {
+  const { grant, selection } = params;
+  assertWithinDelegation(grant, selection, params.existingRun != null);
+
+  let run = params.existingRun;
+  if (run) {
+    if (run.grantId !== grant.id || run.positionId !== grant.positionId) {
+      throw new DelegationScopeViolationError(
+        grant.positionId,
+        "resumed run belongs to a different grant/position"
+      );
+    }
+  } else {
+    const runId = nanoid();
+    const steps: CoordinatorStepRecord[] = selection.trancheIds.flatMap(
+      (trancheId) => {
+        const tranche = grant.tranches.find((t) => t.id === trancheId);
+        if (!tranche) return [];
+        return tranche.steps.map((s) => ({
+          idempotencyKey: idempotencyKey(runId, trancheId, s.stepId),
+          trancheId,
+          stepId: s.stepId,
+          status: "pending" as const,
+        }));
+      }
+    );
+    run = {
+      id: runId,
+      positionId: grant.positionId,
+      grantId: grant.id,
+      reason: "deleverage-guard",
+      triggeredAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "in_progress",
+      healthFactorAtTrigger: params.healthFactorAtTrigger,
+      healthFactorTarget: params.healthFactorTarget,
+      trancheIdsPlanned: selection.trancheIds,
+      steps,
+    };
+    await deps.store.saveRun(run);
+  }
+
+  const workingGrant: DelegationGrant = {
+    ...grant,
+    consumedTrancheIds: [...grant.consumedTrancheIds],
+  };
+
+  for (const stepRecord of run.steps) {
+    if (stepRecord.status === "completed" || stepRecord.status === "failed")
+      continue;
+
+    const tranche = grant.tranches.find((t) => t.id === stepRecord.trancheId);
+    const signedStep = tranche?.steps.find(
+      (s) => s.stepId === stepRecord.stepId
+    );
+    if (!tranche || !signedStep) {
+      throw new DelegationScopeViolationError(
+        grant.positionId,
+        `run step ${stepRecord.idempotencyKey} references a step no longer present in the grant`
+      );
+    }
+
+    try {
+      stepRecord.status = "submitting";
+      run.updatedAt = Date.now();
+      await deps.store.saveRun(run);
+
+      const xdrToSubmit = deps.wrapForSubmission
+        ? (
+            await deps.wrapForSubmission(
+              signedStep.signedXdr,
+              signedStep.networkPassphrase
+            )
+          ).xdr
+        : signedStep.signedXdr;
+
+      const transport = deps.transports[signedStep.submissionMode];
+      const { hash } = await transport.submit(
+        xdrToSubmit,
+        signedStep.networkPassphrase
+      );
+      stepRecord.txHash = hash;
+      stepRecord.submittedAt = Date.now();
+      stepRecord.status = "confirming";
+      run.updatedAt = Date.now();
+      await deps.store.saveRun(run);
+
+      await transport.confirm(hash);
+      stepRecord.status = "completed";
+      stepRecord.confirmedAt = Date.now();
+      run.updatedAt = Date.now();
+      await deps.store.saveRun(run);
+    } catch (error) {
+      stepRecord.status = "failed";
+      stepRecord.errorMessage =
+        error instanceof Error ? error.message : String(error);
+      run.status = "failed";
+      run.updatedAt = Date.now();
+      await deps.store.saveRun(run);
+      return run;
+    }
+
+    const trancheFullyComplete = tranche.steps.every(
+      (s) =>
+        run!.steps.find(
+          (r) => r.trancheId === tranche.id && r.stepId === s.stepId
+        )?.status === "completed"
+    );
+    if (
+      trancheFullyComplete &&
+      !workingGrant.consumedTrancheIds.includes(tranche.id)
+    ) {
+      workingGrant.consumedTrancheIds.push(tranche.id);
+      await deps.store.saveGrant(workingGrant);
+    }
+  }
+
+  run.status = "completed";
+  run.completedAt = Date.now();
+  run.updatedAt = Date.now();
+  await deps.store.saveRun(run);
+  return run;
+}
+
+// ─── Crash recovery ──────────────────────────────────────────────────────────
+
+export type OnChainTxStatus = "SUCCESS" | "FAILED" | "PENDING" | "NOT_FOUND";
+
+export interface ReconcileCoordinatorRunDeps {
+  getTransactionStatus: (hash: string) => Promise<OnChainTxStatus>;
+}
+
+/**
+ * On restart: for any run step still marked "submitting"/"confirming" (the
+ * process died between submit and the confirm-write), re-poll the chain to
+ * determine the real outcome before runCoordinatorUnwind is asked to
+ * resume — mirrors lib/strategy/execution.ts's reconcileExecution exactly,
+ * for the exact same reason: resubmitting a step that actually already
+ * landed on-chain would either double-execute it or blow up on a stale
+ * sequence number. A PENDING/NOT_FOUND result is left untouched so a later
+ * resume attempt can retry rather than guessing.
+ */
+export async function reconcileCoordinatorRun(
+  run: CoordinatorRun,
+  deps: ReconcileCoordinatorRunDeps
+): Promise<CoordinatorRun> {
+  const reconciled: CoordinatorRun = {
+    ...run,
+    steps: run.steps.map((s) => ({ ...s })),
+  };
+
+  for (const step of reconciled.steps) {
+    const inFlight =
+      step.status === "submitting" || step.status === "confirming";
+    if (!inFlight || !step.txHash) continue;
+
+    try {
+      const status = await deps.getTransactionStatus(step.txHash);
+      if (status === "SUCCESS") {
+        step.status = "completed";
+        step.confirmedAt = Date.now();
+      } else if (status === "FAILED") {
+        step.status = "failed";
+        step.errorMessage =
+          "Transaction failed on-chain while the coordinator was not running.";
+      }
+    } catch {
+      // Reconciliation network error — leave the step's recorded status as-is; retried on a future resume.
+    }
+  }
+
+  return reconciled;
+}

--- a/apps/web-app/src/lib/coordinator/ledger.ts
+++ b/apps/web-app/src/lib/coordinator/ledger.ts
@@ -1,0 +1,189 @@
+import { promises as fs } from "fs";
+import path from "path";
+import type { CoordinatorRun, DelegationGrant } from "./types";
+
+/**
+ * The durable job-ledger primitive the coordinator is built on (Scope §5).
+ *
+ * This repo doesn't have a real database — app/api/automation/* (the
+ * closest existing "durable job" precedent) is an explicitly-labeled
+ * in-memory demo store ("swap for a real DB in production"), and
+ * app/api/vault/invest/route.ts persists nothing at all between
+ * invocations beyond an in-memory cooldown timestamp. Since the
+ * coordinator's crash-resumption requirement is meaningless against a
+ * store that doesn't survive a process restart, this is a real
+ * file-backed store (atomic write-temp-then-rename per record) rather
+ * than another in-memory Map — the interface below is the swap-in point for
+ * a real database in production, and InMemoryCoordinatorLedgerStore below
+ * is what tests use to exercise the same contract without touching disk.
+ */
+export interface CoordinatorLedgerStore {
+  getGrant(positionId: string): Promise<DelegationGrant | null>;
+  saveGrant(grant: DelegationGrant): Promise<void>;
+  listActiveGrants(): Promise<DelegationGrant[]>;
+
+  getRun(runId: string): Promise<CoordinatorRun | null>;
+  saveRun(run: CoordinatorRun): Promise<void>;
+  /** For crash-resume: an existing run for this position still in progress, if any. */
+  findInProgressRunForPosition(
+    positionId: string
+  ): Promise<CoordinatorRun | null>;
+  listRunsForPosition(positionId: string): Promise<CoordinatorRun[]>;
+}
+
+function safeFileName(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), "utf8");
+  await fs.rename(tmpPath, filePath);
+}
+
+async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * File-backed ledger: one JSON file per grant (keyed by positionId) and per
+ * run (keyed by runId), plus a small per-position index of run ids so
+ * `findInProgressRunForPosition` doesn't need to scan the whole directory.
+ * Every write is atomic (temp file + rename) so a crash mid-write can never
+ * leave a torn/partial record behind for the next resume to read.
+ */
+export class FileCoordinatorLedgerStore implements CoordinatorLedgerStore {
+  constructor(
+    private readonly baseDir: string = process.env.LEVERAGE_LEDGER_DIR ??
+      path.join(process.cwd(), ".data", "leverage-coordinator")
+  ) {}
+
+  private grantPath(positionId: string): string {
+    return path.join(
+      this.baseDir,
+      "grants",
+      `${safeFileName(positionId)}.json`
+    );
+  }
+
+  private runPath(runId: string): string {
+    return path.join(this.baseDir, "runs", `${safeFileName(runId)}.json`);
+  }
+
+  private runIndexPath(positionId: string): string {
+    return path.join(
+      this.baseDir,
+      "run-index",
+      `${safeFileName(positionId)}.json`
+    );
+  }
+
+  async getGrant(positionId: string): Promise<DelegationGrant | null> {
+    return readJsonIfExists<DelegationGrant>(this.grantPath(positionId));
+  }
+
+  async saveGrant(grant: DelegationGrant): Promise<void> {
+    await atomicWriteJson(this.grantPath(grant.positionId), grant);
+  }
+
+  async listActiveGrants(): Promise<DelegationGrant[]> {
+    const dir = path.join(this.baseDir, "grants");
+    let files: string[];
+    try {
+      files = await fs.readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const grants = await Promise.all(
+      files
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => readJsonIfExists<DelegationGrant>(path.join(dir, f)))
+    );
+    return grants.filter(
+      (g): g is DelegationGrant => g != null && g.status === "active"
+    );
+  }
+
+  async getRun(runId: string): Promise<CoordinatorRun | null> {
+    return readJsonIfExists<CoordinatorRun>(this.runPath(runId));
+  }
+
+  async saveRun(run: CoordinatorRun): Promise<void> {
+    await atomicWriteJson(this.runPath(run.id), run);
+    const index =
+      (await readJsonIfExists<string[]>(this.runIndexPath(run.positionId))) ??
+      [];
+    if (!index.includes(run.id)) {
+      index.push(run.id);
+      await atomicWriteJson(this.runIndexPath(run.positionId), index);
+    }
+  }
+
+  async findInProgressRunForPosition(
+    positionId: string
+  ): Promise<CoordinatorRun | null> {
+    const runs = await this.listRunsForPosition(positionId);
+    return runs.find((r) => r.status === "in_progress") ?? null;
+  }
+
+  async listRunsForPosition(positionId: string): Promise<CoordinatorRun[]> {
+    const index =
+      (await readJsonIfExists<string[]>(this.runIndexPath(positionId))) ?? [];
+    const runs = await Promise.all(index.map((id) => this.getRun(id)));
+    return runs.filter((r): r is CoordinatorRun => r != null);
+  }
+}
+
+/** In-process store for tests and for exercising the coordinator without touching disk. */
+export class InMemoryCoordinatorLedgerStore implements CoordinatorLedgerStore {
+  private grants = new Map<string, DelegationGrant>();
+  private runs = new Map<string, CoordinatorRun>();
+
+  async getGrant(positionId: string): Promise<DelegationGrant | null> {
+    return this.grants.get(positionId) ?? null;
+  }
+
+  async saveGrant(grant: DelegationGrant): Promise<void> {
+    this.grants.set(grant.positionId, structuredClone(grant));
+  }
+
+  async listActiveGrants(): Promise<DelegationGrant[]> {
+    return [...this.grants.values()].filter((g) => g.status === "active");
+  }
+
+  async getRun(runId: string): Promise<CoordinatorRun | null> {
+    const run = this.runs.get(runId);
+    return run ? structuredClone(run) : null;
+  }
+
+  async saveRun(run: CoordinatorRun): Promise<void> {
+    this.runs.set(run.id, structuredClone(run));
+  }
+
+  async findInProgressRunForPosition(
+    positionId: string
+  ): Promise<CoordinatorRun | null> {
+    const runs = await this.listRunsForPosition(positionId);
+    return runs.find((r) => r.status === "in_progress") ?? null;
+  }
+
+  async listRunsForPosition(positionId: string): Promise<CoordinatorRun[]> {
+    return [...this.runs.values()].filter((r) => r.positionId === positionId);
+  }
+}
+
+let sharedStore: CoordinatorLedgerStore | null = null;
+
+/** Process-wide singleton for API routes — one file-backed store per server process. */
+export function getCoordinatorLedgerStore(): CoordinatorLedgerStore {
+  sharedStore ??= new FileCoordinatorLedgerStore();
+  return sharedStore;
+}

--- a/apps/web-app/src/lib/coordinator/types.ts
+++ b/apps/web-app/src/lib/coordinator/types.ts
@@ -1,0 +1,143 @@
+/**
+ * Durable, unattended execution coordinator (issue Scope §5).
+ *
+ * lib/strategy/execution.ts's ExecutionEngine requires a live wallet
+ * SignFn for every step, so it cannot run the automated deleveraging guard
+ * (Scope §6) unattended. This module is the alternative execution path for
+ * that ONE case: submitting already user-signed, amount-capped,
+ * operation-capped "unwind tranches" (see
+ * lib/strategy/leverage/buildStrategy.ts's buildUnwindTranches) without a
+ * wallet present.
+ *
+ * The delegation is a set of fully pre-signed transactions collected from
+ * the user's wallet at position-open time — never a server-held key that
+ * can sign arbitrary operations on the user's behalf. The coordinator's own
+ * server keypair (mirroring VAULT_MANAGER_SECRET_KEY's role in
+ * app/api/vault/invest/route.ts) only wraps an already-signed inner
+ * transaction in a fee-bump envelope and submits it — it structurally
+ * cannot construct a new operation, so "never submits outside the granted
+ * delegation" is a property of what's submittable, not just a runtime check
+ * (the runtime check in execute.ts is a defense-in-depth assertion on top).
+ */
+
+import type { PoolType } from "@/lib/orchestrator/types/pool.types";
+
+// ─── Delegation ──────────────────────────────────────────────────────────────
+
+export type CoordinatorOperationType = "repay" | "withdrawCollateral";
+
+/** One already wallet-signed step, ready to submit verbatim — no re-signing, no re-building. */
+export interface SignedCoordinatorStep {
+  stepId: string;
+  /** "repay" or the withdraw leg of a supply(mode=collateral,direction=withdraw) step — audit/display only. */
+  operationType: CoordinatorOperationType;
+  protocol: string;
+  poolType: PoolType;
+  assetCode: string;
+  /** Decimal-string amount this exact signed step moves — the hard cap the scope assertion checks against. */
+  amount: string;
+  submissionMode: "rpc" | "soroswapApi";
+  signedXdr: string;
+  networkPassphrase: string;
+}
+
+export interface DelegationTrancheRecord {
+  id: string;
+  /** Deleverage order: 0 unwinds first (most recently added exposure). */
+  order: number;
+  collateralAmount: string;
+  debtAmount: string;
+  /** Orchestrator PoolInfo ids, carried through from the routed loop so a server-side reader (the guard) can look up live on-chain state without the client's localStorage-only Strategy record. */
+  collateralPoolId: string;
+  borrowPoolId: string;
+  steps: SignedCoordinatorStep[];
+}
+
+export type DelegationStatus = "active" | "revoked";
+
+export interface DelegationGrant {
+  id: string;
+  /** The leverage-loop Strategy.id this grant is scoped to — the coordinator never touches any other position. */
+  positionId: string;
+  walletAddress: string;
+  assetCode: string;
+  borrowAssetCode: string;
+  status: DelegationStatus;
+  createdAt: number;
+  revokedAt?: number;
+  /**
+   * Unix ms after which the pre-signed tranches are no longer eligible to
+   * submit, mirroring the validity window baked into each inner
+   * transaction's own time bounds at signing time.
+   */
+  expiresAt: number;
+  tranches: DelegationTrancheRecord[];
+  /** Tranche ids already submitted (successfully or not) — never resubmitted, whether or not this run recovers from a crash. */
+  consumedTrancheIds: string[];
+  /**
+   * The guard config this grant authorizes automated unwinds under — a
+   * grant with no guard config wouldn't have a reason to exist, since
+   * granting delegation IS "turn on automated deleveraging for this
+   * position". Deliberately kept on the grant rather than a separate store:
+   * there is no other durable per-position record in this feature to hang
+   * it off of, and the two are opened/revoked together in the UI.
+   */
+  guardConfig: { deleverageThreshold: number; hysteresis: number };
+  /** The guard's own persisted breach flag (mirrors useRiskAlerts' BreachStateMap) — held through the hysteresis band between guard ticks. */
+  breached: boolean;
+}
+
+export class DelegationScopeViolationError extends Error {
+  constructor(
+    public readonly positionId: string,
+    public readonly reason: string
+  ) {
+    super(
+      `Coordinator refused to submit a step outside its granted delegation for position ${positionId}: ${reason}`
+    );
+    this.name = "DelegationScopeViolationError";
+  }
+}
+
+// ─── Coordinator runs (durable job ledger) ───────────────────────────────────
+
+export type CoordinatorStepStatus =
+  | "pending"
+  | "submitting"
+  | "confirming"
+  | "completed"
+  | "failed";
+
+export interface CoordinatorStepRecord {
+  /** Deterministic `${runId}:${trancheId}:${stepId}` — the same step is never submitted twice even across a crash-resume. */
+  idempotencyKey: string;
+  trancheId: string;
+  stepId: string;
+  status: CoordinatorStepStatus;
+  txHash?: string;
+  submittedAt?: number;
+  confirmedAt?: number;
+  errorMessage?: string;
+}
+
+export type CoordinatorRunStatus =
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "stopped";
+
+export interface CoordinatorRun {
+  id: string;
+  positionId: string;
+  grantId: string;
+  reason: "deleverage-guard";
+  triggeredAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  status: CoordinatorRunStatus;
+  healthFactorAtTrigger: number | null;
+  /** HF + hysteresis the guard is trying to clear — recorded so a resumed run knows its own stop condition without re-deriving it. */
+  healthFactorTarget: number;
+  trancheIdsPlanned: string[];
+  steps: CoordinatorStepRecord[];
+}

--- a/apps/web-app/src/lib/env.server.ts
+++ b/apps/web-app/src/lib/env.server.ts
@@ -26,6 +26,11 @@ const serverSchema = z.object({
   // Vault manager signing key (server-only)
   VAULT_MANAGER_SECRET_KEY: z.string().optional(),
 
+  // Leverage deleveraging coordinator fee-bump key (server-only) — never
+  // authorizes a repay/withdraw itself, only wraps an already user-signed
+  // unwind-tranche transaction with a fresh fee. See lib/coordinator/execute.ts.
+  LEVERAGE_COORDINATOR_SECRET_KEY: z.string().optional(),
+
   // Faucet (server-only)
   FAUCET_SECRET_KEY: z.string().optional(),
   FAUCET_CONTRACT_ID: z.string().optional(),
@@ -42,6 +47,7 @@ const serverSchema = z.object({
 
 const parsed = serverSchema.safeParse({
   VAULT_MANAGER_SECRET_KEY: process.env.VAULT_MANAGER_SECRET_KEY,
+  LEVERAGE_COORDINATOR_SECRET_KEY: process.env.LEVERAGE_COORDINATOR_SECRET_KEY,
   FAUCET_SECRET_KEY: process.env.FAUCET_SECRET_KEY,
   FAUCET_CONTRACT_ID: process.env.FAUCET_CONTRACT_ID,
   ETHERFUSE_API_KEY: process.env.ETHERFUSE_API_KEY,

--- a/apps/web-app/src/lib/strategy/leverage/__tests__/buildStrategy.test.ts
+++ b/apps/web-app/src/lib/strategy/leverage/__tests__/buildStrategy.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@neko/lending", () => ({
+  networks: {
+    testnet: {
+      pool1ContractId: "CPOOL1USDCXLM",
+      pool2ContractId: "CPOOL2RWA",
+    },
+  },
+}));
+
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getAvailableTokens: () => ({
+    USTRY: {
+      contract: "CUSTRYTOKEN",
+      code: "USTRY",
+      name: "US Treasury",
+      decimals: 7,
+    },
+    USDC: {
+      contract: "CUSDCTOKEN",
+      code: "USDC",
+      name: "USD Coin",
+      decimals: 7,
+    },
+  }),
+}));
+
+import {
+  buildLeverageStrategy,
+  buildOpenLoopSteps,
+  buildUnwindTranches,
+} from "../buildStrategy";
+import type { RoutedLoopPlan } from "../types";
+
+function makeRoute(): RoutedLoopPlan {
+  return {
+    ok: true,
+    assetCode: "USTRY",
+    poolsUsed: [
+      {
+        poolType: "blend",
+        collateralPoolId: "blend:CBLENDPOOL:CUSTRYTOKEN",
+        borrowPoolId: "blend:CBLENDPOOL:CUSDCTOKEN",
+        maxLtvPct: 75,
+        borrowRatePct: 4,
+        availableLiquidity: "1000",
+      },
+    ],
+    iterations: [
+      {
+        index: 1,
+        poolType: "blend",
+        collateralPoolId: "blend:CBLENDPOOL:CUSTRYTOKEN",
+        borrowPoolId: "blend:CBLENDPOOL:CUSDCTOKEN",
+        depositAmount: "100",
+        borrowAmount: "70",
+        swapAmountOut: "69",
+        swapPriceImpactBps: 15,
+      },
+      {
+        index: 2,
+        poolType: "neko",
+        collateralPoolId: "neko:USTRY",
+        borrowPoolId: "neko:USDC",
+        depositAmount: "69",
+        borrowAmount: "48.3",
+        swapAmountOut: "47",
+        swapPriceImpactBps: 20,
+      },
+    ],
+    simulation: {
+      steps: [],
+      blendedEntryPrice: null,
+      totalBorrowCostPct: 4.5,
+      totalSlippageBps: 35,
+    },
+  };
+}
+
+describe("buildOpenLoopSteps", () => {
+  it("chains supply -> borrow -> swap per iteration, plus a final redeposit, via dependsOn and stepOutput bindings", () => {
+    const route = makeRoute();
+    const steps = buildOpenLoopSteps({
+      route,
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+    });
+
+    // 3 steps per iteration (supply, borrow, swap) x 2 iterations + 1 final redeposit.
+    expect(steps).toHaveLength(7);
+
+    const byId = new Map(steps.map((s) => [s.id, s]));
+    const supply1 = byId.get("leverage-supply-1")!;
+    expect(supply1.dependsOn).toEqual([]);
+    expect(supply1.params.amount).toEqual({ source: "literal", value: "100" });
+    expect(supply1.protocol).toBe("blend");
+    expect(supply1.params.poolContractId).toEqual({
+      source: "literal",
+      value: "CBLENDPOOL",
+    });
+
+    const borrow1 = byId.get("leverage-borrow-1")!;
+    expect(borrow1.dependsOn).toEqual(["leverage-supply-1"]);
+    expect(borrow1.params.amount).toEqual({ source: "literal", value: "70" });
+
+    const swap1 = byId.get("leverage-swap-1")!;
+    expect(swap1.dependsOn).toEqual(["leverage-borrow-1"]);
+    expect(swap1.params.amountIn).toEqual({
+      source: "stepOutput",
+      stepId: "leverage-borrow-1",
+      portId: "out.borrowedAsset",
+    });
+
+    const supply2 = byId.get("leverage-supply-2")!;
+    expect(supply2.dependsOn).toEqual(["leverage-swap-1"]);
+    expect(supply2.protocol).toBe("neko");
+    expect(supply2.params.amount).toEqual({
+      source: "stepOutput",
+      stepId: "leverage-swap-1",
+      portId: "out.receivedAsset",
+    });
+    // Neko collateral resolves through the fixed pool2 contract + token address.
+    expect(supply2.params.poolContractId).toEqual({
+      source: "literal",
+      value: "CPOOL2RWA",
+    });
+    expect(supply2.params.collateralTokenAddress).toEqual({
+      source: "literal",
+      value: "CUSTRYTOKEN",
+    });
+
+    const borrow2 = byId.get("leverage-borrow-2")!;
+    // Neko borrow only needs assetCode — pool1 resolution is internal to the adapter.
+    expect(borrow2.params).toEqual({
+      assetCode: { source: "literal", value: "USDC" },
+      amount: { source: "literal", value: "48.3" },
+    });
+
+    const final = byId.get("leverage-redeposit-final")!;
+    expect(final.dependsOn).toEqual(["leverage-swap-2"]);
+    expect(final.params.amount).toEqual({
+      source: "stepOutput",
+      stepId: "leverage-swap-2",
+      portId: "out.receivedAsset",
+    });
+  });
+});
+
+describe("buildLeverageStrategy", () => {
+  it("attaches leverageMeta with the kind discriminator, target/achieved multiple, buffer, and route", () => {
+    const route = makeRoute();
+    const strategy = buildLeverageStrategy(
+      {
+        route,
+        assetCode: "USTRY",
+        borrowAssetCode: "USDC",
+        initialCollateralAmount: "100",
+      },
+      2,
+      2.02,
+      5
+    );
+
+    expect(strategy.leverageMeta).toEqual({
+      kind: "leverage-loop",
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      targetMultiple: 2,
+      achievedMultiple: 2.02,
+      safetyBufferPct: 5,
+      route: { poolsUsed: route.poolsUsed, iterations: route.iterations },
+    });
+    expect(strategy.isTemplate).toBe(false);
+    expect(strategy.steps.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildUnwindTranches", () => {
+  it("orders tranches newest-iteration-first, each independently self-contained and repay-before-withdraw", () => {
+    const route = makeRoute();
+    const tranches = buildUnwindTranches({
+      route,
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+    });
+
+    // One tranche per iteration — no tranche for the debt-free final
+    // redeposit, since withdrawing it without a matching repay would only
+    // ever worsen health factor.
+    expect(tranches).toHaveLength(2);
+    expect(tranches.map((t) => t.order)).toEqual([0, 1]);
+
+    // order 0: iteration 2 unwound first (newest first).
+    expect(tranches[0].debtAmount).toBe("48.3");
+    expect(tranches[0].steps).toHaveLength(2);
+    expect(tranches[0].steps[0].type).toBe("repay");
+    expect(tranches[0].steps[0].dependsOn).toEqual([]);
+    expect(tranches[0].steps[1].type).toBe("supply");
+    expect(tranches[0].steps[1].params.direction).toEqual({
+      source: "literal",
+      value: "withdraw",
+    });
+    expect(tranches[0].steps[1].dependsOn).toEqual([tranches[0].steps[0].id]);
+
+    // order 1: iteration 1 unwound last.
+    expect(tranches[1].debtAmount).toBe("70");
+
+    // Every step across every tranche only binds literal values — no
+    // stepOutput bindings crossing tranche boundaries, since each tranche
+    // must be independently pre-signable and submittable.
+    for (const tranche of tranches) {
+      for (const step of tranche.steps) {
+        for (const binding of Object.values(step.params)) {
+          expect(binding.source).toBe("literal");
+        }
+      }
+    }
+  });
+});

--- a/apps/web-app/src/lib/strategy/leverage/__tests__/loopSizing.test.ts
+++ b/apps/web-app/src/lib/strategy/leverage/__tests__/loopSizing.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeLeverageLoop,
+  LEVERAGE_LOOP_MAX_ITERATIONS,
+} from "../loopSizing";
+
+describe("computeLeverageLoop", () => {
+  it("sizes a reachable loop into iterations that converge on the target multiple", () => {
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "1000",
+      targetMultiple: 2,
+      maxLtvPct: 75,
+      safetyBufferPct: 5,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.effectiveLtvPct).toBeCloseTo(70, 5);
+    expect(result.achievedMultiple).toBeGreaterThanOrEqual(2);
+    expect(result.iterations.length).toBeGreaterThan(0);
+    // Every iteration's cumulative multiple must be monotonically increasing.
+    const multiples = result.iterations.map((i) => i.multipleAtStep);
+    for (let i = 1; i < multiples.length; i++) {
+      expect(multiples[i]).toBeGreaterThan(multiples[i - 1]);
+    }
+    // The last iteration is the first one to cross the target.
+    expect(multiples[multiples.length - 1]).toBeGreaterThanOrEqual(2 - 1e-6);
+  });
+
+  it("boundary: target multiple exactly at the theoretical ceiling for zero safety buffer is reachable", () => {
+    // maxLtv 80%, buffer 0 -> ceiling = 1 / (1 - 0.8) = 5x exactly.
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 5,
+      maxLtvPct: 80,
+      safetyBufferPct: 0,
+      maxIterations: 200,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.effectiveLtvPct).toBe(80);
+  });
+
+  it("boundary: a target multiple fractionally beyond the zero-buffer ceiling is rejected as unreachable", () => {
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 5.5,
+      maxLtvPct: 80,
+      safetyBufferPct: 0,
+      maxIterations: 200,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("UNREACHABLE_TARGET_MULTIPLE");
+  });
+
+  it("rejects an unreachable target multiple given the pool's max LTV and safety buffer", () => {
+    // maxLtv 50%, buffer 10 -> effective 40% -> ceiling 1/(1-0.4) = 1.667x.
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "500",
+      targetMultiple: 3,
+      maxLtvPct: 50,
+      safetyBufferPct: 10,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("UNREACHABLE_TARGET_MULTIPLE");
+    expect(result.reason).toMatch(/unreachable/i);
+  });
+
+  it("rejects a loop whose required borrow exceeds available route liquidity", () => {
+    // Per-iteration borrow amounts strictly decrease each step (borrow =
+    // deposit * effectiveLtv < deposit), so a FLAT per-iteration liquidity
+    // cap is always tightest on iteration 1 — this proves the very first
+    // iteration is checked before any collateral is posted, not just
+    // validated after the fact.
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "1000",
+      targetMultiple: 3,
+      maxLtvPct: 75,
+      safetyBufferPct: 0,
+      maxLiquidityPerIteration: "100",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("INSUFFICIENT_ROUTE_LIQUIDITY");
+    expect(result.partialIterations).toEqual([]);
+  });
+
+  it("rejects at the exact iteration where cumulative liquidity would be exceeded, once earlier iterations fit", () => {
+    // A cap comfortably above iteration 1's borrow (750) but below
+    // iteration 2's (562.5) never occurs for a flat cap since amounts only
+    // shrink — so this instead proves the boundary sits exactly at
+    // iteration 1's own requirement, not one iteration early or late.
+    const justBelow = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "1000",
+      targetMultiple: 3,
+      maxLtvPct: 75,
+      safetyBufferPct: 0,
+      maxLiquidityPerIteration: "749.99",
+    });
+    expect(justBelow.ok).toBe(false);
+
+    const justAbove = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "1000",
+      targetMultiple: 1.2,
+      maxLtvPct: 75,
+      safetyBufferPct: 0,
+      maxLiquidityPerIteration: "750.01",
+    });
+    expect(justAbove.ok).toBe(true);
+  });
+
+  it("rejects a safety buffer that consumes the entire max LTV", () => {
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 2,
+      maxLtvPct: 60,
+      safetyBufferPct: 60,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("INVALID_SAFETY_BUFFER");
+  });
+
+  it("rejects a target multiple that isn't greater than 1x", () => {
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 1,
+      maxLtvPct: 75,
+      safetyBufferPct: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("INVALID_TARGET_MULTIPLE");
+  });
+
+  it("rejects an out-of-range max LTV", () => {
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 2,
+      maxLtvPct: 0,
+      safetyBufferPct: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("INVALID_MAX_LTV");
+  });
+
+  it("caps iterations at LEVERAGE_LOOP_MAX_ITERATIONS by default", () => {
+    // Effective LTV so close to 100% that the default cap is hit before
+    // convergence, even though the target is theoretically reachable.
+    const result = computeLeverageLoop({
+      assetCode: "USTRY",
+      initialCollateralAmount: "100",
+      targetMultiple: 50,
+      maxLtvPct: 99,
+      safetyBufferPct: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("MAX_ITERATIONS_EXCEEDED");
+    expect(result.partialIterations?.length).toBe(LEVERAGE_LOOP_MAX_ITERATIONS);
+  });
+});

--- a/apps/web-app/src/lib/strategy/leverage/__tests__/openLoopExecution.test.ts
+++ b/apps/web-app/src/lib/strategy/leverage/__tests__/openLoopExecution.test.ts
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("@neko/lending", () => ({
+  networks: {
+    testnet: {
+      pool1ContractId: "CPOOL1USDCXLM",
+      pool2ContractId: "CPOOL2RWA",
+    },
+  },
+}));
+
+vi.mock("@/lib/helpers/stellar/soroswap", () => ({
+  getAvailableTokens: () => ({
+    USTRY: {
+      contract: "CUSTRYTOKEN",
+      code: "USTRY",
+      name: "US Treasury",
+      decimals: 7,
+    },
+    USDC: {
+      contract: "CUSDCTOKEN",
+      code: "USDC",
+      name: "USD Coin",
+      decimals: 7,
+    },
+  }),
+}));
+
+import { buildOpenLoopSteps } from "../buildStrategy";
+import {
+  ExecutionEngine,
+  type ExecutionEngineDeps,
+} from "@/lib/strategy/execution";
+import { StrategyStepRegistry } from "@/lib/strategy/registry";
+import type {
+  ExecutionRecord,
+  Strategy,
+  StrategyStepDefinition,
+} from "@/lib/strategy/types";
+import type { RoutedLoopPlan } from "../types";
+
+/**
+ * Integration test (Testing section): a full routed leverage loop, composed
+ * exactly the way lib/strategy/leverage/buildStrategy.ts produces it, run
+ * end-to-end through the REAL lib/strategy/execution.ts ExecutionEngine —
+ * only the protocol adapters underneath (supply/borrow/swap prepare()) are
+ * mocked, exactly like lib/strategy/__tests__/execution.test.ts's own
+ * pattern. Proves Scope §3's "composition onto the existing engine" claim
+ * actually holds for a real multi-iteration, cross-protocol loop, not just
+ * the unit-level step-shape assertions in buildStrategy.test.ts.
+ */
+
+function twoIterationRoute(): RoutedLoopPlan {
+  return {
+    ok: true,
+    assetCode: "USTRY",
+    poolsUsed: [
+      {
+        poolType: "blend",
+        collateralPoolId: "blend:CBLENDPOOL:CUSTRYTOKEN",
+        borrowPoolId: "blend:CBLENDPOOL:CUSDCTOKEN",
+        maxLtvPct: 75,
+        borrowRatePct: 4,
+        availableLiquidity: "1000",
+      },
+      {
+        poolType: "neko",
+        collateralPoolId: "neko:USTRY",
+        borrowPoolId: "neko:USDC",
+        maxLtvPct: 70,
+        borrowRatePct: 6,
+        availableLiquidity: "1000",
+      },
+    ],
+    iterations: [
+      {
+        index: 1,
+        poolType: "blend",
+        collateralPoolId: "blend:CBLENDPOOL:CUSTRYTOKEN",
+        borrowPoolId: "blend:CBLENDPOOL:CUSDCTOKEN",
+        depositAmount: "100",
+        borrowAmount: "70",
+        swapAmountOut: "69",
+        swapPriceImpactBps: 15,
+      },
+      {
+        index: 2,
+        poolType: "neko",
+        collateralPoolId: "neko:USTRY",
+        borrowPoolId: "neko:USDC",
+        depositAmount: "69",
+        borrowAmount: "48.3",
+        swapAmountOut: "47",
+        swapPriceImpactBps: 20,
+      },
+    ],
+    simulation: {
+      steps: [],
+      blendedEntryPrice: null,
+      totalBorrowCostPct: 4.8,
+      totalSlippageBps: 35,
+    },
+  };
+}
+
+function fakeDefinition(
+  stepType: string,
+  protocol: string,
+  overrides: Partial<StrategyStepDefinition> = {}
+): StrategyStepDefinition {
+  return {
+    stepType: stepType as StrategyStepDefinition["stepType"],
+    protocol,
+    submissionMode: "rpc",
+    paramsSchema: z.object({}).passthrough(),
+    describeOutputs: () => [],
+    validate: () => [],
+    simulate: async () => ({ outputs: {}, estimatedFee: "0", warnings: [] }),
+    prepare: async () => ({ xdr: "UNSIGNED_XDR", networkPassphrase: "p" }),
+    ...overrides,
+  };
+}
+
+function buildRegistry(overrides?: {
+  borrowBlendPrepare?: StrategyStepDefinition["prepare"];
+  onSwapAmountIn?: (amountIn: string) => void;
+}): StrategyStepRegistry {
+  const registry = new StrategyStepRegistry();
+
+  registry.register(fakeDefinition("supply", "blend"));
+  registry.register(fakeDefinition("supply", "neko"));
+  registry.register(
+    fakeDefinition("borrow", "blend", {
+      // Object spread in fakeDefinition() overrides the default `prepare`
+      // even when the value is explicitly `undefined` (the key is still
+      // present) — only include it when there's a real override.
+      ...(overrides?.borrowBlendPrepare
+        ? { prepare: overrides.borrowBlendPrepare }
+        : {}),
+      interpretResult: async (ctx) => ({
+        outputs: { "out.borrowedAsset": String(ctx.resolvedParams.amount) },
+      }),
+    })
+  );
+  registry.register(
+    fakeDefinition("borrow", "neko", {
+      interpretResult: async (ctx) => ({
+        outputs: { "out.borrowedAsset": String(ctx.resolvedParams.amount) },
+      }),
+    })
+  );
+  registry.register(
+    fakeDefinition("swap", "soroswap", {
+      submissionMode: "soroswapApi",
+      prepare: async (ctx) => {
+        overrides?.onSwapAmountIn?.(String(ctx.resolvedParams.amountIn));
+        return { xdr: "UNSIGNED_XDR", networkPassphrase: "p" };
+      },
+      interpretResult: async (ctx) => ({
+        outputs: {
+          "out.receivedAsset": String(ctx.resolvedParams.amountIn),
+        },
+      }),
+    })
+  );
+
+  return registry;
+}
+
+function freshRecord(strategy: Strategy): ExecutionRecord {
+  return {
+    id: "exec-1",
+    strategyId: strategy.id,
+    strategySnapshot: strategy,
+    status: "in_progress",
+    startedAt: 0,
+    updatedAt: 0,
+    projectedOutcome: { steps: {} },
+    steps: [],
+  };
+}
+
+function baseDeps(
+  registry: StrategyStepRegistry,
+  overrides: Partial<ExecutionEngineDeps> = {}
+): ExecutionEngineDeps {
+  return {
+    registry,
+    sign: vi.fn(async (xdr: string) => ({ signedTxXdr: `signed(${xdr})` })),
+    transports: {
+      rpc: {
+        submit: vi.fn(async () => ({ hash: "HASH" })),
+        confirm: vi.fn(async () => ({ status: "SUCCESS" })),
+      },
+      soroswapApi: {
+        submit: vi.fn(async () => ({ hash: "SORO_HASH" })),
+        confirm: vi.fn(async () => ({ status: "SUCCESS" })),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("leverage-loop open steps through the real ExecutionEngine", () => {
+  it("executes every step of a 2-iteration cross-protocol loop in dependency order, all the way to completion", async () => {
+    const route = twoIterationRoute();
+    const steps = buildOpenLoopSteps({
+      route,
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+    });
+    const strategy: Strategy = {
+      id: "leverage-strat-1",
+      version: 1,
+      name: "USTRY 1.7x",
+      isTemplate: false,
+      steps,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    const swapAmountIns: string[] = [];
+    const registry = buildRegistry({
+      onSwapAmountIn: (amountIn) => swapAmountIns.push(amountIn),
+    });
+    const engine = new ExecutionEngine(baseDeps(registry));
+    const result = await engine.executeStrategy({
+      strategy,
+      execution: freshRecord(strategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.record.steps).toHaveLength(steps.length);
+    expect(result.record.steps.every((s) => s.status === "completed")).toBe(
+      true
+    );
+
+    // Each swap's amountIn is the STEP OUTPUT of that iteration's own
+    // borrow, not the route's static plan — proves the dependsOn/stepOutput
+    // chain actually threads live actualOutputs across iterations AND
+    // across protocols (blend iteration 1 feeding into neko iteration 2),
+    // not just structurally matching what buildStrategy.test.ts checks.
+    expect(swapAmountIns).toEqual(["70", "48.3"]);
+  });
+
+  it("stops at the failing step on a mid-loop failure, leaving a well-defined, inspectable partial state", async () => {
+    const route = twoIterationRoute();
+    const steps = buildOpenLoopSteps({
+      route,
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+    });
+    const strategy: Strategy = {
+      id: "leverage-strat-2",
+      version: 1,
+      name: "USTRY 1.7x",
+      isTemplate: false,
+      steps,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    // Iteration 2's borrow (the 5th step overall: supply1, borrow1, swap1,
+    // supply2, borrow2, swap2, redeposit) fails on-chain.
+    const registry = buildRegistry();
+    // Re-register neko's borrow specifically to fail — iteration 2 is neko.
+    registry.register(
+      fakeDefinition("borrow", "neko", {
+        prepare: async () => {
+          throw new Error("insufficient collateral on-chain");
+        },
+      })
+    );
+
+    const engine = new ExecutionEngine(baseDeps(registry));
+    const result = await engine.executeStrategy({
+      strategy,
+      execution: freshRecord(strategy),
+      userAddress: "GUSER",
+      networkPassphrase: "p",
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.record.status).toBe("failed");
+
+    const byId = new Map(result.record.steps.map((s) => [s.stepId, s]));
+
+    // Everything before iteration 2's borrow completed.
+    expect(byId.get("leverage-supply-1")?.status).toBe("completed");
+    expect(byId.get("leverage-borrow-1")?.status).toBe("completed");
+    expect(byId.get("leverage-swap-1")?.status).toBe("completed");
+    expect(byId.get("leverage-supply-2")?.status).toBe("completed");
+
+    // The failing step itself is recorded, with its error.
+    expect(byId.get("leverage-borrow-2")?.status).toBe("failed");
+    expect(byId.get("leverage-borrow-2")?.errorMessage).toMatch(
+      /insufficient collateral/
+    );
+
+    // Nothing after the failure was ever attempted — not even recorded as
+    // "pending", since the engine never reached them. That absence IS the
+    // well-defined partial state: exactly what ran, exactly where it
+    // stopped, nothing guessed about what would have happened next.
+    expect(byId.has("leverage-swap-2")).toBe(false);
+    expect(byId.has("leverage-redeposit-final")).toBe(false);
+
+    // The position's on-chain collateral/debt from the completed steps is
+    // real and inspectable from the record alone — a caller can resume or
+    // manually unwind from here without re-deriving anything.
+    expect(result.record.steps).toHaveLength(5);
+  });
+});

--- a/apps/web-app/src/lib/strategy/leverage/__tests__/routing.test.ts
+++ b/apps/web-app/src/lib/strategy/leverage/__tests__/routing.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+import { deriveRouteCandidates, selectRoute } from "../routing";
+import type { PoolInfo } from "@/lib/orchestrator/types/pool.types";
+import type { RouteCandidatePool, SwapQuoteFn } from "../types";
+
+function makePoolInfo(overrides: Partial<PoolInfo> = {}): PoolInfo {
+  return {
+    id: "blend:CPOOL1:CASSET1",
+    type: "blend",
+    name: "Pool",
+    tokens: [
+      { address: "CASSET1", code: "USTRY", name: "US Treasury", decimals: 7 },
+    ],
+    tvl: 10_000_0000000n,
+    apy: 5,
+    state: "active",
+    supportedActions: ["deposit", "withdraw", "supplyCollateral", "borrow"],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function flatQuote(priceImpactBps: number): SwapQuoteFn {
+  return async ({ amountIn }) => ({
+    amountOut: amountIn, // 1:1, no price effect on the amount itself
+    priceImpactBps,
+  });
+}
+
+describe("deriveRouteCandidates", () => {
+  it("pairs a Blend collateral reserve only with a borrow reserve in the SAME pool contract", () => {
+    const collateral = [
+      makePoolInfo({
+        id: "blend:CPOOL1:CUSTRY",
+        metadata: { cFactor: 0.8 },
+      }),
+    ];
+    const borrow = [
+      makePoolInfo({
+        id: "blend:CPOOL1:CUSDC",
+        metadata: { borrowApy: 4.2 },
+      }),
+      makePoolInfo({
+        id: "blend:CPOOLOTHER:CUSDC",
+        metadata: { borrowApy: 1.0 }, // cheaper, but wrong pool contract
+      }),
+    ];
+
+    const candidates = deriveRouteCandidates(collateral, borrow);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].collateralPoolId).toBe("blend:CPOOL1:CUSTRY");
+    expect(candidates[0].borrowPoolId).toBe("blend:CPOOL1:CUSDC");
+    expect(candidates[0].maxLtvPct).toBeCloseTo(80, 5);
+    expect(candidates[0].borrowRatePct).toBeCloseTo(4.2, 5);
+  });
+
+  it("pairs every Neko collateral entry with every Neko borrow entry (fixed pool1/pool2 wiring)", () => {
+    const collateral = [
+      makePoolInfo({ id: "neko:USTRY", type: "neko", metadata: {} }),
+    ];
+    const borrow = [
+      makePoolInfo({
+        id: "neko:USDC",
+        type: "neko",
+        metadata: { borrowApy: 3 },
+      }),
+    ];
+    const candidates = deriveRouteCandidates(collateral, borrow);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].poolType).toBe("neko");
+    expect(candidates[0].maxLtvPct).toBeGreaterThan(0);
+  });
+
+  it("excludes pools that don't support the required action or are inactive", () => {
+    const collateral = [
+      makePoolInfo({
+        id: "blend:CPOOL1:CUSTRY",
+        supportedActions: ["deposit", "withdraw"], // no supplyCollateral
+      }),
+    ];
+    const borrow = [
+      makePoolInfo({ id: "blend:CPOOL1:CUSDC", state: "frozen" }),
+    ];
+    expect(deriveRouteCandidates(collateral, borrow)).toHaveLength(0);
+  });
+});
+
+describe("selectRoute", () => {
+  const cheap: RouteCandidatePool = {
+    poolType: "blend",
+    collateralPoolId: "blend:CPOOL1:CUSTRY",
+    borrowPoolId: "blend:CPOOL1:CUSDC",
+    maxLtvPct: 75,
+    borrowRatePct: 3,
+    availableLiquidity: "1000",
+  };
+  const expensive: RouteCandidatePool = {
+    poolType: "neko",
+    collateralPoolId: "neko:USTRY",
+    borrowPoolId: "neko:USDC",
+    maxLtvPct: 70,
+    borrowRatePct: 9,
+    availableLiquidity: "1000",
+  };
+
+  it("picks the lowest blended-cost pool when it has enough liquidity for every iteration", async () => {
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+      targetMultiple: 1.5,
+      safetyBufferPct: 5,
+      candidates: [cheap, expensive],
+      getSwapQuote: flatQuote(10),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.iterations.every((it) => it.poolType === "blend")).toBe(true);
+    expect(result.poolsUsed).toHaveLength(1);
+    expect(result.poolsUsed[0].borrowPoolId).toBe(cheap.borrowPoolId);
+  });
+
+  it("falls over to a second (more expensive) pool once the cheapest pool's liquidity is exhausted — cross-protocol routing", async () => {
+    // Enough for iteration 1 (needs 70) but exhausted immediately after —
+    // every later iteration must fall back to the more expensive pool.
+    const partiallyDrainedCheap: RouteCandidatePool = {
+      ...cheap,
+      availableLiquidity: "75",
+    };
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+      targetMultiple: 2.5,
+      safetyBufferPct: 5,
+      candidates: [partiallyDrainedCheap, expensive],
+      getSwapQuote: flatQuote(5),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.iterations[0].poolType).toBe("blend");
+    const poolTypesUsed = new Set(result.iterations.map((it) => it.poolType));
+    expect(poolTypesUsed.has("neko")).toBe(true);
+    expect(result.poolsUsed.length).toBeGreaterThan(1);
+  });
+
+  it("rejects with INSUFFICIENT_ROUTE_LIQUIDITY when every eligible pool runs out of room", async () => {
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "1000",
+      targetMultiple: 3,
+      safetyBufferPct: 0,
+      candidates: [
+        { ...cheap, availableLiquidity: "1" },
+        { ...expensive, availableLiquidity: "1" },
+      ],
+      getSwapQuote: flatQuote(0),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("INSUFFICIENT_ROUTE_LIQUIDITY");
+  });
+
+  it("rejects an unreachable target multiple before ever calling the swap quote", async () => {
+    const getSwapQuote = vi.fn(flatQuote(0));
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+      targetMultiple: 10,
+      safetyBufferPct: 30,
+      candidates: [{ ...cheap, maxLtvPct: 40 }],
+      getSwapQuote,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("UNREACHABLE_TARGET_MULTIPLE");
+    expect(getSwapQuote).not.toHaveBeenCalled();
+  });
+
+  it("produces a pre-trade simulation whose totals match the known per-iteration outputs", async () => {
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+      targetMultiple: 1.5,
+      safetyBufferPct: 5,
+      candidates: [cheap],
+      getSwapQuote: flatQuote(25),
+      priceUsd: 100,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const expectedSlippage = result.iterations.reduce(
+      (sum, it) => sum + it.swapPriceImpactBps,
+      0
+    );
+    expect(result.simulation.totalSlippageBps).toBe(expectedSlippage);
+    expect(result.simulation.totalBorrowCostPct).toBeCloseTo(3, 5);
+    expect(result.simulation.blendedEntryPrice).toBeCloseTo(
+      100 * (1 + expectedSlippage / 10_000),
+      6
+    );
+    // One deposit + one borrow + one swap step per iteration.
+    expect(result.simulation.steps.length).toBe(result.iterations.length * 3);
+  });
+
+  it("rejects when no candidate pool has positive LTV headroom after the safety buffer", async () => {
+    const result = await selectRoute({
+      assetCode: "USTRY",
+      borrowAssetCode: "USDC",
+      initialCollateralAmount: "100",
+      targetMultiple: 1.2,
+      safetyBufferPct: 80,
+      candidates: [cheap, expensive],
+      getSwapQuote: flatQuote(0),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reasonCode).toBe("NO_SUPPORTED_POOL");
+  });
+});

--- a/apps/web-app/src/lib/strategy/leverage/buildStrategy.ts
+++ b/apps/web-app/src/lib/strategy/leverage/buildStrategy.ts
@@ -1,0 +1,302 @@
+import { nanoid } from "nanoid";
+import { networks } from "@neko/lending";
+import { getAvailableTokens } from "@/lib/helpers/stellar/soroswap";
+import type { ParamBinding, Strategy, StrategyStep } from "../types";
+import type {
+  LeverageLoopStrategyMeta,
+  RouteIterationAssignment,
+  RoutedLoopPlan,
+} from "./types";
+
+const lit = (value: string): ParamBinding => ({ source: "literal", value });
+const fromOutput = (stepId: string, portId: string): ParamBinding => ({
+  source: "stepOutput",
+  stepId,
+  portId,
+});
+
+/**
+ * Resolves a routing iteration's `collateralPoolId` (orchestrator PoolInfo
+ * id, e.g. "blend:CPOOL...:CASSET..." or "neko:USTRY") into the literal
+ * params the matching supply(mode=collateral) step definition expects. Kept
+ * here rather than in routing.ts because it's execution wiring, not routing
+ * decision-making.
+ */
+function collateralParams(
+  collateralPoolId: string,
+  assetCode: string
+): Record<string, ParamBinding> {
+  if (collateralPoolId.startsWith("blend:")) {
+    const [, poolContractId, assetAddress] = collateralPoolId.split(":");
+    return {
+      poolContractId: lit(poolContractId),
+      assetAddress: lit(assetAddress),
+    };
+  }
+  // neko:<assetCode> — collateral always lands in pool2, mirroring
+  // NekoLendingAdapter's own fixed routing.
+  const tokenAddress = getAvailableTokens()[assetCode]?.contract ?? "";
+  return {
+    poolContractId: lit(networks.testnet.pool2ContractId),
+    collateralTokenAddress: lit(tokenAddress),
+  };
+}
+
+/**
+ * Resolves a routing iteration's `borrowPoolId` into the literal params the
+ * matching borrow/repay step definition expects.
+ */
+function borrowParams(
+  borrowPoolId: string,
+  assetCode: string,
+  amount: string
+): Record<string, ParamBinding> {
+  if (borrowPoolId.startsWith("blend:")) {
+    const [, poolContractId, assetAddress] = borrowPoolId.split(":");
+    return {
+      poolContractId: lit(poolContractId),
+      assetAddress: lit(assetAddress),
+      amount: lit(amount),
+    };
+  }
+  // neko:<assetCode> — debt is always drawn from pool1; NekoLendingAdapter
+  // resolves the contract internally from assetCode.
+  return { assetCode: lit(assetCode), amount: lit(amount) };
+}
+
+export interface BuildOpenLoopStepsInput {
+  route: RoutedLoopPlan;
+  assetCode: string;
+  borrowAssetCode: string;
+  initialCollateralAmount: string;
+}
+
+/**
+ * Turns a routed leverage loop into an ordered StrategyStep[] the EXISTING
+ * lib/strategy/execution.ts engine can run wallet-present, step by step —
+ * Scope §3's "no new execution primitive for this path". Each iteration
+ * expands to supply(collateral) -> borrow -> swap, chained by dependsOn +
+ * stepOutput bindings; a final supply(collateral) step redeposits the last
+ * iteration's swap output, realizing the multiple the router simulated.
+ */
+export function buildOpenLoopSteps(
+  input: BuildOpenLoopStepsInput
+): StrategyStep[] {
+  const { route, assetCode, borrowAssetCode, initialCollateralAmount } = input;
+  const steps: StrategyStep[] = [];
+  let previousSwapStepId: string | null = null;
+
+  route.iterations.forEach((it: RouteIterationAssignment, idx: number) => {
+    const supplyId = `leverage-supply-${it.index}`;
+    const borrowId = `leverage-borrow-${it.index}`;
+    const swapId = `leverage-swap-${it.index}`;
+    const protocol = it.poolType === "blend" ? "blend" : "neko";
+
+    steps.push({
+      id: supplyId,
+      type: "supply",
+      protocol,
+      label: `Deposit ${assetCode} collateral (iteration ${it.index})`,
+      dependsOn: previousSwapStepId ? [previousSwapStepId] : [],
+      params: {
+        mode: lit("collateral"),
+        direction: lit("deposit"),
+        ...collateralParams(it.collateralPoolId, assetCode),
+        amount: previousSwapStepId
+          ? fromOutput(previousSwapStepId, "out.receivedAsset")
+          : lit(idx === 0 ? initialCollateralAmount : it.depositAmount),
+      },
+    });
+
+    steps.push({
+      id: borrowId,
+      type: "borrow",
+      protocol,
+      label: `Borrow ${borrowAssetCode} (iteration ${it.index})`,
+      dependsOn: [supplyId],
+      params: borrowParams(it.borrowPoolId, borrowAssetCode, it.borrowAmount),
+    });
+
+    steps.push({
+      id: swapId,
+      type: "swap",
+      protocol: "soroswap",
+      label: `Swap ${borrowAssetCode} -> ${assetCode} (iteration ${it.index})`,
+      dependsOn: [borrowId],
+      params: {
+        // Asset CODES, not resolved contract addresses — matching every
+        // other swap step in this codebase (lib/strategy/templates.ts's
+        // built-in templates, lib/strategy/definitions.ts's own
+        // validate()/knownAssetCode()). getQuote()/buildTransaction()
+        // actually need addresses, which is a PRE-EXISTING mismatch in
+        // swapSoroswapDefinition affecting every swap step, not something
+        // specific to this feature — out of scope to patch here.
+        tokenIn: lit(borrowAssetCode),
+        tokenOut: lit(assetCode),
+        amountIn: fromOutput(borrowId, "out.borrowedAsset"),
+      },
+    });
+
+    previousSwapStepId = swapId;
+  });
+
+  if (previousSwapStepId) {
+    const last = route.iterations[route.iterations.length - 1];
+    const protocol = last.poolType === "blend" ? "blend" : "neko";
+    steps.push({
+      id: "leverage-redeposit-final",
+      type: "supply",
+      protocol,
+      label: `Redeposit ${assetCode} collateral (final)`,
+      dependsOn: [previousSwapStepId],
+      params: {
+        mode: lit("collateral"),
+        direction: lit("deposit"),
+        ...collateralParams(last.collateralPoolId, assetCode),
+        amount: fromOutput(previousSwapStepId, "out.receivedAsset"),
+      },
+    });
+  }
+
+  return steps;
+}
+
+export function buildLeverageStrategyMeta(
+  input: BuildOpenLoopStepsInput,
+  targetMultiple: number,
+  achievedMultiple: number,
+  safetyBufferPct: number
+): LeverageLoopStrategyMeta {
+  return {
+    kind: "leverage-loop",
+    assetCode: input.route.assetCode,
+    borrowAssetCode: input.borrowAssetCode,
+    targetMultiple,
+    achievedMultiple,
+    safetyBufferPct,
+    route: {
+      poolsUsed: input.route.poolsUsed,
+      iterations: input.route.iterations,
+    },
+  };
+}
+
+export function buildLeverageStrategy(
+  input: BuildOpenLoopStepsInput,
+  targetMultiple: number,
+  achievedMultiple: number,
+  safetyBufferPct: number,
+  name = `Leverage ${input.assetCode} ${targetMultiple.toFixed(1)}x`
+): Strategy {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    version: 1,
+    name,
+    description: `Recursive leverage loop on ${input.assetCode}, routed across ${input.route.poolsUsed.map((p) => p.poolType).join(", ")}.`,
+    isTemplate: false,
+    steps: buildOpenLoopSteps(input),
+    createdAt: now,
+    updatedAt: now,
+    leverageMeta: buildLeverageStrategyMeta(
+      input,
+      targetMultiple,
+      achievedMultiple,
+      safetyBufferPct
+    ),
+  };
+}
+
+// ─── Unwind tranches (Scope §5 delegation payload) ───────────────────────────
+
+export interface UnwindTranche {
+  id: string;
+  /** Deleverage order: 0 unwinds first (most recently added exposure). */
+  order: number;
+  /** USD-free estimate of how much collateral/debt this tranche clears, in the asset's own units. */
+  collateralAmount: string;
+  debtAmount: string;
+  /** The pool this tranche's collateral/debt lives in — carried alongside the signed steps so a server-side reader (the guard) can look up live on-chain state without needing the client's localStorage-only Strategy record. */
+  collateralPoolId: string;
+  borrowPoolId: string;
+  steps: StrategyStep[];
+}
+
+/**
+ * Builds the pre-signed "circuit breaker" tranches the deleveraging guard
+ * (Scope §6) is later allowed to submit through the coordinator (Scope §5),
+ * reusing the exact same repay/supply(withdraw) step definitions the manual
+ * Position Unwind template uses (lib/strategy/templates.ts's
+ * "template-position-unwind") — no new execution primitive, no new
+ * contract call. Each tranche repays BEFORE withdrawing, deliberately
+ * mirroring that template's order: repaying first only ever improves
+ * health factor and is safe to submit at any HF above 1.0, whereas
+ * withdrawing collateral first — even collateral about to be backed by an
+ * imminent repay — risks the pool's own on-chain LTV check rejecting the
+ * withdrawal at exactly the moment (HF already low) the guard needs it to
+ * succeed. The tradeoff, documented rather than hidden: repay needs the
+ * debt asset already available to the coordinator's relay flow (see
+ * lib/coordinator/execute.ts) — this loop's own borrowed-and-swapped asset
+ * isn't sitting idle to fund it, the same real constraint every
+ * non-flashloan deleverage flow has.
+ *
+ * Deliberately excludes the loop's final, debt-free redeposit — there is no
+ * on-chain per-iteration partition of collateral (every deposit backs the
+ * position's total debt together), so withdrawing unencumbered collateral
+ * without a matching repay would only ever WORSEN health factor. Only
+ * repay-backed tranches are ever safe to hand the guard.
+ *
+ * Ordered newest-iteration-first: unwinding the most recently added
+ * exposure first is the standard deleverage order and lets the guard stop
+ * as soon as enough tranches have cleared the breach.
+ */
+export function buildUnwindTranches(
+  input: BuildOpenLoopStepsInput
+): UnwindTranche[] {
+  const { route, assetCode, borrowAssetCode } = input;
+  const tranches: UnwindTranche[] = [];
+
+  [...route.iterations].reverse().forEach((it, i) => {
+    const protocol = it.poolType === "blend" ? "blend" : "neko";
+    const repayId = `unwind-repay-${it.index}-${nanoid(6)}`;
+    const withdrawId = `unwind-withdraw-${it.index}-${nanoid(6)}`;
+
+    tranches.push({
+      id: nanoid(),
+      order: i,
+      collateralAmount: it.depositAmount,
+      debtAmount: it.borrowAmount,
+      collateralPoolId: it.collateralPoolId,
+      borrowPoolId: it.borrowPoolId,
+      steps: [
+        {
+          id: repayId,
+          type: "repay",
+          protocol,
+          label: `Repay ${borrowAssetCode} (iteration ${it.index})`,
+          dependsOn: [],
+          params: borrowParams(
+            it.borrowPoolId,
+            borrowAssetCode,
+            it.borrowAmount
+          ),
+        },
+        {
+          id: withdrawId,
+          type: "supply",
+          protocol,
+          label: `Withdraw ${assetCode} collateral (iteration ${it.index})`,
+          dependsOn: [repayId],
+          params: {
+            mode: lit("collateral"),
+            direction: lit("withdraw"),
+            ...collateralParams(it.collateralPoolId, assetCode),
+            amount: lit(it.depositAmount),
+          },
+        },
+      ],
+    });
+  });
+
+  return tranches;
+}

--- a/apps/web-app/src/lib/strategy/leverage/loopSizing.ts
+++ b/apps/web-app/src/lib/strategy/leverage/loopSizing.ts
@@ -1,0 +1,162 @@
+import type {
+  LoopIterationPlan,
+  LoopSizingInput,
+  LoopSizingResult,
+} from "./types";
+
+/**
+ * Safety rail against a pathological input (e.g. safety buffer within
+ * floating-point epsilon of the max LTV) looping effectively forever.
+ * Chosen well above any realistic route — real RWA lending LTVs on this
+ * app top out well under 90%, which converges in single digits of
+ * iterations for any sane target multiple.
+ */
+export const LEVERAGE_LOOP_MAX_ITERATIONS = 25;
+
+/** Below this, two multiples are treated as equal — avoids float-epsilon false rejections/loops. */
+const MULTIPLE_EPSILON = 1e-6;
+
+function toNum(amount: string): number {
+  const n = Number(amount);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Computes the number of deposit→borrow→swap→redeposit iterations needed to
+ * reach `targetMultiple`, and the amount per iteration, for a single pool's
+ * max LTV honoring a safety buffer below it.
+ *
+ * Pure geometric-series sizing: each iteration borrows
+ * `effectiveLtv * depositAmount` and (assuming the swap leg returns the
+ * borrowed value 1:1 in the same asset — routing.ts is what layers real
+ * swap-quote slippage on top of this) redeposits that as the next
+ * iteration's collateral. The series converges to
+ * `1 / (1 - effectiveLtv)` as iterations → ∞, which is the maximum
+ * multiple ANY loop on this route can reach no matter how many iterations
+ * run — targets beyond it are rejected outright rather than looping
+ * forever chasing an unreachable ratio.
+ */
+export function computeLeverageLoop(input: LoopSizingInput): LoopSizingResult {
+  const {
+    assetCode,
+    initialCollateralAmount,
+    targetMultiple,
+    maxLtvPct,
+    safetyBufferPct,
+    maxLiquidityPerIteration,
+    maxIterations = LEVERAGE_LOOP_MAX_ITERATIONS,
+  } = input;
+
+  if (!Number.isFinite(maxLtvPct) || maxLtvPct <= 0 || maxLtvPct >= 100) {
+    return {
+      ok: false,
+      reasonCode: "INVALID_MAX_LTV",
+      reason: `Pool max LTV (${maxLtvPct}%) must be between 0 and 100.`,
+    };
+  }
+
+  if (!Number.isFinite(safetyBufferPct) || safetyBufferPct < 0) {
+    return {
+      ok: false,
+      reasonCode: "INVALID_SAFETY_BUFFER",
+      reason: `Safety buffer (${safetyBufferPct}%) must be zero or a positive percentage.`,
+    };
+  }
+
+  if (!Number.isFinite(targetMultiple) || targetMultiple <= 1) {
+    return {
+      ok: false,
+      reasonCode: "INVALID_TARGET_MULTIPLE",
+      reason: `Target multiple (${targetMultiple}x) must be greater than 1x — a loop only amplifies exposure above the initial deposit.`,
+    };
+  }
+
+  const effectiveLtvPct = maxLtvPct - safetyBufferPct;
+  if (effectiveLtvPct <= 0) {
+    return {
+      ok: false,
+      reasonCode: "INVALID_SAFETY_BUFFER",
+      reason: `Safety buffer (${safetyBufferPct}%) leaves no usable LTV headroom against the pool's max LTV (${maxLtvPct}%).`,
+    };
+  }
+
+  const effectiveLtv = effectiveLtvPct / 100;
+  // Sum of an infinite geometric series with ratio effectiveLtv < 1: the
+  // theoretical ceiling this route can ever reach, regardless of iteration count.
+  const maxAchievableMultiple = 1 / (1 - effectiveLtv);
+
+  if (targetMultiple > maxAchievableMultiple + MULTIPLE_EPSILON) {
+    return {
+      ok: false,
+      reasonCode: "UNREACHABLE_TARGET_MULTIPLE",
+      reason:
+        `Target multiple ${targetMultiple.toFixed(2)}x is unreachable at an effective LTV of ` +
+        `${effectiveLtvPct.toFixed(2)}% (max LTV ${maxLtvPct}% minus ${safetyBufferPct}% safety buffer) — ` +
+        `the highest multiple this route can reach, even with unlimited iterations, is ${maxAchievableMultiple.toFixed(2)}x.`,
+    };
+  }
+
+  const initial = toNum(initialCollateralAmount);
+  const liquidityCap =
+    maxLiquidityPerIteration != null ? toNum(maxLiquidityPerIteration) : null;
+
+  const iterations: LoopIterationPlan[] = [];
+  let cumulativeCollateral = initial;
+  let cumulativeDebt = 0;
+  let depositAmount = initial;
+
+  for (let i = 1; i <= maxIterations; i++) {
+    const borrowAmount = depositAmount * effectiveLtv;
+
+    if (liquidityCap != null && borrowAmount > liquidityCap) {
+      return {
+        ok: false,
+        reasonCode: "INSUFFICIENT_ROUTE_LIQUIDITY",
+        reason:
+          `Iteration ${i} would need to borrow ${borrowAmount.toFixed(7)} ${assetCode}, exceeding the ` +
+          `route's available liquidity of ${liquidityCap.toFixed(7)} ${assetCode} for this leg.`,
+        partialIterations: iterations,
+      };
+    }
+
+    cumulativeDebt += borrowAmount;
+    cumulativeCollateral += borrowAmount; // swap leg assumed 1:1 at this layer
+    const multipleAtStep = cumulativeCollateral / initial;
+
+    iterations.push({
+      index: i,
+      depositAmount: depositAmount.toFixed(7),
+      borrowAmount: borrowAmount.toFixed(7),
+      cumulativeCollateral: cumulativeCollateral.toFixed(7),
+      cumulativeDebt: cumulativeDebt.toFixed(7),
+      multipleAtStep,
+    });
+
+    if (multipleAtStep >= targetMultiple - MULTIPLE_EPSILON) {
+      return {
+        ok: true,
+        assetCode,
+        initialCollateralAmount: initialCollateralAmount,
+        targetMultiple,
+        achievedMultiple: multipleAtStep,
+        effectiveLtvPct,
+        iterations,
+        totalCollateral: cumulativeCollateral.toFixed(7),
+        totalDebt: cumulativeDebt.toFixed(7),
+      };
+    }
+
+    // Next iteration's deposit is this iteration's borrowed-then-swapped amount.
+    depositAmount = borrowAmount;
+  }
+
+  return {
+    ok: false,
+    reasonCode: "MAX_ITERATIONS_EXCEEDED",
+    reason:
+      `Target multiple ${targetMultiple.toFixed(2)}x was not reached within the ${maxIterations}-iteration safety cap ` +
+      `(reached ${(cumulativeCollateral / initial).toFixed(2)}x). This should only happen extremely close to the ` +
+      `route's theoretical ceiling — try a lower target multiple or a larger safety buffer.`,
+    partialIterations: iterations,
+  };
+}

--- a/apps/web-app/src/lib/strategy/leverage/routing.ts
+++ b/apps/web-app/src/lib/strategy/leverage/routing.ts
@@ -1,0 +1,302 @@
+import { computeLeverageLoop } from "./loopSizing";
+import type { PoolInfo } from "@/lib/orchestrator/types/pool.types";
+import type {
+  RouteCandidatePool,
+  RouteIterationAssignment,
+  RouteResult,
+  RouteSimulation,
+  RouteSimulationStep,
+  SwapQuoteFn,
+} from "./types";
+
+/**
+ * Neko's collateral pool doesn't expose a per-reserve collateral factor the
+ * way Blend does (see BlendPoolAdapter's metadata.cFactor) — its contract
+ * enforces LTV internally without surfacing it through PoolInfo. Documented
+ * fallback, consistent with lib/strategy/engine.ts's
+ * DEFAULT_COLLATERAL_FACTOR_PCT used for the same reason.
+ */
+export const DEFAULT_NEKO_MAX_LTV_PCT = 75;
+
+function blendPoolContractId(poolInfoId: string): string | null {
+  if (!poolInfoId.startsWith("blend:")) return null;
+  return poolInfoId.split(":")[1] ?? null;
+}
+
+/**
+ * Pairs orchestrator PoolInfo entries into routing candidates. A leverage
+ * loop always deposits the same collateral asset and borrows the same debt
+ * asset every iteration, so a "route" is really a (collateral reserve,
+ * borrow reserve) pair, not a single pool:
+ *  - Blend pools are shared-liquidity multi-asset pools — the collateral
+ *    and debt reserves are two different PoolInfo entries that must share
+ *    the same underlying pool contract for one deposit to back one borrow.
+ *  - Neko is two fixed single-asset pools (RWA collateral in pool2, USDC/XLM
+ *    debt in pool1) — every RWA collateralPools entry pairs with every
+ *    borrowPools entry, since the two contracts are wired together for all
+ *    assets the same way.
+ *
+ * `maxLtvPct` comes from the COLLATERAL reserve's own collateral factor —
+ * borrowRatePct/availableLiquidity come from the BORROW reserve, since
+ * that's the leg being minimized/liquidity-checked when routing.
+ */
+export function deriveRouteCandidates(
+  collateralPools: PoolInfo[],
+  borrowPools: PoolInfo[]
+): RouteCandidatePool[] {
+  const eligibleCollateral = collateralPools.filter(
+    (p) =>
+      p.supportedActions.includes("supplyCollateral") && p.state === "active"
+  );
+  const eligibleBorrow = borrowPools.filter(
+    (p) => p.supportedActions.includes("borrow") && p.state === "active"
+  );
+
+  const candidates: RouteCandidatePool[] = [];
+
+  for (const collateral of eligibleCollateral) {
+    const collateralContract = blendPoolContractId(collateral.id);
+    for (const borrow of eligibleBorrow) {
+      if (collateral.type !== borrow.type) continue;
+      if (collateral.type === "blend") {
+        // Same pool contract required — Blend borrowing power is computed
+        // per-pool from every reserve deposited within that same contract.
+        if (blendPoolContractId(borrow.id) !== collateralContract) continue;
+      }
+
+      const cFactor = collateral.metadata.cFactor;
+      const maxLtvPct =
+        typeof cFactor === "number" && cFactor > 0 && cFactor <= 1
+          ? cFactor * 100
+          : DEFAULT_NEKO_MAX_LTV_PCT;
+      const borrowApy = borrow.metadata.borrowApy;
+      const borrowRatePct =
+        typeof borrowApy === "number" ? borrowApy : Number.POSITIVE_INFINITY;
+
+      candidates.push({
+        poolType: collateral.type,
+        collateralPoolId: collateral.id,
+        borrowPoolId: borrow.id,
+        maxLtvPct,
+        borrowRatePct,
+        availableLiquidity: (Number(borrow.tvl) / 10 ** 7).toFixed(7),
+      });
+    }
+  }
+
+  return candidates;
+}
+
+export interface SelectRouteInput {
+  /** RWA asset supplied as collateral and reacquired via the swap-back leg. */
+  assetCode: string;
+  /** Asset borrowed against the collateral (e.g. USDC). */
+  borrowAssetCode: string;
+  initialCollateralAmount: string;
+  targetMultiple: number;
+  safetyBufferPct: number;
+  candidates: RouteCandidatePool[];
+  getSwapQuote: SwapQuoteFn;
+  maxIterations?: number;
+  /** Optional spot USD price for assetCode, used only to express blendedEntryPrice. */
+  priceUsd?: number | null;
+}
+
+function weightedAverage(
+  values: { weight: number; value: number }[]
+): number | null {
+  const totalWeight = values.reduce((sum, v) => sum + v.weight, 0);
+  if (totalWeight <= 0) return null;
+  return values.reduce((sum, v) => sum + v.weight * v.value, 0) / totalWeight;
+}
+
+/**
+ * Selects the lowest blended-cost route for a recursive leverage loop across
+ * every eligible registered pool, and produces a full pre-trade simulation
+ * (Scope §2). Unlike loopSizing.computeLeverageLoop (which assumes a
+ * 1:1 swap-back to size the theoretical loop against a single pool's LTV),
+ * this walks the loop iteration-by-iteration against LIVE swap quotes and a
+ * per-pool liquidity budget, greedily picking the cheapest pool with enough
+ * remaining liquidity at each step — which is what naturally produces a
+ * cross-protocol route when the cheapest pool runs out of room mid-loop.
+ */
+export async function selectRoute(
+  input: SelectRouteInput
+): Promise<RouteResult> {
+  const {
+    assetCode,
+    borrowAssetCode,
+    initialCollateralAmount,
+    targetMultiple,
+    safetyBufferPct,
+    candidates,
+    getSwapQuote,
+    maxIterations,
+    priceUsd,
+  } = input;
+
+  const eligible = candidates.filter((c) => c.maxLtvPct - safetyBufferPct > 0);
+  if (eligible.length === 0) {
+    return {
+      ok: false,
+      reasonCode: "NO_SUPPORTED_POOL",
+      reason: `No registered pool supports leveraging ${assetCode} with a positive LTV after the ${safetyBufferPct}% safety buffer.`,
+    };
+  }
+
+  // Reachability gate: if even the single most permissive pool (ignoring
+  // liquidity and swap slippage) can't reach the target multiple, no
+  // combination of pools can either — fail fast with the same rejection
+  // vocabulary as the standalone sizing calculator.
+  const bestLtvCandidate = eligible.reduce((best, c) =>
+    c.maxLtvPct > best.maxLtvPct ? c : best
+  );
+  const reachability = computeLeverageLoop({
+    assetCode,
+    initialCollateralAmount,
+    targetMultiple,
+    maxLtvPct: bestLtvCandidate.maxLtvPct,
+    safetyBufferPct,
+    maxIterations,
+  });
+  if (!reachability.ok) {
+    return {
+      ok: false,
+      reasonCode: reachability.reasonCode,
+      reason: `No available route can reach the target multiple: ${reachability.reason}`,
+    };
+  }
+
+  const remainingLiquidity = new Map(
+    eligible.map((c) => [c.borrowPoolId, Number(c.availableLiquidity)])
+  );
+
+  const iterations: RouteIterationAssignment[] = [];
+  const initial = Number(initialCollateralAmount);
+  let depositAmount = initial;
+  let cumulativeCollateral = initial;
+  const cap = maxIterations ?? 25;
+
+  for (let i = 1; i <= cap; i++) {
+    const ranked = [...eligible].sort(
+      (a, b) => a.borrowRatePct - b.borrowRatePct
+    );
+    const chosen = ranked.find((c) => {
+      const effectiveLtv = (c.maxLtvPct - safetyBufferPct) / 100;
+      const borrowAmount = depositAmount * effectiveLtv;
+      return (remainingLiquidity.get(c.borrowPoolId) ?? 0) >= borrowAmount;
+    });
+
+    if (!chosen) {
+      return {
+        ok: false,
+        reasonCode: "INSUFFICIENT_ROUTE_LIQUIDITY",
+        reason: `Iteration ${i} needs more ${borrowAssetCode} liquidity than any eligible pool has remaining after prior iterations' borrows.`,
+      };
+    }
+
+    const effectiveLtv = (chosen.maxLtvPct - safetyBufferPct) / 100;
+    const borrowAmount = depositAmount * effectiveLtv;
+    remainingLiquidity.set(
+      chosen.borrowPoolId,
+      (remainingLiquidity.get(chosen.borrowPoolId) ?? 0) - borrowAmount
+    );
+
+    const quote = await getSwapQuote({
+      tokenIn: borrowAssetCode,
+      tokenOut: assetCode,
+      amountIn: borrowAmount.toFixed(7),
+    });
+    if (!quote) {
+      return {
+        ok: false,
+        reasonCode: "NO_SUPPORTED_POOL",
+        reason: `No swap liquidity found for ${borrowAssetCode} -> ${assetCode} to close iteration ${i}'s loop.`,
+      };
+    }
+
+    const swapAmountOut = Number(quote.amountOut);
+    iterations.push({
+      index: i,
+      poolType: chosen.poolType,
+      collateralPoolId: chosen.collateralPoolId,
+      borrowPoolId: chosen.borrowPoolId,
+      depositAmount: depositAmount.toFixed(7),
+      borrowAmount: borrowAmount.toFixed(7),
+      swapAmountOut: swapAmountOut.toFixed(7),
+      swapPriceImpactBps: quote.priceImpactBps,
+    });
+
+    cumulativeCollateral += swapAmountOut;
+    const multipleAtStep = cumulativeCollateral / initial;
+    depositAmount = swapAmountOut;
+
+    if (multipleAtStep >= targetMultiple - 1e-6) {
+      const steps: RouteSimulationStep[] = iterations.flatMap((it) => [
+        {
+          kind: "deposit" as const,
+          iterationIndex: it.index,
+          poolId: it.collateralPoolId,
+          assetCode,
+          amount: it.depositAmount,
+        },
+        {
+          kind: "borrow" as const,
+          iterationIndex: it.index,
+          poolId: it.borrowPoolId,
+          assetCode: borrowAssetCode,
+          amount: it.borrowAmount,
+        },
+        {
+          kind: "swap" as const,
+          iterationIndex: it.index,
+          assetCode,
+          amount: it.swapAmountOut,
+          priceImpactBps: it.swapPriceImpactBps,
+        },
+      ]);
+
+      const totalSlippageBps = iterations.reduce(
+        (sum, it) => sum + it.swapPriceImpactBps,
+        0
+      );
+      const totalBorrowCostPct =
+        weightedAverage(
+          iterations.map((it) => {
+            const pool = eligible.find(
+              (c) => c.borrowPoolId === it.borrowPoolId
+            );
+            return {
+              weight: Number(it.borrowAmount),
+              value: pool?.borrowRatePct ?? 0,
+            };
+          })
+        ) ?? 0;
+
+      const simulation: RouteSimulation = {
+        steps,
+        blendedEntryPrice:
+          priceUsd != null ? priceUsd * (1 + totalSlippageBps / 10_000) : null,
+        totalBorrowCostPct,
+        totalSlippageBps,
+      };
+
+      const poolsUsed: RouteCandidatePool[] = [];
+      const seen = new Set<string>();
+      for (const it of iterations) {
+        if (seen.has(it.borrowPoolId)) continue;
+        seen.add(it.borrowPoolId);
+        const pool = eligible.find((c) => c.borrowPoolId === it.borrowPoolId);
+        if (pool) poolsUsed.push(pool);
+      }
+
+      return { ok: true, assetCode, iterations, simulation, poolsUsed };
+    }
+  }
+
+  return {
+    ok: false,
+    reasonCode: "MAX_ITERATIONS_EXCEEDED",
+    reason: `Target multiple ${targetMultiple.toFixed(2)}x was not reached within ${cap} iterations once live swap slippage was accounted for — try a lower target multiple.`,
+  };
+}

--- a/apps/web-app/src/lib/strategy/leverage/types.ts
+++ b/apps/web-app/src/lib/strategy/leverage/types.ts
@@ -1,0 +1,183 @@
+import type { PoolType } from "@/lib/orchestrator/types/pool.types";
+
+/**
+ * Leverage-loop domain types (issue: recursive leverage on RWA collateral).
+ *
+ * Kept separate from lib/strategy/types.ts's generic StrategyStep model —
+ * this module computes *how many* deposit→borrow→swap→redeposit iterations
+ * a target multiple needs and *which pools/swap paths* to route them
+ * through; lib/strategy/leverage/buildStrategy.ts is the only place that
+ * turns the result into StrategyStep[] for the existing engine to run.
+ */
+
+// ─── Loop sizing (Scope §1) ──────────────────────────────────────────────────
+
+export interface LoopSizingInput {
+  /** RWA asset code being leveraged (e.g. "USTRY"). */
+  assetCode: string;
+  /** Starting collateral, in the asset's own decimal units (not USD). */
+  initialCollateralAmount: string;
+  /** Desired total collateral / initial collateral ratio, e.g. 3 for 3x. */
+  targetMultiple: number;
+  /** Pool's max loan-to-value, as a percentage (e.g. 75 for 75%). */
+  maxLtvPct: number;
+  /** User-configured safety margin subtracted from maxLtvPct, in percentage points. */
+  safetyBufferPct: number;
+  /**
+   * Upper bound on borrow-then-swap size the chosen route can absorb per
+   * iteration, in the asset's own units. Omit to skip the liquidity check
+   * (used by the pure sizing calculator in isolation; routing.ts always
+   * supplies it from live PoolInfo.tvl / quote depth).
+   */
+  maxLiquidityPerIteration?: string;
+  /** Safety rail against runaway loops — default LEVERAGE_LOOP_MAX_ITERATIONS. */
+  maxIterations?: number;
+}
+
+export interface LoopIterationPlan {
+  /** 1-based iteration number. */
+  index: number;
+  /** Collateral this iteration deposits, before borrowing against it. */
+  depositAmount: string;
+  /** Amount borrowed against depositAmount at the effective LTV. */
+  borrowAmount: string;
+  /** Running total collateral posted so far, after this iteration's deposit. */
+  cumulativeCollateral: string;
+  /** Running total debt so far, after this iteration's borrow. */
+  cumulativeDebt: string;
+  /** cumulativeCollateral / initialCollateralAmount at this point in the loop. */
+  multipleAtStep: number;
+}
+
+export interface LoopSizingPlan {
+  ok: true;
+  assetCode: string;
+  initialCollateralAmount: string;
+  targetMultiple: number;
+  achievedMultiple: number;
+  effectiveLtvPct: number;
+  iterations: LoopIterationPlan[];
+  totalCollateral: string;
+  totalDebt: string;
+}
+
+export type LoopRejectionReasonCode =
+  | "UNREACHABLE_TARGET_MULTIPLE"
+  | "INVALID_SAFETY_BUFFER"
+  | "INVALID_TARGET_MULTIPLE"
+  | "INVALID_MAX_LTV"
+  | "INSUFFICIENT_ROUTE_LIQUIDITY"
+  | "MAX_ITERATIONS_EXCEEDED";
+
+export interface LoopSizingRejection {
+  ok: false;
+  reasonCode: LoopRejectionReasonCode;
+  reason: string;
+  /** How far the loop got before rejecting, for UI diagnostics. */
+  partialIterations?: LoopIterationPlan[];
+}
+
+export type LoopSizingResult = LoopSizingPlan | LoopSizingRejection;
+
+// ─── Multi-pool routing (Scope §2) ───────────────────────────────────────────
+
+export interface RouteCandidatePool {
+  poolType: PoolType;
+  /**
+   * PoolInfo.id for the COLLATERAL leg — where the RWA asset is deposited.
+   * For Blend this is one specific reserve; for Neko it's always the
+   * shared RWA collateral pool (pool2).
+   */
+  collateralPoolId: string;
+  /**
+   * PoolInfo.id for the BORROW leg — where the debt asset is drawn from.
+   * For Blend, the sibling reserve inside the SAME pool contract as
+   * collateralPoolId (Blend pools are shared-liquidity multi-asset pools,
+   * so collateral and debt reserves live together); for Neko, always the
+   * fixed USDC/XLM pool (pool1) — a different contract than pool2.
+   */
+  borrowPoolId: string;
+  /** Max LTV the collateral reserve offers, as a percentage. */
+  maxLtvPct: number;
+  /** Borrow APY/rate on the debt reserve, as a percentage — minimized when routing. */
+  borrowRatePct: number;
+  /** Available liquidity for the borrow leg, in the borrow asset's own units. */
+  availableLiquidity: string;
+}
+
+export interface SwapQuoteFn {
+  (input: {
+    tokenIn: string;
+    tokenOut: string;
+    amountIn: string;
+  }): Promise<{ amountOut: string; priceImpactBps: number } | null>;
+}
+
+export interface RouteIterationAssignment {
+  index: number;
+  poolType: PoolType;
+  collateralPoolId: string;
+  borrowPoolId: string;
+  depositAmount: string;
+  borrowAmount: string;
+  /** The swap step converting the borrowed asset back into more collateral. */
+  swapAmountOut: string;
+  swapPriceImpactBps: number;
+}
+
+export interface RouteSimulationStep {
+  kind: "deposit" | "borrow" | "swap" | "redeposit";
+  iterationIndex: number;
+  poolId?: string;
+  assetCode: string;
+  amount: string;
+  priceImpactBps?: number;
+}
+
+export interface RouteSimulation {
+  steps: RouteSimulationStep[];
+  /** Blended entry price for the position (collateral value / RWA units acquired). Null when unpriced. */
+  blendedEntryPrice: number | null;
+  /** Sum of borrow-rate cost across iterations, expressed as a blended annualized percentage. */
+  totalBorrowCostPct: number;
+  /** Cumulative swap slippage across every redeposit leg. */
+  totalSlippageBps: number;
+}
+
+export interface RoutedLoopPlan {
+  ok: true;
+  assetCode: string;
+  iterations: RouteIterationAssignment[];
+  simulation: RouteSimulation;
+  /** Pools touched by this route, in the order first used. */
+  poolsUsed: RouteCandidatePool[];
+}
+
+export type RouteRejectionReasonCode =
+  | "NO_SUPPORTED_POOL"
+  | "INSUFFICIENT_ROUTE_LIQUIDITY"
+  | LoopRejectionReasonCode;
+
+export interface RouteRejection {
+  ok: false;
+  reasonCode: RouteRejectionReasonCode;
+  reason: string;
+}
+
+export type RouteResult = RoutedLoopPlan | RouteRejection;
+
+// ─── Strategy metadata persisted on the Strategy document (Scope §3) ────────
+
+export interface LeverageLoopStrategyMeta {
+  kind: "leverage-loop";
+  assetCode: string;
+  /** Debt asset borrowed each iteration (e.g. "USDC") — needed to price the debt leg independently of the collateral asset. */
+  borrowAssetCode: string;
+  targetMultiple: number;
+  achievedMultiple: number;
+  safetyBufferPct: number;
+  route: {
+    poolsUsed: RouteCandidatePool[];
+    iterations: RouteIterationAssignment[];
+  };
+}

--- a/apps/web-app/src/lib/strategy/persistence.ts
+++ b/apps/web-app/src/lib/strategy/persistence.ts
@@ -31,6 +31,45 @@ const strategyStepSchema = z.object({
   dependsOn: z.array(z.string()),
 });
 
+const routeCandidatePoolSchema = z.object({
+  poolType: z.string(),
+  collateralPoolId: z.string(),
+  borrowPoolId: z.string(),
+  maxLtvPct: z.number(),
+  borrowRatePct: z.number(),
+  availableLiquidity: z.string(),
+});
+
+const routeIterationAssignmentSchema = z.object({
+  index: z.number(),
+  poolType: z.string(),
+  collateralPoolId: z.string(),
+  borrowPoolId: z.string(),
+  depositAmount: z.string(),
+  borrowAmount: z.string(),
+  swapAmountOut: z.string(),
+  swapPriceImpactBps: z.number(),
+});
+
+/**
+ * Additive discriminated metadata for a `kind: "leverage-loop"` strategy
+ * (Scope §3) — extends, not replaces, the existing schema. Optional so
+ * every non-leverage strategy (including the four built-in templates)
+ * parses exactly as before.
+ */
+const leverageLoopStrategyMetaSchema = z.object({
+  kind: z.literal("leverage-loop"),
+  assetCode: z.string(),
+  borrowAssetCode: z.string(),
+  targetMultiple: z.number(),
+  achievedMultiple: z.number(),
+  safetyBufferPct: z.number(),
+  route: z.object({
+    poolsUsed: z.array(routeCandidatePoolSchema),
+    iterations: z.array(routeIterationAssignmentSchema),
+  }),
+});
+
 const strategySchema = z.object({
   id: z.string(),
   version: z.number(),
@@ -40,6 +79,7 @@ const strategySchema = z.object({
   steps: z.array(strategyStepSchema),
   createdAt: z.number(),
   updatedAt: z.number(),
+  leverageMeta: leverageLoopStrategyMetaSchema.optional(),
 });
 
 export const strategyStorageSchema = z.object({

--- a/apps/web-app/src/lib/strategy/types.ts
+++ b/apps/web-app/src/lib/strategy/types.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { RiskTier } from "@/features/borrowing/const/riskThresholds";
+import type { LeverageLoopStrategyMeta } from "./leverage/types";
 
 // ─── Strategy model ──────────────────────────────────────────────────────────
 
@@ -63,6 +64,12 @@ export interface Strategy {
   steps: StrategyStep[];
   createdAt: number;
   updatedAt: number;
+  /**
+   * Present only for a strategy built by the leverage-loop builder (Scope
+   * §3) — an additive discriminated field, not a replacement of the generic
+   * Strategy shape every other template also uses.
+   */
+  leverageMeta?: LeverageLoopStrategyMeta;
 }
 
 // ─── Step definition plugin interface ───────────────────────────────────────


### PR DESCRIPTION
## Summary Closes #298

Closes #298

Adds recursive leverage loops for RWA positions, with route-aware sizing, an interactive strategy builder, aggregated position tracking, and an automated deleveraging safeguard.

Users can configure a target leverage multiple, preview the deposit → borrow → swap → redeposit sequence, open the position through the existing execution engine, and optionally grant a tightly scoped, pre-signed delegation for unattended risk reduction.

## Why

Opening a leveraged RWA position previously required users to manually calculate and execute each loop. There was no unified representation of the resulting collateral and debt, no route selection across supported pools, and no safe way to reduce leverage automatically if a position’s health factor deteriorated.

This PR provides the strategy construction and execution flow, while ensuring automated deleveraging is limited to user-approved, pre-signed unwind transactions.

## What was built

### Leverage-loop strategy engine (`apps/web-app/src/lib/strategy/leverage/`)

| Piece | What it does |
| --- | --- |
| `loopSizing.ts` | Calculates recursive deposit/borrow/redeposit iterations for a requested leverage multiple, applying max-LTV, safety-buffer, liquidity, and iteration-limit checks. |
| `routing.ts` | Selects supported lending pools and swap routes, accounting for available liquidity, borrow rates, price impact, slippage, and blended entry price. |
| `buildStrategy.ts` | Converts the routed loop into executable strategy steps and builds reverse unwind tranches for deleveraging. |
| `types.ts` | Defines loop-sizing, routing, strategy metadata, simulation, and rejection-result contracts. |
| Strategy persistence | Persists leverage-loop metadata alongside the existing strategy document. |

### Durable delegated execution coordinator (`apps/web-app/src/lib/coordinator/`)

- Adds a coordinator for automated deleveraging runs with durable run, step, and idempotency state.
- Uses leases and deterministic step keys so a crash or retry does not resubmit an already processed transaction.
- Records submission, confirmation, completion, failure, and stop states.
- Selects only the smallest required prefix of available unwind tranches to clear a health-factor breach.

### Safe delegation model

- Creates and revokes delegation grants scoped to a single leverage position.
- Pre-signs every permitted repay/withdraw transaction while the user’s wallet is connected.
- The server can submit only those pre-signed, amount-capped transactions; it cannot create new arbitrary operations.
- Enforces expiration, revocation, consumed-tranche tracking, and position-scope checks.
- Adds a delegation API route and UI panel for granting and revoking this capability.

### Automated deleveraging guard

- Adds the cron/API route that evaluates delegated positions and triggers an unwind when the configured health-factor threshold is breached.
- Uses hysteresis to prevent repeated trigger/recover oscillation.
- Falls back safely when a grant is missing, revoked, expired, or has no remaining eligible tranches.

### User experience and portfolio visibility

- Adds a leverage builder and open-position hook to the Strategies flow.
- Adds a delegation panel for the automated deleveraging configuration.
- Integrates leverage entry points in strategy and asset-detail screens.
- Extends the unified positions engine to aggregate leveraged collateral and debt into portfolio rows and allocation calculations.

## Test coverage

- Loop sizing: target reachability, safety buffers, liquidity limits, max iterations, and rejection cases.
- Routing and strategy composition: pool selection, slippage, borrow costs, and open-loop steps.
- Coordinator: delegation scope, expiration/revocation, minimum-tranche selection, idempotent resumption, and guard behavior.
- Position aggregation: normalization and portfolio-row calculations.
- Full integration coverage for opening a leverage loop through the real `ExecutionEngine`.