### PR TITLE
fix(automation): move strategies and coordinator ledger to Supabase-backed durable stores

### DIFF
--- a/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
+++ b/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
@@ -27,10 +27,6 @@ function seedPlan(overrides: Partial<RebalancePlan> = {}): RebalancePlan {
     status: "draft",
     ...overrides,
   };
-  // Never reassign globalThis.__automationPlans here: the route module
-  // captured a const reference to the Map at import time, so a replacement
-  // object would become invisible to it. Mutate the existing map instead.
-  globalThis.__automationPlans!.set(plan.id, plan);
   return plan;
 }
 
@@ -45,8 +41,6 @@ function post(body: Record<string, unknown>) {
 
 describe("POST /api/automation/execute — failure event wiring", () => {
   beforeEach(() => {
-    globalThis.__automationPlans ??= new Map();
-    globalThis.__automationPlans!.clear();
     raiseEventMock.mockReset();
   });
 

--- a/apps/web-app/src/app/api/automation/execute/route.ts
+++ b/apps/web-app/src/app/api/automation/execute/route.ts
@@ -16,14 +16,6 @@ import {
 } from "@/lib/jobs/walletAuth";
 import { raiseEvent } from "@/lib/event-platform/outbox";
 
-// In-memory plan store for demo
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationPlans: Map<string, RebalancePlan> | undefined;
-}
-globalThis.__automationPlans ??= new Map<string, RebalancePlan>();
-const planStore = globalThis.__automationPlans;
-
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
@@ -119,7 +111,6 @@ export async function POST(req: NextRequest) {
 
   if (action === "confirm") {
     plan = { ...plan, status: "executing" };
-    planStore.set(plan.id, plan);
     // In production: kick off step execution via a queue worker
     return NextResponse.json(plan);
   }

--- a/apps/web-app/src/app/api/automation/strategies/[id]/route.ts
+++ b/apps/web-app/src/app/api/automation/strategies/[id]/route.ts
@@ -1,15 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
-// Re-use the same in-memory map (module singleton in dev)
-// In prod, replace with a real database call
-import type { Strategy } from "@/features/automation/types/automation";
-
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationStrategies: Map<string, Strategy> | undefined;
-}
-globalThis.__automationStrategies ??= new Map<string, Strategy>();
-const store = globalThis.__automationStrategies;
+import { getAutomationStrategiesStore } from "@/lib/automation/strategiesStore";
 
 export const dynamic = "force-dynamic";
 
@@ -17,17 +7,11 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const existing = store.get(params.id);
-  if (!existing)
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
   const patch = await req.json();
-  const updated: Strategy = {
-    ...existing,
-    ...patch,
-    id: existing.id,
-    updatedAt: Date.now(),
-  };
-  store.set(updated.id, updated);
+  const store = getAutomationStrategiesStore();
+  const updated = await store.update(params.id, patch);
+  if (!updated)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
   return NextResponse.json(updated);
 }
 
@@ -35,8 +19,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  if (!store.has(params.id))
+  const store = getAutomationStrategiesStore();
+  const removed = await store.remove(params.id);
+  if (!removed)
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  store.delete(params.id);
   return new NextResponse(null, { status: 204 });
 }

--- a/apps/web-app/src/app/api/automation/strategies/route.ts
+++ b/apps/web-app/src/app/api/automation/strategies/route.ts
@@ -1,34 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
-import { nanoid } from "nanoid";
-import type { Strategy } from "@/features/automation/types/automation";
-import { PRESET_RULES } from "@/features/automation/const/automation";
-
-// In-memory store for demo; swap for a real DB in production
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationStrategies: Map<string, Strategy> | undefined;
-}
-globalThis.__automationStrategies ??= new Map<string, Strategy>();
-const store = globalThis.__automationStrategies;
+import { getAutomationStrategiesStore } from "@/lib/automation/strategiesStore";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return NextResponse.json([...store.values()]);
+  const store = getAutomationStrategiesStore();
+  const strategies = await store.list();
+  return NextResponse.json(strategies);
 }
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const now = Date.now();
-  const strategy: Strategy = {
-    id: nanoid(),
-    name: body.name ?? "Unnamed",
-    preset: body.preset ?? "balanced",
-    rule: body.rule ?? PRESET_RULES.balanced,
-    enabled: body.enabled ?? false,
-    createdAt: now,
-    updatedAt: now,
-  };
-  store.set(strategy.id, strategy);
+  const store = getAutomationStrategiesStore();
+  const strategy = await store.create({
+    name: body.name,
+    preset: body.preset,
+    rule: body.rule,
+    enabled: body.enabled,
+  });
   return NextResponse.json(strategy, { status: 201 });
 }

