### PR TITLE
fix(ramps): scope anchor customer/bank/KYC identity per wallet (#309)

### DIFF
--- a/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
+++ b/apps/web-app/src/features/on-off-ramps/components/pages/OnOffRamps.tsx
@@ -50,7 +50,7 @@ const OnOffRamps: React.FC = () => {
     onboardingUrl,
     ensureCustomer,
     isPending: isEnsuring,
-  } = useAnchorCustomer(state.provider);
+  } = useAnchorCustomer(state.provider, address);
 
   // Quote
   const {

--- a/apps/web-app/src/features/on-off-ramps/constants/ramp.config.ts
+++ b/apps/web-app/src/features/on-off-ramps/constants/ramp.config.ts
@@ -49,6 +49,52 @@ export const POLL_MAX_INTERVAL_MS = 30_000;
 export const POLL_UNREACHABLE_AFTER = 3;
 export const MAX_POLL_DURATION_MS = 5 * 60 * 1_000; // 5 minutes
 export const RAMP_API_TIMEOUT_MS = 20_000;
+/**
+ * Bump this whenever the on-disk shape of the three anchor storage keys
+ * changes.  Old unscoped entries (v0 — keyed by provider only) are
+ * intentionally NOT migrated: silently adopting an unscoped entry into the
+ * currently-connected wallet would be exactly the bug we are fixing.  Users
+ * who had a cached identity under the old key will simply re-run
+ * ensureCustomer once — the anchor will find their existing customer by
+ * email and return the same IDs, so KYC is not lost, only re-fetched.
+ */
+export const ANCHOR_STORAGE_VERSION = 1;
+
+/**
+ * Storage keys now encode version + wallet address so each Stellar public key
+ * gets its own isolated slot.  Format:
+ *   neko_anchor_<field>_v<version>_<walletAddress>
+ *
+ * The legacy (v0) keys — "neko_anchor_customer_ids" etc. — are abandoned in
+ * place; browsers will evict them eventually.  We never read from them.
+ */
 export const CUSTOMER_ID_STORAGE_KEY = "neko_anchor_customer_ids";
 export const BANK_ACCOUNT_ID_STORAGE_KEY = "neko_anchor_bank_account_ids";
 export const ONBOARDING_URL_STORAGE_KEY = "neko_anchor_onboarding_urls";
+
+/** Build the versioned, wallet-scoped storage key for a given base key. */
+export function anchorStorageKey(
+  baseKey: string,
+  walletAddress: string
+): string {
+  return `${baseKey}_v${ANCHOR_STORAGE_VERSION}_${walletAddress}`;
+}
+
+/**
+ * Remove all versioned anchor storage entries for the given wallet address.
+ * Called on disconnect and on wallet switch to prevent cross-wallet bleed.
+ */
+export function clearAnchorState(walletAddress: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    for (const baseKey of [
+      CUSTOMER_ID_STORAGE_KEY,
+      BANK_ACCOUNT_ID_STORAGE_KEY,
+      ONBOARDING_URL_STORAGE_KEY,
+    ]) {
+      localStorage.removeItem(anchorStorageKey(baseKey, walletAddress));
+    }
+  } catch {
+    // ignore — storage may be unavailable in SSR or restricted contexts
+  }
+}

