### PR TITLE
fix(automation): migrate strategies/plans/coordinator stores to durable Supabase persistence

### DIFF
--- a/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
+++ b/apps/web-app/src/app/api/automation/execute/__tests__/route.test.ts
@@ -27,10 +27,6 @@ function seedPlan(overrides: Partial<RebalancePlan> = {}): RebalancePlan {
     status: "draft",
     ...overrides,
   };
-  // Never reassign globalThis.__automationPlans here: the route module
-  // captured a const reference to the Map at import time, so a replacement
-  // object would become invisible to it. Mutate the existing map instead.
-  globalThis.__automationPlans!.set(plan.id, plan);
   return plan;
 }
 
@@ -45,8 +41,6 @@ function post(body: Record<string, unknown>) {
 
 describe("POST /api/automation/execute — failure event wiring", () => {
   beforeEach(() => {
-    globalThis.__automationPlans ??= new Map();
-    globalThis.__automationPlans!.clear();
     raiseEventMock.mockReset();
   });
 

--- a/apps/web-app/src/app/api/automation/execute/route.ts
+++ b/apps/web-app/src/app/api/automation/execute/route.ts
@@ -16,14 +16,6 @@ import {
 } from "@/lib/jobs/walletAuth";
 import { raiseEvent } from "@/lib/event-platform/outbox";
 
-// In-memory plan store for demo
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationPlans: Map<string, RebalancePlan> | undefined;
-}
-globalThis.__automationPlans ??= new Map<string, RebalancePlan>();
-const planStore = globalThis.__automationPlans;
-
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
@@ -110,19 +102,18 @@ export async function POST(req: NextRequest) {
       const updated = await cancelPlan(planId, walletAddress);
       return NextResponse.json(updated);
     }
-  // Checked against the plan as fetched, before confirm/cancel below
-  // overwrite its status — this is what makes the hook observable at all: a
-  // plan already marked "failed" by some other process (the future
-  // step-execution worker) before this request arrived still gets reported,
-  // even though confirm/cancel always assign their own terminal status next.
-  await raiseFailureEventIfNeeded(plan, walletAddress);
+    // Checked against the plan as fetched, before confirm/cancel below
+    // overwrite its status — this is what makes the hook observable at all: a
+    // plan already marked "failed" by some other process (the future
+    // step-execution worker) before this request arrived still gets reported,
+    // even though confirm/cancel always assign their own terminal status next.
+    await raiseFailureEventIfNeeded(plan, walletAddress);
 
-  if (action === "confirm") {
-    plan = { ...plan, status: "executing" };
-    planStore.set(plan.id, plan);
-    // In production: kick off step execution via a queue worker
-    return NextResponse.json(plan);
-  }
+    if (action === "confirm") {
+      plan = { ...plan, status: "executing" };
+      // In production: kick off step execution via a queue worker
+      return NextResponse.json(plan);
+    }
 
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   } catch (err) {

--- a/apps/web-app/src/app/api/automation/strategies/[id]/route.ts
+++ b/apps/web-app/src/app/api/automation/strategies/[id]/route.ts
@@ -1,15 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-
-// Re-use the same in-memory map (module singleton in dev)
-// In prod, replace with a real database call
-import type { Strategy } from "@/features/automation/types/automation";
-
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationStrategies: Map<string, Strategy> | undefined;
-}
-globalThis.__automationStrategies ??= new Map<string, Strategy>();
-const store = globalThis.__automationStrategies;
+import { getStrategiesStore } from "@/lib/automation/strategiesStore";
 
 export const dynamic = "force-dynamic";
 
@@ -17,17 +7,10 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const existing = store.get(params.id);
-  if (!existing)
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
   const patch = await req.json();
-  const updated: Strategy = {
-    ...existing,
-    ...patch,
-    id: existing.id,
-    updatedAt: Date.now(),
-  };
-  store.set(updated.id, updated);
+  const updated = await getStrategiesStore().update(params.id, patch);
+  if (!updated)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
   return NextResponse.json(updated);
 }
 
@@ -35,8 +18,8 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  if (!store.has(params.id))
+  const deleted = await getStrategiesStore().remove(params.id);
+  if (!deleted)
     return NextResponse.json({ error: "Not found" }, { status: 404 });
-  store.delete(params.id);
   return new NextResponse(null, { status: 204 });
 }

--- a/apps/web-app/src/app/api/automation/strategies/route.ts
+++ b/apps/web-app/src/app/api/automation/strategies/route.ts
@@ -1,34 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { nanoid } from "nanoid";
-import type { Strategy } from "@/features/automation/types/automation";
 import { PRESET_RULES } from "@/features/automation/const/automation";
-
-// In-memory store for demo; swap for a real DB in production
-declare global {
-  // eslint-disable-next-line no-var
-  var __automationStrategies: Map<string, Strategy> | undefined;
-}
-globalThis.__automationStrategies ??= new Map<string, Strategy>();
-const store = globalThis.__automationStrategies;
+import { getStrategiesStore } from "@/lib/automation/strategiesStore";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return NextResponse.json([...store.values()]);
+  return NextResponse.json(await getStrategiesStore().list());
 }
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const now = Date.now();
-  const strategy: Strategy = {
-    id: nanoid(),
+  const strategy = await getStrategiesStore().create({
     name: body.name ?? "Unnamed",
     preset: body.preset ?? "balanced",
     rule: body.rule ?? PRESET_RULES.balanced,
     enabled: body.enabled ?? false,
-    createdAt: now,
-    updatedAt: now,
-  };
-  store.set(strategy.id, strategy);
+  });
   return NextResponse.json(strategy, { status: 201 });
 }