--- a/apps/web-app/src/lib/automation/strategiesStore.ts
+++ b/apps/web-app/src/lib/automation/strategiesStore.ts
@@ -1,0 +1,151 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { PRESET_RULES } from "@/features/automation/const/automation";
+import type {
+  Strategy,
+  StrategyPreset,
+  StrategyRule,
+} from "@/features/automation/types/automation";
+import { requireServerEnv } from "@/lib/env.server";
+
+export interface AutomationStrategiesStore {
+  list(): Promise<Strategy[]>;
+  get(id: string): Promise<Strategy | null>;
+  create(input: {
+    name?: string;
+    preset?: string;
+    rule?: unknown;
+    enabled?: boolean;
+  }): Promise<Strategy>;
+  update(id: string, patch: Partial<Strategy>): Promise<Strategy | null>;
+  remove(id: string): Promise<boolean>;
+}
+
+// ─── Row <-> domain mapping ──────────────────────────────────────────────
+
+interface AutomationStrategyRow {
+  id: string;
+  name: string;
+  preset: string;
+  rule: StrategyRule;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapStrategy(row: AutomationStrategyRow): Strategy {
+  return {
+    id: row.id,
+    name: row.name,
+    preset: row.preset as StrategyPreset,
+    rule: row.rule,
+    enabled: row.enabled,
+    createdAt: new Date(row.created_at).getTime(),
+    updatedAt: new Date(row.updated_at).getTime(),
+  };
+}
+
+let cachedClient: SupabaseClient | null = null;
+
+function getClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireServerEnv([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+  cachedClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+  return cachedClient;
+}
+
+/** Test-only: force a fresh client on next use. */
+export function resetSupabaseStrategiesClientForTests(): void {
+  cachedClient = null;
+}
+
+export class SupabaseAutomationStrategiesStore
+  implements AutomationStrategiesStore
+{
+  async list(): Promise<Strategy[]> {
+    const { data, error } = await getClient()
+      .from("automation_strategies")
+      .select("*")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return ((data ?? []) as AutomationStrategyRow[]).map(mapStrategy);
+  }
+
+  async get(id: string): Promise<Strategy | null> {
+    const { data, error } = await getClient()
+      .from("automation_strategies")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapStrategy(data as AutomationStrategyRow) : null;
+  }
+
+  async create(input: {
+    name?: string;
+    preset?: string;
+    rule?: unknown;
+    enabled?: boolean;
+  }): Promise<Strategy> {
+    const preset = (input.preset ?? "balanced") as StrategyPreset;
+    const rule = (input.rule ?? PRESET_RULES.balanced) as StrategyRule;
+    const { data, error } = await getClient()
+      .from("automation_strategies")
+      .insert({
+        name: input.name ?? "Unnamed",
+        preset,
+        rule,
+        enabled: input.enabled ?? false,
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    return mapStrategy(data as AutomationStrategyRow);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Strategy>
+  ): Promise<Strategy | null> {
+    const row: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+    if (patch.name !== undefined) row.name = patch.name;
+    if (patch.preset !== undefined) row.preset = patch.preset;
+    if (patch.rule !== undefined) row.rule = patch.rule;
+    if (patch.enabled !== undefined) row.enabled = patch.enabled;
+
+    const { data, error } = await getClient()
+      .from("automation_strategies")
+      .update(row)
+      .eq("id", id)
+      .select("*")
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapStrategy(data as AutomationStrategyRow) : null;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const { data, error } = await getClient()
+      .from("automation_strategies")
+      .delete()
+      .eq("id", id)
+      .select("id")
+      .maybeSingle();
+    if (error) throw error;
+    return data !== null;
+  }
+}
+
+let cachedStore: AutomationStrategiesStore | null = null;
+
+export function getAutomationStrategiesStore(): AutomationStrategiesStore {
+  if (!cachedStore) {
+    cachedStore = new SupabaseAutomationStrategiesStore();
+  }
+  return cachedStore;
+}

--- a/apps/web-app/src/lib/coordinator/ledger.ts
+++ b/apps/web-app/src/lib/coordinator/ledger.ts
@@ -1,5 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { requireServerEnv } from "@/lib/env.server";
 import type { CoordinatorRun, DelegationGrant } from "./types";
 
 /**
@@ -180,10 +182,158 @@ export class InMemoryCoordinatorLedgerStore implements CoordinatorLedgerStore {
   }
 }
 
+// ─── Supabase-backed store (production default) ──────────────────────────────
+
+interface GrantRow {
+  position_id: string;
+  id: string;
+  status: string;
+  payload: DelegationGrant;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RunRow {
+  id: string;
+  position_id: string;
+  status: string;
+  payload: CoordinatorRun;
+  created_at: string;
+  updated_at: string;
+}
+
+function payloadAsGrant(payload: unknown): DelegationGrant {
+  if (typeof payload === "string") {
+    return JSON.parse(payload) as DelegationGrant;
+  }
+  return payload as DelegationGrant;
+}
+
+function payloadAsRun(payload: unknown): CoordinatorRun {
+  if (typeof payload === "string") {
+    return JSON.parse(payload) as CoordinatorRun;
+  }
+  return payload as CoordinatorRun;
+}
+
+let cachedClient: SupabaseClient | null = null;
+
+function getClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireServerEnv([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+  cachedClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+  return cachedClient;
+}
+
+/** Test-only: force a fresh client on next use. */
+export function resetSupabaseCoordinatorClientForTests(): void {
+  cachedClient = null;
+}
+
+/**
+ * Supabase-backed ledger: one row per grant (keyed by position_id) and per
+ * run (keyed by id). Full grant/run objects live in a jsonb `payload` column;
+ * `id`/`position_id`/`status` are denormalized for indexed filters. Saves are
+ * last-write-wins upserts (same atomicity contract as FileCoordinatorLedgerStore's
+ * write-temp-then-rename — no read-modify-write gap).
+ */
+export class SupabaseCoordinatorLedgerStore implements CoordinatorLedgerStore {
+  async getGrant(positionId: string): Promise<DelegationGrant | null> {
+    const { data, error } = await getClient()
+      .from("coordinator_delegation_grants")
+      .select("payload")
+      .eq("position_id", positionId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? payloadAsGrant((data as GrantRow).payload) : null;
+  }
+
+  async saveGrant(grant: DelegationGrant): Promise<void> {
+    const { error } = await getClient()
+      .from("coordinator_delegation_grants")
+      .upsert(
+        {
+          position_id: grant.positionId,
+          id: grant.id,
+          status: grant.status,
+          payload: grant,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "position_id" }
+      );
+    if (error) throw error;
+  }
+
+  async listActiveGrants(): Promise<DelegationGrant[]> {
+    const { data, error } = await getClient()
+      .from("coordinator_delegation_grants")
+      .select("payload")
+      .eq("status", "active");
+    if (error) throw error;
+    return ((data ?? []) as GrantRow[]).map((row) =>
+      payloadAsGrant(row.payload)
+    );
+  }
+
+  async getRun(runId: string): Promise<CoordinatorRun | null> {
+    const { data, error } = await getClient()
+      .from("coordinator_runs")
+      .select("payload")
+      .eq("id", runId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? payloadAsRun((data as RunRow).payload) : null;
+  }
+
+  async saveRun(run: CoordinatorRun): Promise<void> {
+    const { error } = await getClient()
+      .from("coordinator_runs")
+      .upsert(
+        {
+          id: run.id,
+          position_id: run.positionId,
+          status: run.status,
+          payload: run,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "id" }
+      );
+    if (error) throw error;
+  }
+
+  async findInProgressRunForPosition(
+    positionId: string
+  ): Promise<CoordinatorRun | null> {
+    const { data, error } = await getClient()
+      .from("coordinator_runs")
+      .select("payload")
+      .eq("position_id", positionId)
+      .eq("status", "in_progress")
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? payloadAsRun((data as RunRow).payload) : null;
+  }
+
+  async listRunsForPosition(positionId: string): Promise<CoordinatorRun[]> {
+    const { data, error } = await getClient()
+      .from("coordinator_runs")
+      .select("payload")
+      .eq("position_id", positionId);
+    if (error) throw error;
+    return ((data ?? []) as RunRow[]).map((row) => payloadAsRun(row.payload));
+  }
+}
+
 let sharedStore: CoordinatorLedgerStore | null = null;
 
-/** Process-wide singleton for API routes — one file-backed store per server process. */
+/** Process-wide singleton for API routes — one Supabase-backed store per server process. */
 export function getCoordinatorLedgerStore(): CoordinatorLedgerStore {
-  sharedStore ??= new FileCoordinatorLedgerStore();
+  sharedStore ??= new SupabaseCoordinatorLedgerStore();
   return sharedStore;
 }

--- a/supabase/migrations/20260830130000_create_automation_strategies.sql
+++ b/supabase/migrations/20260830130000_create_automation_strategies.sql
@@ -1,0 +1,16 @@
+-- Durable store for automation rebalance strategies. See lib/automation/strategiesStore
+-- (web-app) for the store built on top of this table.
+
+create table public.automation_strategies (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  preset text not null,
+  rule jsonb not null,
+  enabled boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.automation_strategies enable row level security;
+
+comment on table public.automation_strategies is 'Automation rebalance strategy definitions (preset, rule, enabled). Written/read only via the service role (lib/automation/strategiesStore in the web-app) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';

--- a/supabase/migrations/20260830140000_create_coordinator_ledger.sql
+++ b/supabase/migrations/20260830140000_create_coordinator_ledger.sql
@@ -1,0 +1,36 @@
+-- Durable store for the leverage coordinator's delegation grants and runs.
+-- See lib/coordinator/ledger (web-app) for the store built on top of these tables.
+
+create table public.coordinator_delegation_grants (
+  position_id text primary key,
+  id text not null,
+  status text not null check (status in ('active', 'revoked')),
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index coordinator_delegation_grants_id_idx
+  on public.coordinator_delegation_grants (id);
+create index coordinator_delegation_grants_status_idx
+  on public.coordinator_delegation_grants (status);
+
+create table public.coordinator_runs (
+  id text primary key,
+  position_id text not null,
+  status text not null check (status in ('in_progress', 'completed', 'failed', 'stopped')),
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index coordinator_runs_position_id_idx
+  on public.coordinator_runs (position_id);
+create index coordinator_runs_status_idx
+  on public.coordinator_runs (status);
+
+alter table public.coordinator_delegation_grants enable row level security;
+alter table public.coordinator_runs enable row level security;
+
+comment on table public.coordinator_delegation_grants is 'Leverage-coordinator DelegationGrant records, one per position. Written/read only via the service role (lib/coordinator/ledger in the web-app) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';
+comment on table public.coordinator_runs is 'Leverage-coordinator CoordinatorRun records for crash-resumable unwind jobs. Written/read only via the service role (lib/coordinator/ledger in the web-app) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';


### PR DESCRIPTION
## Summary

Closes #317. Three hand-rolled in-memory/local-disk stores backed real user state and didn't survive a redeploy or a second serverless instance:

- `globalThis.__automationStrategies` (strategies CRUD) → now `SupabaseAutomationStrategiesStore` (`lib/automation/strategiesStore.ts`), mirroring `lib/jobs/backend.ts`'s `SupabaseJobsBackend` pattern.
- `globalThis.__automationPlans` in `execute/route.ts` — dead, write-only map — deleted outright.
- `FileCoordinatorLedgerStore` (local disk) → `SupabaseCoordinatorLedgerStore` is now the default returned by `getCoordinatorLedgerStore()`. `FileCoordinatorLedgerStore` and `InMemoryCoordinatorLedgerStore` are kept in place (local dev / existing test contract).

New Supabase migrations follow the existing `20260830120000_create_job_ledger.sql` convention: RLS enabled, service-role-only, no anon/authenticated policies.

- `supabase/migrations/20260830130000_create_automation_strategies.sql`
- `supabase/migrations/20260830140000_create_coordinator_ledger.sql`

## Known limitation

Test coverage from the issue's acceptance criteria (strategy CRUD durability across store instances, grant/run save-and-read-back, concurrent-write/no-lost-update) is **not included in this PR yet** — opening now per request to get this up quickly; tests to follow in a fast-follow commit on this branch.

## Test plan

- [ ] `npm run test`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [x] `grep -r "__automationStrategies\|__automationPlans" apps/web-app/src` → no hits