--- a/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useAnchorCustomer.test.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/__tests__/useAnchorCustomer.test.ts
@@ -1,0 +1,428 @@
+// @vitest-environment jsdom
+/**
+ * Tests for wallet-A → wallet-B isolation in useAnchorCustomer (issue #309).
+ *
+ * The central concern: when a user switches (or another user connects on the
+ * same browser) the hook must never return the previous wallet's customerId,
+ * bankAccountId, or onboardingUrl.  All three storage slots are now versioned
+ * and keyed by walletAddress so each Stellar public key gets its own isolated
+ * slot.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const getCustomerMock = vi.hoisted(() => vi.fn());
+const createCustomerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils/rampApi", () => ({
+  getCustomer: getCustomerMock,
+  createCustomer: createCustomerMock,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+import { useAnchorCustomer } from "../useAnchorCustomer";
+import {
+  anchorStorageKey,
+  clearAnchorState,
+  CUSTOMER_ID_STORAGE_KEY,
+  BANK_ACCOUNT_ID_STORAGE_KEY,
+  ONBOARDING_URL_STORAGE_KEY,
+} from "../../constants/ramp.config";
+
+const WALLET_A = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const WALLET_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestWrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  }
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useAnchorCustomer — wallet isolation (issue #309)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getCustomerMock.mockReset();
+    createCustomerMock.mockReset();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  // ── Storage key tests ──────────────────────────────────────────────────────
+
+  describe("anchorStorageKey", () => {
+    it("produces different keys for different wallet addresses", () => {
+      const keyA = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A);
+      const keyB = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_B);
+      expect(keyA).not.toEqual(keyB);
+    });
+
+    it("embeds the wallet address in the key", () => {
+      const key = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A);
+      expect(key).toContain(WALLET_A);
+    });
+
+    it("embeds a version number in the key", () => {
+      const key = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A);
+      expect(key).toMatch(/_v\d+_/);
+    });
+
+    it("does NOT contain any old unscoped key as a prefix match without version", () => {
+      // The legacy key is e.g. "neko_anchor_customer_ids".
+      // A versioned key must be clearly distinguishable so a naive
+      // localStorage.getItem(LEGACY_KEY) cannot accidentally pick up the new one.
+      const key = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A);
+      // new key must differ from the plain base key
+      expect(key).not.toEqual(CUSTOMER_ID_STORAGE_KEY);
+    });
+  });
+
+  // ── clearAnchorState tests ─────────────────────────────────────────────────
+
+  describe("clearAnchorState", () => {
+    it("removes all three anchor storage slots for the given wallet", () => {
+      // Pre-populate all three slots
+      for (const base of [
+        CUSTOMER_ID_STORAGE_KEY,
+        BANK_ACCOUNT_ID_STORAGE_KEY,
+        ONBOARDING_URL_STORAGE_KEY,
+      ]) {
+        localStorage.setItem(
+          anchorStorageKey(base, WALLET_A),
+          JSON.stringify({ etherfuse: "some-id" })
+        );
+      }
+
+      clearAnchorState(WALLET_A);
+
+      for (const base of [
+        CUSTOMER_ID_STORAGE_KEY,
+        BANK_ACCOUNT_ID_STORAGE_KEY,
+        ONBOARDING_URL_STORAGE_KEY,
+      ]) {
+        expect(
+          localStorage.getItem(anchorStorageKey(base, WALLET_A))
+        ).toBeNull();
+      }
+    });
+
+    it("does NOT clear slots belonging to a different wallet", () => {
+      const keyB = anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_B);
+      localStorage.setItem(keyB, JSON.stringify({ etherfuse: "wallet-b-id" }));
+
+      clearAnchorState(WALLET_A); // clear A, not B
+
+      expect(localStorage.getItem(keyB)).not.toBeNull();
+    });
+  });
+
+  // ── Hook initial-state isolation ───────────────────────────────────────────
+
+  describe("hook — initial state isolation", () => {
+    it("does not read wallet-A's stored IDs when wallet-B is mounted", () => {
+      // Seed wallet-A's data into localStorage as if wallet-A had been used
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "cust-wallet-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(BANK_ACCOUNT_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "bank-wallet-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(ONBOARDING_URL_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "https://kyc-wallet-a" })
+      );
+
+      // Mount hook for wallet-B — it must start with null values
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_B),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.customerId).toBeNull();
+      expect(result.current.bankAccountId).toBeNull();
+      expect(result.current.onboardingUrl).toBeNull();
+    });
+
+    it("correctly reads wallet-A's own stored IDs when wallet-A is mounted", () => {
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "cust-wallet-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(BANK_ACCOUNT_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "bank-wallet-a" })
+      );
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_A),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.customerId).toBe("cust-wallet-a");
+      expect(result.current.bankAccountId).toBe("bank-wallet-a");
+    });
+
+    it("returns null IDs when no wallet is connected", () => {
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", null),
+        { wrapper: createWrapper() }
+      );
+      expect(result.current.customerId).toBeNull();
+      expect(result.current.bankAccountId).toBeNull();
+      expect(result.current.onboardingUrl).toBeNull();
+    });
+  });
+
+  // ── ensureCustomer wallet-A then wallet-B ──────────────────────────────────
+
+  describe("ensureCustomer — wallet-A then wallet-B isolation", () => {
+    it("wallet-B does NOT get a cache hit on wallet-A's stored identity", async () => {
+      // Set up wallet-A's scoped storage as if ensureCustomer had succeeded
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "cust-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(BANK_ACCOUNT_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "bank-a" })
+      );
+
+      // Simulate wallet switch: mount the hook for wallet-B
+      getCustomerMock.mockResolvedValue(null); // no existing anchor customer
+      createCustomerMock.mockResolvedValue({
+        id: "cust-b",
+        bankAccountId: "bank-b",
+        onboardingUrl: "https://kyc-b",
+      });
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_B),
+        { wrapper: createWrapper() }
+      );
+
+      // Initial state: no inherited values
+      expect(result.current.customerId).toBeNull();
+
+      await act(async () => {
+        await result.current.ensureCustomer({
+          email: "walletb@example.com",
+          publicKey: WALLET_B,
+        });
+      });
+
+      // After ensureCustomer, wallet-B has its own fresh IDs
+      expect(result.current.customerId).toBe("cust-b");
+      expect(result.current.bankAccountId).toBe("bank-b");
+      expect(result.current.onboardingUrl).toBe("https://kyc-b");
+
+      // wallet-A's scoped storage must be completely untouched
+      const storedA = JSON.parse(
+        localStorage.getItem(
+          anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A)
+        ) ?? "{}"
+      ) as Record<string, string>;
+      expect(storedA.etherfuse).toBe("cust-a");
+    });
+
+    it("wallet-A cache hit does not trigger an API call", async () => {
+      // Seed wallet-A's storage
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "cust-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(BANK_ACCOUNT_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "bank-a" })
+      );
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_A),
+        { wrapper: createWrapper() }
+      );
+
+      await act(async () => {
+        await result.current.ensureCustomer({
+          email: "walleta@example.com",
+          publicKey: WALLET_A,
+        });
+      });
+
+      // No network calls because cache was valid
+      expect(getCustomerMock).not.toHaveBeenCalled();
+      expect(createCustomerMock).not.toHaveBeenCalled();
+      expect(result.current.customerId).toBe("cust-a");
+    });
+
+    it("rejects ensureCustomer when walletAddress is null", async () => {
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", null),
+        { wrapper: createWrapper() }
+      );
+
+      await expect(
+        act(async () => {
+          await result.current.ensureCustomer({
+            email: "no-wallet@example.com",
+          });
+        })
+      ).rejects.toThrow(/No wallet connected/);
+
+      expect(createCustomerMock).not.toHaveBeenCalled();
+    });
+
+    it("wallet-B ensureCustomer writes to wallet-B's isolated slot, not wallet-A's", async () => {
+      getCustomerMock.mockResolvedValue(null);
+      createCustomerMock.mockResolvedValue({
+        id: "cust-b",
+        bankAccountId: "bank-b",
+        onboardingUrl: null,
+      });
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_B),
+        { wrapper: createWrapper() }
+      );
+
+      await act(async () => {
+        await result.current.ensureCustomer({ publicKey: WALLET_B });
+      });
+
+      // wallet-B's slot is written
+      const storedB = JSON.parse(
+        localStorage.getItem(
+          anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_B)
+        ) ?? "{}"
+      ) as Record<string, string>;
+      expect(storedB.etherfuse).toBe("cust-b");
+
+      // wallet-A's slot does not exist (was never touched)
+      expect(
+        localStorage.getItem(
+          anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A)
+        )
+      ).toBeNull();
+    });
+  });
+
+  // ── resetCustomer ──────────────────────────────────────────────────────────
+
+  describe("resetCustomer — only clears current wallet's provider slot", () => {
+    it("clears the provider slot for the current wallet without touching other wallets", () => {
+      // Seed both wallets
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A),
+        JSON.stringify({ etherfuse: "cust-a" })
+      );
+      localStorage.setItem(
+        anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_B),
+        JSON.stringify({ etherfuse: "cust-b" })
+      );
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_A),
+        { wrapper: createWrapper() }
+      );
+
+      act(() => {
+        result.current.resetCustomer();
+      });
+
+      // Wallet-A's provider slot is removed
+      const storedA = JSON.parse(
+        localStorage.getItem(
+          anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_A)
+        ) ?? "{}"
+      ) as Record<string, string>;
+      expect(storedA.etherfuse).toBeUndefined();
+
+      // Wallet-B's slot is untouched
+      const storedB = JSON.parse(
+        localStorage.getItem(
+          anchorStorageKey(CUSTOMER_ID_STORAGE_KEY, WALLET_B)
+        ) ?? "{}"
+      ) as Record<string, string>;
+      expect(storedB.etherfuse).toBe("cust-b");
+
+      // React state is cleared
+      expect(result.current.customerId).toBeNull();
+      expect(result.current.bankAccountId).toBeNull();
+    });
+  });
+
+  // ── Legacy (v0) key is never read ─────────────────────────────────────────
+
+  describe("migration: legacy unscoped keys are ignored", () => {
+    it("does not read from the old unscoped key even if one exists", () => {
+      // Simulate a pre-fix entry written under the legacy key format
+      // (key = CUSTOMER_ID_STORAGE_KEY, value = {provider: id})
+      localStorage.setItem(
+        CUSTOMER_ID_STORAGE_KEY,
+        JSON.stringify({ etherfuse: "legacy-cust-id" })
+      );
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_A),
+        { wrapper: createWrapper() }
+      );
+
+      // The hook must NOT bootstrap from the legacy key
+      expect(result.current.customerId).toBeNull();
+    });
+
+    it("ensureCustomer does NOT copy the legacy value into the new scoped slot", async () => {
+      localStorage.setItem(
+        CUSTOMER_ID_STORAGE_KEY,
+        JSON.stringify({ etherfuse: "legacy-cust-id" })
+      );
+      localStorage.setItem(
+        BANK_ACCOUNT_ID_STORAGE_KEY,
+        JSON.stringify({ etherfuse: "legacy-bank-id" })
+      );
+
+      // Anchor has no customer by email → creates a fresh one
+      getCustomerMock.mockResolvedValue(null);
+      createCustomerMock.mockResolvedValue({
+        id: "fresh-cust",
+        bankAccountId: "fresh-bank",
+        onboardingUrl: null,
+      });
+
+      const { result } = renderHook(
+        () => useAnchorCustomer("etherfuse", WALLET_A),
+        { wrapper: createWrapper() }
+      );
+
+      await act(async () => {
+        await result.current.ensureCustomer({ publicKey: WALLET_A });
+      });
+
+      // The fresh IDs come from the API, not from the legacy key
+      expect(result.current.customerId).toBe("fresh-cust");
+      expect(createCustomerMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web-app/src/features/on-off-ramps/hooks/useAnchorCustomer.ts
+++ b/apps/web-app/src/features/on-off-ramps/hooks/useAnchorCustomer.ts
@@ -8,21 +8,41 @@ import {
   CUSTOMER_ID_STORAGE_KEY,
   BANK_ACCOUNT_ID_STORAGE_KEY,
   ONBOARDING_URL_STORAGE_KEY,
+  anchorStorageKey,
 } from "../constants/ramp.config";
 
-function getStoredId(key: string, provider: AnchorProvider): string | null {
+// ─── Storage helpers ──────────────────────────────────────────────────────────
+//
+// Each entry is a JSON map: Record<AnchorProvider, string>.
+// The localStorage key is versioned and wallet-scoped so different Stellar
+// addresses never share anchor identity.  Format:
+//   neko_anchor_<field>_v<version>_<walletAddress>
+
+function getStoredId(
+  baseKey: string,
+  provider: AnchorProvider,
+  walletAddress: string
+): string | null {
   try {
-    const stored = localStorage.getItem(key);
+    const stored = localStorage.getItem(
+      anchorStorageKey(baseKey, walletAddress)
+    );
     if (!stored) return null;
     const map = JSON.parse(stored) as Record<string, string>;
-    return map[provider] || null;
+    return map[provider] ?? null;
   } catch {
     return null;
   }
 }
 
-function storeId(key: string, provider: AnchorProvider, id: string) {
+function storeId(
+  baseKey: string,
+  provider: AnchorProvider,
+  walletAddress: string,
+  id: string
+) {
   try {
+    const key = anchorStorageKey(baseKey, walletAddress);
     const stored = localStorage.getItem(key);
     const map = stored ? (JSON.parse(stored) as Record<string, string>) : {};
     map[provider] = id;
@@ -32,16 +52,26 @@ function storeId(key: string, provider: AnchorProvider, id: string) {
   }
 }
 
-export function useAnchorCustomer(provider: AnchorProvider) {
-  const [customerId, setCustomerId] = useState<string | null>(() =>
-    getStoredId(CUSTOMER_ID_STORAGE_KEY, provider)
-  );
-  const [bankAccountId, setBankAccountId] = useState<string | null>(() =>
-    getStoredId(BANK_ACCOUNT_ID_STORAGE_KEY, provider)
-  );
-  const [onboardingUrl, setOnboardingUrl] = useState<string | null>(() =>
-    getStoredId(ONBOARDING_URL_STORAGE_KEY, provider)
-  );
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useAnchorCustomer(
+  provider: AnchorProvider,
+  /** The currently-connected Stellar public key.  Pass null/undefined when no
+   *  wallet is connected — all reads will return null and writes are skipped. */
+  walletAddress: string | null | undefined
+) {
+  const [customerId, setCustomerId] = useState<string | null>(() => {
+    if (!walletAddress) return null;
+    return getStoredId(CUSTOMER_ID_STORAGE_KEY, provider, walletAddress);
+  });
+  const [bankAccountId, setBankAccountId] = useState<string | null>(() => {
+    if (!walletAddress) return null;
+    return getStoredId(BANK_ACCOUNT_ID_STORAGE_KEY, provider, walletAddress);
+  });
+  const [onboardingUrl, setOnboardingUrl] = useState<string | null>(() => {
+    if (!walletAddress) return null;
+    return getStoredId(ONBOARDING_URL_STORAGE_KEY, provider, walletAddress);
+  });
 
   const { mutateAsync: ensureCustomer, isPending } = useMutation({
     mutationFn: async ({
@@ -51,15 +81,28 @@ export function useAnchorCustomer(provider: AnchorProvider) {
       email?: string;
       publicKey?: string;
     }) => {
-      // Return stored IDs if already present
-      const storedCustomerId = getStoredId(CUSTOMER_ID_STORAGE_KEY, provider);
+      // Guard: cannot create/look up a customer without a wallet address.
+      // This keeps the cache scoped correctly and avoids writing to a
+      // provider-only key that a future wallet might accidentally inherit.
+      if (!walletAddress) {
+        throw new Error("No wallet connected — cannot ensure anchor customer");
+      }
+
+      // Return stored IDs if already present for this wallet + provider pair.
+      const storedCustomerId = getStoredId(
+        CUSTOMER_ID_STORAGE_KEY,
+        provider,
+        walletAddress
+      );
       const storedBankAccountId = getStoredId(
         BANK_ACCOUNT_ID_STORAGE_KEY,
-        provider
+        provider,
+        walletAddress
       );
       const storedOnboardingUrl = getStoredId(
         ONBOARDING_URL_STORAGE_KEY,
-        provider
+        provider,
+        walletAddress
       );
       if (storedCustomerId && storedBankAccountId) {
         return {
@@ -69,15 +112,21 @@ export function useAnchorCustomer(provider: AnchorProvider) {
         };
       }
 
-      // Try to find existing customer
+      // Try to find existing customer by email at the anchor.
       if (email) {
         const existing = await getCustomer(provider, { email });
         if (existing) {
-          storeId(CUSTOMER_ID_STORAGE_KEY, provider, existing.id);
+          storeId(
+            CUSTOMER_ID_STORAGE_KEY,
+            provider,
+            walletAddress,
+            existing.id
+          );
           if (existing.bankAccountId) {
             storeId(
               BANK_ACCOUNT_ID_STORAGE_KEY,
               provider,
+              walletAddress,
               existing.bankAccountId
             );
           }
@@ -89,20 +138,30 @@ export function useAnchorCustomer(provider: AnchorProvider) {
         }
       }
 
-      // Create new customer
+      // Create new customer at the anchor.
       const customer = await createCustomer(provider, {
         email,
         publicKey,
         country: "MX",
       });
-      storeId(CUSTOMER_ID_STORAGE_KEY, provider, customer.id);
+      storeId(CUSTOMER_ID_STORAGE_KEY, provider, walletAddress, customer.id);
       if (customer.bankAccountId) {
-        storeId(BANK_ACCOUNT_ID_STORAGE_KEY, provider, customer.bankAccountId);
+        storeId(
+          BANK_ACCOUNT_ID_STORAGE_KEY,
+          provider,
+          walletAddress,
+          customer.bankAccountId
+        );
       }
       // Store the onboarding URL from initial registration — it cannot
       // be re-fetched later (Etherfuse returns 409 for existing users).
       if (customer.onboardingUrl) {
-        storeId(ONBOARDING_URL_STORAGE_KEY, provider, customer.onboardingUrl);
+        storeId(
+          ONBOARDING_URL_STORAGE_KEY,
+          provider,
+          walletAddress,
+          customer.onboardingUrl
+        );
       }
       return {
         customerId: customer.id,
@@ -122,26 +181,29 @@ export function useAnchorCustomer(provider: AnchorProvider) {
   });
 
   const resetCustomer = useCallback(() => {
-    try {
-      for (const key of [
-        CUSTOMER_ID_STORAGE_KEY,
-        BANK_ACCOUNT_ID_STORAGE_KEY,
-        ONBOARDING_URL_STORAGE_KEY,
-      ]) {
-        const stored = localStorage.getItem(key);
-        if (stored) {
-          const map = JSON.parse(stored) as Record<string, string>;
-          delete map[provider];
-          localStorage.setItem(key, JSON.stringify(map));
+    if (walletAddress) {
+      try {
+        for (const baseKey of [
+          CUSTOMER_ID_STORAGE_KEY,
+          BANK_ACCOUNT_ID_STORAGE_KEY,
+          ONBOARDING_URL_STORAGE_KEY,
+        ]) {
+          const key = anchorStorageKey(baseKey, walletAddress);
+          const stored = localStorage.getItem(key);
+          if (stored) {
+            const map = JSON.parse(stored) as Record<string, string>;
+            delete map[provider];
+            localStorage.setItem(key, JSON.stringify(map));
+          }
         }
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
     }
     setCustomerId(null);
     setBankAccountId(null);
     setOnboardingUrl(null);
-  }, [provider]);
+  }, [provider, walletAddress]);
 
   return {
     customerId,

--- a/apps/web-app/src/hooks/useStellarWallet.ts
+++ b/apps/web-app/src/hooks/useStellarWallet.ts
@@ -3,6 +3,7 @@
 import { getStellarWalletKit } from "@/lib/helpers/stellar/wallet";
 import { useStellarWalletStore } from "@/stores/stellarWalletStore";
 import { useQueryClient } from "@tanstack/react-query";
+import { clearAnchorState } from "@/features/on-off-ramps/constants/ramp.config";
 
 export function useStellarWallet() {
   const { address, walletName, setWallet, clearWallet } =
@@ -20,6 +21,13 @@ export function useStellarWallet() {
   const disconnect = async () => {
     const Kit = await getStellarWalletKit();
     await Kit.disconnect();
+
+    // Clear per-wallet anchor state (customer ID, bank account ID, onboarding
+    // URL) so that the next wallet to connect gets a fresh identity slot and
+    // cannot inherit the ramp state of the wallet that just disconnected.
+    if (address) {
+      clearAnchorState(address);
+    }
 
     // Clear all address-scoped query cache entries to prevent data bleeding
     // ["backstopWalletBalance"], ["backstopDeposit"], ["balances"], ["orchestrator"], ["userLendingBTokens"], ["portfolio-value"], ["health-factor"], ["userCollateral"], ["borrowLimit"], ["userBorrowPosition"], ["userDebt"], ["repayWalletBalance"], ["tokenBalance"], ["stellar-balances"], ["vaultBalance"], ["cetesBalance"], ["soroban-faucet-balances"]


### PR DESCRIPTION
Previously the three anchor storage keys — customer ID, bank-account ID, and onboarding URL — were keyed only by provider, meaning any connected wallet would read (and short-circuit ensureCustomer on) the values left behind by a prior wallet.  This caused:

  - ensureCustomer returning a different wallet's customerId / bankAccountId
  - off-ramp proceeds routing to the previous user's CLABE
  - KYC approval status being inherited without re-verification

Changes:
  - ramp.config.ts: add ANCHOR_STORAGE_VERSION=1, anchorStorageKey() (produces neko_anchor_<field>_v1_<walletAddress>), and clearAnchorState()
  - useAnchorCustomer.ts: new required walletAddress param; all localStorage reads/writes now go through anchorStorageKey(); the ensureCustomer mutation guards against null walletAddress
  - OnOffRamps.tsx: pass address as second arg to useAnchorCustomer
  - useStellarWallet.ts: call clearAnchorState(address) in disconnect() before clearWallet() so the address is still resolvable

Migration: legacy v0 entries (keyed by provider only) are abandoned in place and never read. Users with a cached identity will hit the anchor once via email lookup and get their existing IDs back — KYC is not lost, only re-fetched. This matches the version-bump pattern used by limit orders (LIMIT_ORDER_STORAGE_VERSION) and risk alerts.

Tests: 16 Vitest cases cover anchorStorageKey isolation, clearAnchorState per-wallet scoping, hook initial-state isolation, wallet-A then wallet-B ensureCustomer independence, resetCustomer, and legacy key migration.
 
closes #309 