--- a/apps/web-app/src/lib/automation/__tests__/strategiesStore.test.ts
+++ b/apps/web-app/src/lib/automation/__tests__/strategiesStore.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PRESET_RULES } from "@/features/automation/const/automation";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Minimal thenable query builder covering the chains SupabaseStrategiesStore
+ * actually uses against `automation_strategies`.
+ */
+const { fakeClient, resetFakeTables } = vi.hoisted(() => {
+  const tables: Record<string, Row[]> = {
+    automation_strategies: [],
+  };
+
+  class FakeQueryBuilder implements PromiseLike<{
+    data: unknown;
+    error: null;
+  }> {
+    private filters: Array<(row: Row) => boolean> = [];
+    private orderBy: { col: string; ascending: boolean } | null = null;
+    private mode: "select" | "insert" | "update" | "delete" = "select";
+    private payload: Row | null = null;
+    private singleFlag = false;
+    private maybeSingleFlag = false;
+
+    constructor(
+      private readonly dbTables: Record<string, Row[]>,
+      private readonly table: string
+    ) {}
+
+    select(_cols?: string): this {
+      // After insert/update/delete, `.select()` means "return affected rows",
+      // not "switch to read mode".
+      return this;
+    }
+
+    insert(row: Row): this {
+      this.mode = "insert";
+      this.payload = row;
+      return this;
+    }
+
+    update(row: Row): this {
+      this.mode = "update";
+      this.payload = row;
+      return this;
+    }
+
+    delete(): this {
+      this.mode = "delete";
+      return this;
+    }
+
+    eq(col: string, value: unknown): this {
+      this.filters.push((row) => row[col] === value);
+      return this;
+    }
+
+    order(col: string, opts?: { ascending?: boolean }): this {
+      this.orderBy = { col, ascending: opts?.ascending ?? true };
+      return this;
+    }
+
+    single(): this {
+      this.singleFlag = true;
+      return this;
+    }
+
+    maybeSingle(): this {
+      this.maybeSingleFlag = true;
+      return this;
+    }
+
+    private materialize(): { data: unknown; error: null } {
+      const table =
+        this.dbTables[this.table] ?? (this.dbTables[this.table] = []);
+
+      if (this.mode === "insert") {
+        const inserted = structuredClone(this.payload as Row);
+        table.push(inserted);
+        return {
+          data: this.singleFlag
+            ? structuredClone(inserted)
+            : [structuredClone(inserted)],
+          error: null,
+        };
+      }
+
+      let matched = table.filter((row) => this.filters.every((f) => f(row)));
+
+      if (this.mode === "update") {
+        const patch = this.payload as Row;
+        matched.forEach((row) => Object.assign(row, patch));
+        if (this.maybeSingleFlag || this.singleFlag) {
+          return {
+            data: matched[0] != null ? structuredClone(matched[0]) : null,
+            error: null,
+          };
+        }
+        return { data: structuredClone(matched), error: null };
+      }
+
+      if (this.mode === "delete") {
+        const deleted = matched.map((row) => structuredClone(row));
+        const remaining = table.filter(
+          (row) => !this.filters.every((f) => f(row))
+        );
+        table.length = 0;
+        table.push(...remaining);
+        return { data: deleted, error: null };
+      }
+
+      if (this.orderBy) {
+        const { col, ascending } = this.orderBy;
+        matched = [...matched].sort((a, b) => {
+          const av = a[col] as string | number;
+          const bv = b[col] as string | number;
+          if (av === bv) return 0;
+          return ascending ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
+        });
+      }
+
+      if (this.maybeSingleFlag || this.singleFlag) {
+        return {
+          data: matched[0] != null ? structuredClone(matched[0]) : null,
+          error: null,
+        };
+      }
+      return { data: structuredClone(matched), error: null };
+    }
+
+    then<TResult1 = { data: unknown; error: null }, TResult2 = never>(
+      onfulfilled?:
+        | ((value: {
+            data: unknown;
+            error: null;
+          }) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onrejected?:
+        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+        | null
+    ): PromiseLike<TResult1 | TResult2> {
+      return Promise.resolve(this.materialize()).then(onfulfilled, onrejected);
+    }
+  }
+
+  function resetFakeTables() {
+    tables.automation_strategies.length = 0;
+  }
+
+  const fakeClient = {
+    from(table: string) {
+      return new FakeQueryBuilder(tables, table);
+    },
+  };
+
+  return { fakeClient, resetFakeTables };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => fakeClient,
+}));
+
+vi.mock("@/lib/env.server", () => ({
+  requireServerEnv: () => ({
+    SUPABASE_URL: "http://fake",
+    SUPABASE_SERVICE_ROLE_KEY: "fake-key",
+  }),
+}));
+
+import { SupabaseStrategiesStore } from "../strategiesStore";
+
+const T0 = 1_700_000_000_000;
+
+function createInput(
+  overrides: Partial<{
+    name: string;
+    preset: "conservative" | "balanced" | "aggressive" | "custom";
+    rule: (typeof PRESET_RULES)["conservative"];
+    enabled: boolean;
+  }> = {}
+) {
+  return {
+    name: "Test Strategy",
+    preset: "conservative" as const,
+    rule: PRESET_RULES.conservative,
+    enabled: false,
+    ...overrides,
+  };
+}
+
+describe("SupabaseStrategiesStore", () => {
+  beforeEach(() => {
+    resetFakeTables();
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("create assigns an id and sets createdAt === updatedAt with all input fields", async () => {
+    const store = new SupabaseStrategiesStore();
+    const input = createInput({
+      name: "Alpha",
+      preset: "balanced",
+      rule: PRESET_RULES.balanced,
+      enabled: true,
+    });
+
+    const created = await store.create(input);
+
+    expect(created.id).toEqual(expect.any(String));
+    expect(created.id.length).toBeGreaterThan(0);
+    expect(created.createdAt).toBe(T0);
+    expect(created.updatedAt).toBe(T0);
+    expect(created.createdAt).toBe(created.updatedAt);
+    expect(created.name).toBe("Alpha");
+    expect(created.preset).toBe("balanced");
+    expect(created.rule).toEqual(PRESET_RULES.balanced);
+    expect(created.enabled).toBe(true);
+  });
+
+  it("get returns null for an unknown id and the created Strategy for a known id", async () => {
+    const store = new SupabaseStrategiesStore();
+    expect(await store.get("does-not-exist")).toBeNull();
+
+    const created = await store.create(createInput({ name: "Known" }));
+    const fetched = await store.get(created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it("list returns all strategies ordered newest-first by createdAt", async () => {
+    const store = new SupabaseStrategiesStore();
+
+    vi.setSystemTime(T0);
+    const oldest = await store.create(createInput({ name: "Oldest" }));
+    vi.setSystemTime(T0 + 1_000);
+    const middle = await store.create(createInput({ name: "Middle" }));
+    vi.setSystemTime(T0 + 2_000);
+    const newest = await store.create(createInput({ name: "Newest" }));
+
+    const listed = await store.list();
+    expect(listed.map((s) => s.id)).toEqual([newest.id, middle.id, oldest.id]);
+    expect(listed.map((s) => s.name)).toEqual(["Newest", "Middle", "Oldest"]);
+  });
+
+  it("update on an unknown id returns null without throwing", async () => {
+    const store = new SupabaseStrategiesStore();
+    await expect(
+      store.update("missing-id", { enabled: true })
+    ).resolves.toBeNull();
+  });
+
+  it("update with a partial patch leaves other fields untouched and bumps updatedAt", async () => {
+    const store = new SupabaseStrategiesStore();
+    const created = await store.create(
+      createInput({
+        name: "Partial",
+        preset: "aggressive",
+        rule: PRESET_RULES.aggressive,
+        enabled: false,
+      })
+    );
+
+    vi.setSystemTime(T0 + 5_000);
+    const updated = await store.update(created.id, { enabled: true });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.enabled).toBe(true);
+    expect(updated!.name).toBe("Partial");
+    expect(updated!.preset).toBe("aggressive");
+    expect(updated!.rule).toEqual(PRESET_RULES.aggressive);
+    expect(updated!.createdAt).toBe(T0);
+    expect(updated!.updatedAt).toBe(T0 + 5_000);
+    expect(updated!.updatedAt).toBeGreaterThan(created.updatedAt);
+    expect(updated!.updatedAt).toBeGreaterThan(created.createdAt);
+  });
+
+  it("remove returns true for a known id and false for an unknown id", async () => {
+    const store = new SupabaseStrategiesStore();
+    const created = await store.create(createInput({ name: "ToRemove" }));
+
+    expect(await store.remove(created.id)).toBe(true);
+    expect(await store.get(created.id)).toBeNull();
+
+    await expect(store.remove("never-existed")).resolves.toBe(false);
+  });
+
+  it("a strategy created via one store instance is visible to another instance", async () => {
+    const storeA = new SupabaseStrategiesStore();
+    const storeB = new SupabaseStrategiesStore();
+
+    const created = await storeA.create(
+      createInput({ name: "CrossInstance", enabled: true })
+    );
+
+    const listed = await storeB.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toEqual(created);
+
+    const fetched = await storeB.get(created.id);
+    expect(fetched).toEqual(created);
+  });
+
+  it("concurrent creates persist all distinct strategies without corruption", async () => {
+    const store = new SupabaseStrategiesStore();
+    const count = 15;
+
+    const created = await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        store.create(createInput({ name: `Concurrent-${i}` }))
+      )
+    );
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(count);
+
+    const ids = listed.map((s) => s.id);
+    expect(new Set(ids).size).toBe(count);
+
+    const names = new Set(listed.map((s) => s.name));
+    expect(names.size).toBe(count);
+    for (let i = 0; i < count; i++) {
+      expect(names.has(`Concurrent-${i}`)).toBe(true);
+    }
+
+    for (const strategy of created) {
+      const match = listed.find((s) => s.id === strategy.id);
+      expect(match).toEqual(strategy);
+      expect(match!.name).toBe(strategy.name);
+      expect(match!.preset).toBe(strategy.preset);
+      expect(match!.rule).toEqual(strategy.rule);
+      expect(match!.enabled).toBe(strategy.enabled);
+    }
+  });
+});

--- a/apps/web-app/src/lib/automation/strategiesStore.ts
+++ b/apps/web-app/src/lib/automation/strategiesStore.ts
@@ -1,0 +1,137 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { nanoid } from "nanoid";
+import { requireServerEnv } from "@/lib/env.server";
+import type { Strategy } from "@/features/automation/types/automation";
+
+// ─── Row <-> domain mapping ──────────────────────────────────────────────
+
+interface StrategyRow {
+  id: string;
+  name: string;
+  preset: Strategy["preset"];
+  rule: Strategy["rule"];
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+  last_run_at: string | null;
+}
+
+function mapStrategyRow(row: StrategyRow): Strategy {
+  return {
+    id: row.id,
+    name: row.name,
+    preset: row.preset,
+    rule: row.rule,
+    enabled: row.enabled,
+    createdAt: new Date(row.created_at).getTime(),
+    updatedAt: new Date(row.updated_at).getTime(),
+    ...(row.last_run_at
+      ? { lastRunAt: new Date(row.last_run_at).getTime() }
+      : {}),
+  };
+}
+
+let cachedClient: SupabaseClient | null = null;
+
+function getAutomationClient(): SupabaseClient {
+  if (cachedClient) return cachedClient;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireServerEnv([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+  cachedClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+  return cachedClient;
+}
+
+export class SupabaseStrategiesStore {
+  async list(): Promise<Strategy[]> {
+    const { data, error } = await getAutomationClient()
+      .from("automation_strategies")
+      .select("*")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return ((data ?? []) as StrategyRow[]).map(mapStrategyRow);
+  }
+
+  async get(id: string): Promise<Strategy | null> {
+    const { data, error } = await getAutomationClient()
+      .from("automation_strategies")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapStrategyRow(data as StrategyRow) : null;
+  }
+
+  async create(input: {
+    name: string;
+    preset: Strategy["preset"];
+    rule: Strategy["rule"];
+    enabled: boolean;
+  }): Promise<Strategy> {
+    const now = Date.now();
+    const { data, error } = await getAutomationClient()
+      .from("automation_strategies")
+      .insert({
+        id: nanoid(),
+        name: input.name,
+        preset: input.preset,
+        rule: input.rule,
+        enabled: input.enabled,
+        created_at: new Date(now).toISOString(),
+        updated_at: new Date(now).toISOString(),
+      })
+      .select("*")
+      .single();
+    if (error) throw error;
+    return mapStrategyRow(data as StrategyRow);
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<Strategy, "id">>
+  ): Promise<Strategy | null> {
+    const row: Record<string, unknown> = {
+      updated_at: new Date(Date.now()).toISOString(),
+    };
+    if (patch.name !== undefined) row.name = patch.name;
+    if (patch.preset !== undefined) row.preset = patch.preset;
+    if (patch.rule !== undefined) row.rule = patch.rule;
+    if (patch.enabled !== undefined) row.enabled = patch.enabled;
+    if (patch.createdAt !== undefined) {
+      row.created_at = new Date(patch.createdAt).toISOString();
+    }
+    if (patch.lastRunAt !== undefined) {
+      row.last_run_at = new Date(patch.lastRunAt).toISOString();
+    }
+
+    const { data, error } = await getAutomationClient()
+      .from("automation_strategies")
+      .update(row)
+      .eq("id", id)
+      .select("*")
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapStrategyRow(data as StrategyRow) : null;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const { data, error } = await getAutomationClient()
+      .from("automation_strategies")
+      .delete()
+      .eq("id", id)
+      .select("id");
+    if (error) throw error;
+    return (data?.length ?? 0) > 0;
+  }
+}
+
+let sharedStore: SupabaseStrategiesStore | null = null;
+
+/** Process-wide singleton for API routes — one Supabase-backed store per server process. */
+export function getStrategiesStore(): SupabaseStrategiesStore {
+  sharedStore ??= new SupabaseStrategiesStore();
+  return sharedStore;
+}

--- a/apps/web-app/src/lib/coordinator/__tests__/ledger.test.ts
+++ b/apps/web-app/src/lib/coordinator/__tests__/ledger.test.ts
@@ -1,0 +1,511 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import type { CoordinatorRun, DelegationGrant } from "../types";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Minimal thenable query builder for SupabaseCoordinatorLedgerStore.
+ * Upsert replaces the full existing row on conflict (no field merge), matching
+ * Postgres ON CONFLICT DO UPDATE SET … of every column.
+ */
+const { fakeClient, resetFakeTables } = vi.hoisted(() => {
+  const tables: Record<string, Row[]> = {
+    coordinator_delegation_grants: [],
+    coordinator_runs: [],
+  };
+
+  class FakeQueryBuilder implements PromiseLike<{
+    data: unknown;
+    error: null;
+  }> {
+    private filters: Array<(row: Row) => boolean> = [];
+    private orderBy: { col: string; ascending: boolean } | null = null;
+    private limitN: number | null = null;
+    private mode: "select" | "upsert" = "select";
+    private payload: Row | null = null;
+    private onConflictCols: string[] | null = null;
+    private maybeSingleFlag = false;
+
+    constructor(
+      private readonly dbTables: Record<string, Row[]>,
+      private readonly table: string
+    ) {}
+
+    select(_cols?: string): this {
+      return this;
+    }
+
+    upsert(row: Row, opts?: { onConflict?: string }): this {
+      this.mode = "upsert";
+      this.payload = row;
+      this.onConflictCols =
+        opts?.onConflict?.split(",").map((c) => c.trim()) ?? null;
+      return this;
+    }
+
+    eq(col: string, value: unknown): this {
+      this.filters.push((row) => row[col] === value);
+      return this;
+    }
+
+    order(col: string, opts?: { ascending?: boolean }): this {
+      this.orderBy = { col, ascending: opts?.ascending ?? true };
+      return this;
+    }
+
+    limit(n: number): this {
+      this.limitN = n;
+      return this;
+    }
+
+    maybeSingle(): this {
+      this.maybeSingleFlag = true;
+      return this;
+    }
+
+    private materialize(): { data: unknown; error: null } {
+      const table =
+        this.dbTables[this.table] ?? (this.dbTables[this.table] = []);
+
+      if (this.mode === "upsert") {
+        const row = structuredClone(this.payload as Row);
+        const keyCols = this.onConflictCols ?? Object.keys(row);
+        const existingIdx = table.findIndex((r) =>
+          keyCols.every((c) => r[c] === row[c])
+        );
+        if (existingIdx >= 0) {
+          // Full-row replace — never merge with the previous row.
+          table[existingIdx] = row;
+          return { data: structuredClone(row), error: null };
+        }
+        table.push(row);
+        return { data: structuredClone(row), error: null };
+      }
+
+      let matched = table.filter((row) => this.filters.every((f) => f(row)));
+
+      if (this.orderBy) {
+        const { col, ascending } = this.orderBy;
+        matched = [...matched].sort((a, b) => {
+          const av = a[col] as string | number;
+          const bv = b[col] as string | number;
+          if (av === bv) return 0;
+          return ascending ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
+        });
+      }
+      if (this.limitN !== null) matched = matched.slice(0, this.limitN);
+
+      if (this.maybeSingleFlag) {
+        return {
+          data: matched[0] != null ? structuredClone(matched[0]) : null,
+          error: null,
+        };
+      }
+      return { data: structuredClone(matched), error: null };
+    }
+
+    then<TResult1 = { data: unknown; error: null }, TResult2 = never>(
+      onfulfilled?:
+        | ((value: {
+            data: unknown;
+            error: null;
+          }) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onrejected?:
+        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+        | null
+    ): PromiseLike<TResult1 | TResult2> {
+      return Promise.resolve(this.materialize()).then(onfulfilled, onrejected);
+    }
+  }
+
+  function resetFakeTables() {
+    tables.coordinator_delegation_grants.length = 0;
+    tables.coordinator_runs.length = 0;
+  }
+
+  const fakeClient = {
+    from(table: string) {
+      return new FakeQueryBuilder(tables, table);
+    },
+  };
+
+  return { fakeClient, resetFakeTables };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => fakeClient,
+}));
+
+vi.mock("@/lib/env.server", () => ({
+  requireServerEnv: () => ({
+    SUPABASE_URL: "http://fake",
+    SUPABASE_SERVICE_ROLE_KEY: "fake-key",
+  }),
+}));
+
+import {
+  FileCoordinatorLedgerStore,
+  InMemoryCoordinatorLedgerStore,
+  SupabaseCoordinatorLedgerStore,
+  type CoordinatorLedgerStore,
+} from "../ledger";
+
+function makeGrant(overrides: Partial<DelegationGrant> = {}): DelegationGrant {
+  return {
+    id: "grant-1",
+    positionId: "pos-1",
+    walletAddress: "GUSERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    assetCode: "USTRY",
+    borrowAssetCode: "USDC",
+    status: "active",
+    createdAt: 1_700_000_000_000,
+    expiresAt: 1_800_000_000_000,
+    tranches: [
+      {
+        id: "t0",
+        order: 0,
+        collateralAmount: "100.5",
+        debtAmount: "50.25",
+        collateralPoolId: "blend:CPOOL:CUSTRY",
+        borrowPoolId: "blend:CPOOL:CUSDC",
+        steps: [
+          {
+            stepId: "repay-0",
+            operationType: "repay",
+            protocol: "blend",
+            poolType: "blend",
+            assetCode: "USDC",
+            amount: "50.25",
+            submissionMode: "rpc",
+            signedXdr: "AAAA...repay",
+            networkPassphrase: "Test SDF Network ; September 2015",
+          },
+          {
+            stepId: "withdraw-0",
+            operationType: "withdrawCollateral",
+            protocol: "blend",
+            poolType: "blend",
+            assetCode: "USTRY",
+            amount: "100.5",
+            submissionMode: "rpc",
+            signedXdr: "AAAA...withdraw",
+            networkPassphrase: "Test SDF Network ; September 2015",
+          },
+        ],
+      },
+      {
+        id: "t1",
+        order: 1,
+        collateralAmount: "80",
+        debtAmount: "40",
+        collateralPoolId: "blend:CPOOL:CUSTRY",
+        borrowPoolId: "blend:CPOOL:CUSDC",
+        steps: [
+          {
+            stepId: "repay-1",
+            operationType: "repay",
+            protocol: "blend",
+            poolType: "blend",
+            assetCode: "USDC",
+            amount: "40",
+            submissionMode: "soroswapApi",
+            signedXdr: "AAAA...repay1",
+            networkPassphrase: "Test SDF Network ; September 2015",
+          },
+        ],
+      },
+    ],
+    consumedTrancheIds: ["t0"],
+    guardConfig: { deleverageThreshold: 1.15, hysteresis: 0.05 },
+    breached: true,
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<CoordinatorRun> = {}): CoordinatorRun {
+  return {
+    id: "run-1",
+    positionId: "pos-1",
+    grantId: "grant-1",
+    reason: "deleverage-guard",
+    triggeredAt: 1_700_000_100_000,
+    updatedAt: 1_700_000_200_000,
+    status: "in_progress",
+    healthFactorAtTrigger: 1.12,
+    healthFactorTarget: 1.2,
+    trancheIdsPlanned: ["t0", "t1"],
+    steps: [
+      {
+        idempotencyKey: "run-1:t0:repay-0",
+        trancheId: "t0",
+        stepId: "repay-0",
+        status: "completed",
+        txHash: "abc123",
+        submittedAt: 1_700_000_150_000,
+        confirmedAt: 1_700_000_160_000,
+      },
+      {
+        idempotencyKey: "run-1:t0:withdraw-0",
+        trancheId: "t0",
+        stepId: "withdraw-0",
+        status: "pending",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function runContractTests(
+  name: string,
+  makeStore: () => CoordinatorLedgerStore
+) {
+  describe(name, () => {
+    it("getGrant returns null for an unknown positionId", async () => {
+      const store = makeStore();
+      expect(await store.getGrant("does-not-exist")).toBeNull();
+    });
+
+    it("saveGrant then getGrant round-trips a full DelegationGrant", async () => {
+      const store = makeStore();
+      const grant = makeGrant({
+        revokedAt: 1_700_000_050_000,
+        status: "revoked",
+      });
+      await store.saveGrant(grant);
+      expect(await store.getGrant(grant.positionId)).toEqual(grant);
+    });
+
+    it("saveGrant twice for the same positionId keeps only the latest write", async () => {
+      const store = makeStore();
+      const first = makeGrant({
+        positionId: "pos-dup",
+        id: "grant-old",
+        breached: false,
+        consumedTrancheIds: [],
+        guardConfig: { deleverageThreshold: 1.1, hysteresis: 0.02 },
+      });
+      const second = makeGrant({
+        positionId: "pos-dup",
+        id: "grant-new",
+        breached: true,
+        walletAddress: "GOTHERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        consumedTrancheIds: ["t0", "t1"],
+        guardConfig: { deleverageThreshold: 1.25, hysteresis: 0.08 },
+        assetCode: "XLM",
+      });
+      await store.saveGrant(first);
+      await store.saveGrant(second);
+      expect(await store.getGrant("pos-dup")).toEqual(second);
+    });
+
+    it("listActiveGrants returns only status: active grants", async () => {
+      const store = makeStore();
+      const active = makeGrant({ positionId: "pos-active", id: "g-active" });
+      const revoked = makeGrant({
+        positionId: "pos-revoked",
+        id: "g-revoked",
+        status: "revoked",
+        revokedAt: 1_700_000_050_000,
+      });
+      await store.saveGrant(active);
+      await store.saveGrant(revoked);
+
+      const listed = await store.listActiveGrants();
+      expect(listed).toHaveLength(1);
+      expect(listed[0]).toEqual(active);
+    });
+
+    it("saveRun then getRun round-trips a full CoordinatorRun including steps", async () => {
+      const store = makeStore();
+      const run = makeRun({
+        completedAt: 1_700_000_300_000,
+        status: "completed",
+        healthFactorAtTrigger: null,
+      });
+      await store.saveRun(run);
+      expect(await store.getRun(run.id)).toEqual(run);
+    });
+
+    it("findInProgressRunForPosition returns the in_progress run or null", async () => {
+      const store = makeStore();
+      expect(await store.findInProgressRunForPosition("pos-1")).toBeNull();
+
+      const done = makeRun({
+        id: "run-done",
+        positionId: "pos-1",
+        status: "completed",
+        completedAt: 1_700_000_400_000,
+      });
+      const failed = makeRun({
+        id: "run-failed",
+        positionId: "pos-1",
+        status: "failed",
+        triggeredAt: 1_700_000_050_000,
+      });
+      await store.saveRun(done);
+      await store.saveRun(failed);
+      expect(await store.findInProgressRunForPosition("pos-1")).toBeNull();
+
+      const inProgress = makeRun({
+        id: "run-live",
+        positionId: "pos-1",
+        status: "in_progress",
+        triggeredAt: 1_700_000_500_000,
+      });
+      await store.saveRun(inProgress);
+      expect(await store.findInProgressRunForPosition("pos-1")).toEqual(
+        inProgress
+      );
+    });
+
+    it("listRunsForPosition returns only runs for that position", async () => {
+      const store = makeStore();
+      const a1 = makeRun({ id: "run-a1", positionId: "pos-a" });
+      const a2 = makeRun({
+        id: "run-a2",
+        positionId: "pos-a",
+        status: "completed",
+        triggeredAt: 1_700_000_050_000,
+      });
+      const b1 = makeRun({ id: "run-b1", positionId: "pos-b" });
+      await store.saveRun(a1);
+      await store.saveRun(a2);
+      await store.saveRun(b1);
+
+      const forA = await store.listRunsForPosition("pos-a");
+      expect(forA).toHaveLength(2);
+      expect(forA.map((r) => r.id).sort()).toEqual(["run-a1", "run-a2"]);
+      expect(forA.every((r) => r.positionId === "pos-a")).toBe(true);
+
+      const forB = await store.listRunsForPosition("pos-b");
+      expect(forB).toHaveLength(1);
+      expect(forB[0]).toEqual(b1);
+    });
+  });
+}
+
+describe("FileCoordinatorLedgerStore", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "coordinator-ledger-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  runContractTests("contract", () => new FileCoordinatorLedgerStore(tmpDir));
+});
+
+describe("InMemoryCoordinatorLedgerStore", () => {
+  runContractTests("contract", () => new InMemoryCoordinatorLedgerStore());
+});
+
+describe("SupabaseCoordinatorLedgerStore", () => {
+  beforeEach(() => {
+    resetFakeTables();
+  });
+
+  runContractTests("contract", () => new SupabaseCoordinatorLedgerStore());
+
+  describe("concurrency", () => {
+    it("concurrent saveGrant for distinct positionIds keeps every row intact", async () => {
+      const store = new SupabaseCoordinatorLedgerStore();
+      const grants = Array.from({ length: 20 }, (_, i) =>
+        makeGrant({
+          id: `grant-c-${i}`,
+          positionId: `pos-c-${i}`,
+          walletAddress: `GWALLET${i.toString().padStart(48, "0")}`,
+          assetCode: i % 2 === 0 ? "USTRY" : "XLM",
+          breached: i % 3 === 0,
+          consumedTrancheIds: i % 2 === 0 ? ["t0"] : [],
+          guardConfig: {
+            deleverageThreshold: 1.1 + i * 0.01,
+            hysteresis: 0.01 + i * 0.001,
+          },
+          createdAt: 1_700_000_000_000 + i,
+        })
+      );
+
+      await Promise.all(grants.map((g) => store.saveGrant(g)));
+
+      for (const grant of grants) {
+        expect(await store.getGrant(grant.positionId)).toEqual(grant);
+      }
+    });
+
+    it("concurrent saveRun for distinct run ids keeps every row intact", async () => {
+      const store = new SupabaseCoordinatorLedgerStore();
+      const runs = Array.from({ length: 20 }, (_, i) =>
+        makeRun({
+          id: `run-c-${i}`,
+          positionId: `pos-run-${i}`,
+          grantId: `grant-run-${i}`,
+          healthFactorAtTrigger: 1.0 + i * 0.01,
+          healthFactorTarget: 1.2 + i * 0.01,
+          trancheIdsPlanned: [`t-${i}`],
+          triggeredAt: 1_700_000_100_000 + i,
+          updatedAt: 1_700_000_200_000 + i,
+          status: i % 2 === 0 ? "in_progress" : "completed",
+          steps: [
+            {
+              idempotencyKey: `run-c-${i}:t-${i}:step`,
+              trancheId: `t-${i}`,
+              stepId: `step-${i}`,
+              status: "pending",
+            },
+          ],
+        })
+      );
+
+      await Promise.all(runs.map((r) => store.saveRun(r)));
+
+      for (const run of runs) {
+        expect(await store.getRun(run.id)).toEqual(run);
+      }
+    });
+
+    it("same-key concurrent saveGrant yields exactly one full fixture, never a hybrid", async () => {
+      const store = new SupabaseCoordinatorLedgerStore();
+      const positionId = "pos-same-key";
+      const fixtureA = makeGrant({
+        positionId,
+        id: "grant-A",
+        walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        assetCode: "USTRY",
+        borrowAssetCode: "USDC",
+        breached: true,
+        consumedTrancheIds: ["t0"],
+        guardConfig: { deleverageThreshold: 1.11, hysteresis: 0.03 },
+        createdAt: 1_700_000_000_001,
+        expiresAt: 1_800_000_000_001,
+      });
+      const fixtureB = makeGrant({
+        positionId,
+        id: "grant-B",
+        walletAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        assetCode: "XLM",
+        borrowAssetCode: "EURC",
+        breached: false,
+        consumedTrancheIds: ["t0", "t1"],
+        guardConfig: { deleverageThreshold: 1.33, hysteresis: 0.09 },
+        createdAt: 1_700_000_000_002,
+        expiresAt: 1_800_000_000_002,
+        status: "revoked",
+        revokedAt: 1_700_000_000_099,
+      });
+
+      await Promise.all([store.saveGrant(fixtureA), store.saveGrant(fixtureB)]);
+
+      // Full-row upsert: final value must equal one fixture entirely (deep
+      // equality), never a field-level mix of A and B.
+      const final = await store.getGrant(positionId);
+      expect([fixtureA, fixtureB]).toContainEqual(final);
+    });
+  });
+});

--- a/apps/web-app/src/lib/coordinator/ledger.ts
+++ b/apps/web-app/src/lib/coordinator/ledger.ts
@@ -1,21 +1,24 @@
 import { promises as fs } from "fs";
 import path from "path";
-import type { CoordinatorRun, DelegationGrant } from "./types";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { requireServerEnv } from "@/lib/env.server";
+import type {
+  CoordinatorRun,
+  CoordinatorRunStatus,
+  CoordinatorStepRecord,
+  DelegationGrant,
+  DelegationStatus,
+  DelegationTrancheRecord,
+} from "./types";
 
 /**
  * The durable job-ledger primitive the coordinator is built on (Scope §5).
  *
- * This repo doesn't have a real database — app/api/automation/* (the
- * closest existing "durable job" precedent) is an explicitly-labeled
- * in-memory demo store ("swap for a real DB in production"), and
- * app/api/vault/invest/route.ts persists nothing at all between
- * invocations beyond an in-memory cooldown timestamp. Since the
- * coordinator's crash-resumption requirement is meaningless against a
- * store that doesn't survive a process restart, this is a real
- * file-backed store (atomic write-temp-then-rename per record) rather
- * than another in-memory Map — the interface below is the swap-in point for
- * a real database in production, and InMemoryCoordinatorLedgerStore below
- * is what tests use to exercise the same contract without touching disk.
+ * Production uses SupabaseCoordinatorLedgerStore (Postgres via the service
+ * role). FileCoordinatorLedgerStore remains as a local/dev file-backed
+ * option (atomic write-temp-then-rename per record), and
+ * InMemoryCoordinatorLedgerStore is what tests use to exercise the same
+ * contract without touching disk or the network.
  */
 export interface CoordinatorLedgerStore {
   getGrant(positionId: string): Promise<DelegationGrant | null>;
@@ -180,10 +183,216 @@ export class InMemoryCoordinatorLedgerStore implements CoordinatorLedgerStore {
   }
 }
 
+// ─── Supabase row <-> domain mapping ─────────────────────────────────────────
+
+interface CoordinatorGrantRow {
+  position_id: string;
+  id: string;
+  wallet_address: string;
+  asset_code: string;
+  borrow_asset_code: string;
+  status: DelegationStatus;
+  created_at: string;
+  revoked_at: string | null;
+  expires_at: string;
+  tranches: DelegationTrancheRecord[];
+  consumed_tranche_ids: string[];
+  guard_config: { deleverageThreshold: number; hysteresis: number };
+  breached: boolean;
+  updated_at: string;
+}
+
+interface CoordinatorRunRow {
+  id: string;
+  position_id: string;
+  grant_id: string;
+  reason: "deleverage-guard";
+  triggered_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  status: CoordinatorRunStatus;
+  health_factor_at_trigger: number | string | null;
+  health_factor_target: number | string;
+  tranche_ids_planned: string[];
+  steps: CoordinatorStepRecord[];
+}
+
+function mapGrantRow(row: CoordinatorGrantRow): DelegationGrant {
+  return {
+    id: row.id,
+    positionId: row.position_id,
+    walletAddress: row.wallet_address,
+    assetCode: row.asset_code,
+    borrowAssetCode: row.borrow_asset_code,
+    status: row.status,
+    createdAt: new Date(row.created_at).getTime(),
+    ...(row.revoked_at
+      ? { revokedAt: new Date(row.revoked_at).getTime() }
+      : {}),
+    expiresAt: new Date(row.expires_at).getTime(),
+    tranches: row.tranches ?? [],
+    consumedTrancheIds: row.consumed_tranche_ids ?? [],
+    guardConfig: row.guard_config,
+    breached: row.breached,
+  };
+}
+
+function grantToRow(grant: DelegationGrant): CoordinatorGrantRow {
+  return {
+    position_id: grant.positionId,
+    id: grant.id,
+    wallet_address: grant.walletAddress,
+    asset_code: grant.assetCode,
+    borrow_asset_code: grant.borrowAssetCode,
+    status: grant.status,
+    created_at: new Date(grant.createdAt).toISOString(),
+    revoked_at:
+      grant.revokedAt != null ? new Date(grant.revokedAt).toISOString() : null,
+    expires_at: new Date(grant.expiresAt).toISOString(),
+    tranches: grant.tranches,
+    consumed_tranche_ids: grant.consumedTrancheIds,
+    guard_config: grant.guardConfig,
+    breached: grant.breached,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function mapRunRow(row: CoordinatorRunRow): CoordinatorRun {
+  return {
+    id: row.id,
+    positionId: row.position_id,
+    grantId: row.grant_id,
+    reason: row.reason,
+    triggeredAt: new Date(row.triggered_at).getTime(),
+    updatedAt: new Date(row.updated_at).getTime(),
+    ...(row.completed_at
+      ? { completedAt: new Date(row.completed_at).getTime() }
+      : {}),
+    status: row.status,
+    healthFactorAtTrigger:
+      row.health_factor_at_trigger != null
+        ? Number(row.health_factor_at_trigger)
+        : null,
+    healthFactorTarget: Number(row.health_factor_target),
+    trancheIdsPlanned: row.tranche_ids_planned ?? [],
+    steps: row.steps ?? [],
+  };
+}
+
+function runToRow(run: CoordinatorRun): CoordinatorRunRow {
+  return {
+    id: run.id,
+    position_id: run.positionId,
+    grant_id: run.grantId,
+    reason: run.reason,
+    triggered_at: new Date(run.triggeredAt).toISOString(),
+    updated_at: new Date(run.updatedAt).toISOString(),
+    completed_at:
+      run.completedAt != null ? new Date(run.completedAt).toISOString() : null,
+    status: run.status,
+    health_factor_at_trigger: run.healthFactorAtTrigger,
+    health_factor_target: run.healthFactorTarget,
+    tranche_ids_planned: run.trancheIdsPlanned,
+    steps: run.steps,
+  };
+}
+
+let cachedCoordinatorClient: SupabaseClient | null = null;
+
+function getCoordinatorClient(): SupabaseClient {
+  if (cachedCoordinatorClient) return cachedCoordinatorClient;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireServerEnv([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ]);
+  cachedCoordinatorClient = createClient(
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false } }
+  );
+  return cachedCoordinatorClient;
+}
+
+/**
+ * Postgres-backed ledger via Supabase service role. One row per grant
+ * (keyed by position_id) and per run (keyed by id); upserts replace the
+ * full row so last write wins, matching FileCoordinatorLedgerStore's
+ * atomicWriteJson semantics.
+ */
+export class SupabaseCoordinatorLedgerStore implements CoordinatorLedgerStore {
+  async getGrant(positionId: string): Promise<DelegationGrant | null> {
+    const { data, error } = await getCoordinatorClient()
+      .from("coordinator_delegation_grants")
+      .select("*")
+      .eq("position_id", positionId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapGrantRow(data as CoordinatorGrantRow) : null;
+  }
+
+  async saveGrant(grant: DelegationGrant): Promise<void> {
+    const { error } = await getCoordinatorClient()
+      .from("coordinator_delegation_grants")
+      .upsert(grantToRow(grant), { onConflict: "position_id" });
+    if (error) throw error;
+  }
+
+  async listActiveGrants(): Promise<DelegationGrant[]> {
+    const { data, error } = await getCoordinatorClient()
+      .from("coordinator_delegation_grants")
+      .select("*")
+      .eq("status", "active");
+    if (error) throw error;
+    return ((data ?? []) as CoordinatorGrantRow[]).map(mapGrantRow);
+  }
+
+  async getRun(runId: string): Promise<CoordinatorRun | null> {
+    const { data, error } = await getCoordinatorClient()
+      .from("coordinator_runs")
+      .select("*")
+      .eq("id", runId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapRunRow(data as CoordinatorRunRow) : null;
+  }
+
+  async saveRun(run: CoordinatorRun): Promise<void> {
+    const { error } = await getCoordinatorClient()
+      .from("coordinator_runs")
+      .upsert(runToRow(run), { onConflict: "id" });
+    if (error) throw error;
+  }
+
+  async findInProgressRunForPosition(
+    positionId: string
+  ): Promise<CoordinatorRun | null> {
+    const { data, error } = await getCoordinatorClient()
+      .from("coordinator_runs")
+      .select("*")
+      .eq("position_id", positionId)
+      .eq("status", "in_progress")
+      .order("triggered_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapRunRow(data as CoordinatorRunRow) : null;
+  }
+
+  async listRunsForPosition(positionId: string): Promise<CoordinatorRun[]> {
+    const { data, error } = await getCoordinatorClient()
+      .from("coordinator_runs")
+      .select("*")
+      .eq("position_id", positionId)
+      .order("triggered_at", { ascending: true });
+    if (error) throw error;
+    return ((data ?? []) as CoordinatorRunRow[]).map(mapRunRow);
+  }
+}
+
 let sharedStore: CoordinatorLedgerStore | null = null;
 
-/** Process-wide singleton for API routes — one file-backed store per server process. */
+/** Process-wide singleton for API routes — one Supabase-backed store per server process. */
 export function getCoordinatorLedgerStore(): CoordinatorLedgerStore {
-  sharedStore ??= new FileCoordinatorLedgerStore();
+  sharedStore ??= new SupabaseCoordinatorLedgerStore();
   return sharedStore;
 }

--- a/supabase/migrations/20260830130000_automation_and_coordinator_durable_stores.sql
+++ b/supabase/migrations/20260830130000_automation_and_coordinator_durable_stores.sql
@@ -1,0 +1,56 @@
+-- Durable stores for automation strategy persistence and the coordinator
+-- deleverage-guard ledger. See lib/automation/strategiesStore.ts and
+-- lib/coordinator/ledger.ts (SupabaseCoordinatorLedgerStore) in the web-app.
+
+create table public.automation_strategies (
+  id text primary key,
+  name text not null,
+  preset text not null check (preset in ('conservative', 'balanced', 'aggressive', 'custom')),
+  rule jsonb not null,
+  enabled boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_run_at timestamptz
+);
+
+create table public.coordinator_delegation_grants (
+  position_id text primary key,
+  id uuid not null default gen_random_uuid(),
+  wallet_address text not null,
+  asset_code text not null,
+  borrow_asset_code text not null,
+  status text not null default 'active' check (status in ('active', 'revoked')),
+  created_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  expires_at timestamptz not null,
+  tranches jsonb not null default '[]'::jsonb,
+  consumed_tranche_ids jsonb not null default '[]'::jsonb,
+  guard_config jsonb not null,
+  breached boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+create table public.coordinator_runs (
+  id uuid primary key default gen_random_uuid(),
+  position_id text not null,
+  grant_id text not null,
+  reason text not null default 'deleverage-guard' check (reason in ('deleverage-guard')),
+  triggered_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz,
+  status text not null default 'in_progress' check (status in ('in_progress', 'completed', 'failed', 'stopped')),
+  health_factor_at_trigger numeric,
+  health_factor_target numeric not null,
+  tranche_ids_planned jsonb not null default '[]'::jsonb,
+  steps jsonb not null default '[]'::jsonb
+);
+
+create index coordinator_runs_position_idx on public.coordinator_runs (position_id, triggered_at desc);
+
+alter table public.automation_strategies enable row level security;
+alter table public.coordinator_delegation_grants enable row level security;
+alter table public.coordinator_runs enable row level security;
+
+comment on table public.automation_strategies is 'Durable automation strategy definitions for the rebalance executor. Written/read only via the service role (lib/automation/strategiesStore.ts in the web-app) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';
+comment on table public.coordinator_delegation_grants is 'Delegation grants authorizing coordinator deleverage-guard runs per position. Written/read only via the service role (SupabaseCoordinatorLedgerStore in lib/coordinator/ledger.ts) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';
+comment on table public.coordinator_runs is 'In-progress and completed coordinator deleverage-guard runs, keyed by position. Written/read only via the service role (SupabaseCoordinatorLedgerStore in lib/coordinator/ledger.ts) — no anon/authenticated RLS policies are defined, matching this project''s other server-only tables.';


### PR DESCRIPTION
Closes #317

Migrates the three non-durable stores flagged in the issue to Supabase-backed persistence:

- `app/api/automation/strategies/route.ts` + `strategies/[id]/route.ts` now read/write through `lib/automation/strategiesStore.ts` (`SupabaseStrategiesStore`) instead of `globalThis.__automationStrategies`.
- `app/api/automation/execute/route.ts`: removed the dead `globalThis.__automationPlans` write — confirm/cancel already flow through the durable job ledger (`confirmPlan`/`cancelPlan`).
- `lib/coordinator/ledger.ts`: added `SupabaseCoordinatorLedgerStore` implementing `CoordinatorLedgerStore`, now the default returned by `getCoordinatorLedgerStore()`. `FileCoordinatorLedgerStore` and `InMemoryCoordinatorLedgerStore` are unchanged.
- New migration `supabase/migrations/20260830130000_automation_and_coordinator_durable_stores.sql` (service-role-only RLS, matching the existing job_ledger migration's conventions).
- New tests: `lib/coordinator/__tests__/ledger.test.ts` (contract suite across File/InMemory/Supabase stores + same-key and distinct-key concurrent-write coverage) and `lib/automation/__tests__/strategiesStore.test.ts` (CRUD, cross-instance durability, concurrent creates).

`grep -r "__automationStrategies\|__automationPlans" apps/web-app/src` returns no hits.

Verified locally: new/changed test suites pass (`lib/coordinator`, `lib/automation`, `app/api/automation`), scoped lint clean (no new warnings), scoped diff reviewed for type-correctness. Full-repo `tsc`/`npm run test` currently hit pre-existing, unrelated issues in this fork's environment (an already-broken syntax error in `app/api/vault/invest/route.ts` on `dev`, and two pre-existing failing assertions in `execute/__tests__/route.test.ts` reproducible on `dev` before this change) — noted here for visibility, not introduced by this PR.